### PR TITLE
prs faster redirects -> Primary

### DIFF
--- a/apps/desktop/src/renderer/browserMock.ts
+++ b/apps/desktop/src/renderer/browserMock.ts
@@ -1457,6 +1457,20 @@ const ALL_PRS = USE_ADE_DB_SNAPSHOT
     : []
   : [...NORMAL_PRS, ...INTEGRATION_PRS];
 
+function getAdeDbPrSnapshotByGithubCoordinates(args: any): any | null {
+  const repoOwner = String(args?.repoOwner ?? "").trim().toLowerCase();
+  const repoName = String(args?.repoName ?? "").trim().toLowerCase();
+  const githubPrNumber = Number(args?.githubPrNumber);
+  if (!repoOwner || !repoName || !Number.isInteger(githubPrNumber) || githubPrNumber <= 0) return null;
+
+  const pr = ALL_PRS.find((candidate: any) =>
+    String(candidate.repoOwner ?? "").trim().toLowerCase() === repoOwner
+    && String(candidate.repoName ?? "").trim().toLowerCase() === repoName
+    && Number(candidate.githubPrNumber) === githubPrNumber,
+  );
+  return pr ? ADE_DB_PR_SNAPSHOT_BY_ID.get(String(pr.id)) ?? null : null;
+}
+
 // ── Merge Contexts ────────────────────────────────────────────
 const BUILTIN_MOCK_MERGE_CONTEXTS: Record<string, any> = {
   // Normal PRs — no group
@@ -6065,6 +6079,16 @@ if (typeof window !== "undefined" && shouldInstallBrowserMock(window)) {
         MOCK_REVIEWS_BY_PR[prId] ??
         [],
       getReviewThreads: resolvedArg([]),
+      getDetailByGithub: async (args: any) => getAdeDbPrSnapshotByGithubCoordinates(args)?.detail ?? null,
+      getFilesByGithub: async (args: any) => getAdeDbPrSnapshotByGithubCoordinates(args)?.files ?? [],
+      getCommitsByGithub: async (args: any) => getAdeDbPrSnapshotByGithubCoordinates(args)?.commits ?? [],
+      getActionRunsByGithub: async (args: any) => getAdeDbPrSnapshotByGithubCoordinates(args)?.actionRuns ?? [],
+      getActivityByGithub: async (args: any) => getAdeDbPrSnapshotByGithubCoordinates(args)?.activity ?? [],
+      getStatusByGithub: async (args: any) => getAdeDbPrSnapshotByGithubCoordinates(args)?.status ?? null,
+      getChecksByGithub: async (args: any) => getAdeDbPrSnapshotByGithubCoordinates(args)?.checks ?? [],
+      getReviewsByGithub: async (args: any) => getAdeDbPrSnapshotByGithubCoordinates(args)?.reviews ?? [],
+      getCommentsByGithub: async (args: any) => getAdeDbPrSnapshotByGithubCoordinates(args)?.comments ?? [],
+      getReviewThreadsByGithub: async (args: any) => getAdeDbPrSnapshotByGithubCoordinates(args)?.reviewThreads ?? [],
       updateDescription: resolvedArg(undefined),
       delete: resolvedArg({ deleted: true }),
       draftDescription: resolvedArg({

--- a/apps/desktop/src/renderer/components/app/App.tsx
+++ b/apps/desktop/src/renderer/components/app/App.tsx
@@ -72,9 +72,11 @@ const workRoute = createPreloadableRoute<{ active?: boolean }>(() =>
 );
 const TerminalsPage = workRoute.Component;
 const preloadTerminalsPage = workRoute.preload;
-const PRsPage = React.lazy(() =>
+const prsRoute = createPreloadableRoute<{ active?: boolean }>(() =>
   import("../prs/PRsPage").then((m) => ({ default: m.PRsPage }))
 );
+const PRsPage = prsRoute.Component;
+const preloadPrsPage = prsRoute.preload;
 const ReviewPage = React.lazy(() =>
   import("../review/ReviewPage").then((m) => ({ default: m.ReviewPage }))
 );
@@ -753,6 +755,7 @@ function ProjectTabHost() {
       void preloadTerminalsPage().catch(() => undefined);
       void preloadLanesPage().catch(() => undefined);
       void preloadFilesTab().catch(() => undefined);
+      void preloadPrsPage().catch(() => undefined);
       void preloadCtoPage().catch(() => undefined);
     };
     const idleWindow = window as Window & {

--- a/apps/desktop/src/renderer/components/app/AppShell.tsx
+++ b/apps/desktop/src/renderer/components/app/AppShell.tsx
@@ -1609,6 +1609,9 @@ export function AppShell({ children }: { children: React.ReactNode }) {
                               const search = buildPrsRouteSearch({
                                 activeTab: "normal",
                                 selectedPrId: toast.event.prId,
+                                selectedPrNumber: toast.event.prNumber,
+                                repoOwner: toast.event.repoOwner,
+                                repoName: toast.event.repoName,
                                 selectedRebaseItemId: null,
                                 detailTab,
                               });

--- a/apps/desktop/src/renderer/components/chat/ChatGitToolbar.tsx
+++ b/apps/desktop/src/renderer/components/chat/ChatGitToolbar.tsx
@@ -323,6 +323,9 @@ export const ChatGitToolbar = React.memo(function ChatGitToolbar({
       localPath: `/prs${buildPrsRouteSearch({
         activeTab: "normal",
         selectedPrId: pr.id,
+        selectedPrNumber: pr.githubPrNumber,
+        repoOwner: pr.repoOwner,
+        repoName: pr.repoName,
         selectedLaneId: laneId,
         selectedRebaseItemId: null,
       })}`,

--- a/apps/desktop/src/renderer/components/lanes/LaneWorkPane.tsx
+++ b/apps/desktop/src/renderer/components/lanes/LaneWorkPane.tsx
@@ -36,6 +36,9 @@ function LanePullRequestsSection({ lane, prs }: { lane: LaneSummary | null; prs:
               onClick={() => navigate(`/prs${buildPrsRouteSearch({
                 activeTab: "normal",
                 selectedPrId: pr.id,
+                selectedPrNumber: pr.githubPrNumber,
+                repoOwner: pr.repoOwner,
+                repoName: pr.repoName,
                 selectedLaneId: pr.laneId,
                 selectedRebaseItemId: null,
               })}`)}

--- a/apps/desktop/src/renderer/components/lanes/LanesPage.test.ts
+++ b/apps/desktop/src/renderer/components/lanes/LanesPage.test.ts
@@ -4,6 +4,7 @@ import {
   getDeferredLanePaneDelayMs,
   githubPrMatchesCurrentBranch,
   laneHasAncestor,
+  lanePrTagRoutePath,
   lanePrMatchesCurrentBranch,
   lanePrRole,
   planLaneDeleteBatches,
@@ -112,6 +113,17 @@ describe("lane GitHub snapshot force refresh", () => {
       refreshSucceeded: true,
       startedProjectRoot: "/project",
     })).toBe(false);
+  });
+});
+
+describe("lane PR badge routes", () => {
+  it("opens an unmapped lane PR badge in the GitHub tab by coordinates", () => {
+    expect(lanePrTagRoutePath({
+      linkedPrId: null,
+      githubPrNumber: 224,
+      repoOwner: "arul28",
+      repoName: "ADE",
+    })).toBe("/prs?tab=github&pr=224&repoOwner=arul28&repoName=ADE");
   });
 });
 

--- a/apps/desktop/src/renderer/components/lanes/LanesPage.test.ts
+++ b/apps/desktop/src/renderer/components/lanes/LanesPage.test.ts
@@ -20,7 +20,11 @@ import {
   shouldApplyLaneIdsDeepLink,
   sortLaneListRows,
 } from "./lanePageModel";
-import { buildLaneSplitColumnsKey, shouldMountGitActionsPane } from "./LanesPage";
+import {
+  buildLaneSplitColumnsKey,
+  shouldMountGitActionsPane,
+  shouldRetryLaneGithubSnapshotForceRefresh,
+} from "./LanesPage";
 import type {
   GitHubPrListItem,
   LaneSummary,
@@ -93,6 +97,23 @@ function makeGitHubPr(overrides: Partial<GitHubPrListItem> = {}): GitHubPrListIt
     ...overrides,
   };
 }
+
+describe("lane GitHub snapshot force refresh", () => {
+  it("retries after a transient forced refresh failure for the same project", () => {
+    expect(shouldRetryLaneGithubSnapshotForceRefresh({
+      currentProjectRoot: "/project",
+      markedProjectRoot: "/project",
+      refreshSucceeded: false,
+      startedProjectRoot: "/project",
+    })).toBe(true);
+    expect(shouldRetryLaneGithubSnapshotForceRefresh({
+      currentProjectRoot: "/project",
+      markedProjectRoot: "/project",
+      refreshSucceeded: true,
+      startedProjectRoot: "/project",
+    })).toBe(false);
+  });
+});
 
 describe("resolveCreateLaneRequest", () => {
   it("creates an independent lane from the selected primary branch", () => {

--- a/apps/desktop/src/renderer/components/lanes/LanesPage.tsx
+++ b/apps/desktop/src/renderer/components/lanes/LanesPage.tsx
@@ -83,7 +83,7 @@ import {
   DEFAULT_REBASE_SUGGESTIONS,
   type RebaseSuggestionDisplay,
 } from "../../../shared/types/config";
-import { getGitHubSnapshotCoalesced, listPrsCoalesced, refreshPrsCoalesced, warmPrSurfaceCoalesced } from "../../lib/prReadCache";
+import { getGitHubSnapshotCoalesced, listPrsCoalesced, refreshPrsCoalesced } from "../../lib/prReadCache";
 import { logRendererDebugEvent } from "../../lib/debugLog";
 import { shouldRefreshSessionListForChatEvent } from "../../lib/chatSessionEvents";
 import { useLaneListInvalidation } from "../../hooks/useLaneListInvalidation";
@@ -129,6 +129,22 @@ export function shouldMountGitActionsPane({
   surface: LanePaneSurface;
 }): boolean {
   return surface !== "inline" || !laneId || expandedGitActionsLaneId !== laneId;
+}
+
+export function shouldRetryLaneGithubSnapshotForceRefresh({
+  currentProjectRoot,
+  markedProjectRoot,
+  refreshSucceeded,
+  startedProjectRoot,
+}: {
+  currentProjectRoot: string | null;
+  markedProjectRoot: string | null;
+  refreshSucceeded: boolean;
+  startedProjectRoot: string;
+}): boolean {
+  return !refreshSucceeded
+    && currentProjectRoot === startedProjectRoot
+    && markedProjectRoot === startedProjectRoot;
 }
 
 type RebasePushReviewState = {
@@ -482,6 +498,7 @@ export function LanesPage({ active = true }: { active?: boolean } = {}) {
   const laneGithubPrTagsRequestRef = useRef(0);
   const laneVisiblePrRefreshRequestedAtRef = useRef<Map<string, number>>(new Map());
   const laneVisiblePrRefreshProjectRootRef = useRef<string | null>(null);
+  const laneGithubSnapshotForceRefreshProjectRootRef = useRef<string | null>(null);
   const [laneVisiblePrRefreshVisibilityToken, setLaneVisiblePrRefreshVisibilityToken] = useState(0);
   const hasActiveLaneRuntimeRef = useRef(false);
   const [autoRebaseEnabled, setAutoRebaseEnabled] = useState(false);
@@ -911,7 +928,7 @@ export function LanesPage({ active = true }: { active?: boolean } = {}) {
     }
   }, [getActiveProjectRoot]);
 
-  const refreshLaneGithubPrTags = useCallback(async (options?: { force?: boolean }) => {
+  const refreshLaneGithubPrTags = useCallback(async (options?: { force?: boolean }): Promise<boolean> => {
     const requestId = ++laneGithubPrTagsRequestRef.current;
     const startedRoot = getActiveProjectRoot();
     try {
@@ -919,13 +936,15 @@ export function LanesPage({ active = true }: { active?: boolean } = {}) {
         { force: options?.force === true },
         { projectRoot: startedRoot },
       );
-      if (requestId !== laneGithubPrTagsRequestRef.current) return;
-      if (getActiveProjectRoot() !== startedRoot) return;
+      if (requestId !== laneGithubPrTagsRequestRef.current) return false;
+      if (getActiveProjectRoot() !== startedRoot) return false;
       setLaneGithubPrTags(snapshot.repoPullRequests);
+      return true;
     } catch {
-      if (requestId !== laneGithubPrTagsRequestRef.current) return;
-      if (getActiveProjectRoot() !== startedRoot) return;
+      if (requestId !== laneGithubPrTagsRequestRef.current) return false;
+      if (getActiveProjectRoot() !== startedRoot) return false;
       // Keep the last usable GitHub snapshot visible on transient refresh failures.
+      return false;
     }
   }, [getActiveProjectRoot]);
 
@@ -1075,22 +1094,56 @@ export function LanesPage({ active = true }: { active?: boolean } = {}) {
   useEffect(() => {
     lanePrTagsRequestRef.current += 1;
     laneGithubPrTagsRequestRef.current += 1;
+    laneGithubSnapshotForceRefreshProjectRootRef.current = null;
     setLanePrTags([]);
     setLaneGithubPrTags([]);
     if (!active || !activeProjectRoot) {
       return;
     }
-    void refreshLanePrTags({ refreshMapped: true });
-    void refreshLaneGithubPrTags({ force: true });
-    void warmPrSurfaceCoalesced({
-      projectRoot: activeProjectRoot,
-      includeGithubSnapshot: false,
-    });
+    // Keep the lane surface local-first. Visible stale rows are refreshed by
+    // the debounced viewport pass below; a forced snapshot and per-lane PR
+    // refresh here made opening the next PR surface compete with GitHub work.
+    void refreshLanePrTags();
+    void refreshLaneGithubPrTags();
     return () => {
       lanePrTagsRequestRef.current += 1;
       laneGithubPrTagsRequestRef.current += 1;
     };
   }, [active, refreshLanePrTags, refreshLaneGithubPrTags, activeProjectRoot, lanePrBranchSignature]);
+
+  useEffect(() => {
+    if (!active || !activeProjectRoot || document.visibilityState !== "visible") return;
+    if (laneGithubSnapshotForceRefreshProjectRootRef.current === activeProjectRoot) return;
+    const hasVisibleGithubOnlyPr = visibleLaneIds.some((laneId) =>
+      lanePrTagsByLaneId.get(laneId)?.some((tag) => tag.source === "github" && !tag.linkedPrId) ?? false,
+    );
+    if (!hasVisibleGithubOnlyPr) return;
+
+    const startedRoot = activeProjectRoot;
+    const timer = window.setTimeout(() => {
+      if (getActiveProjectRoot() !== startedRoot) return;
+      laneGithubSnapshotForceRefreshProjectRootRef.current = startedRoot;
+      void refreshLaneGithubPrTags({ force: true }).then((refreshSucceeded) => {
+        if (shouldRetryLaneGithubSnapshotForceRefresh({
+          currentProjectRoot: getActiveProjectRoot(),
+          markedProjectRoot: laneGithubSnapshotForceRefreshProjectRootRef.current,
+          refreshSucceeded,
+          startedProjectRoot: startedRoot,
+        })) {
+          laneGithubSnapshotForceRefreshProjectRootRef.current = null;
+        }
+      });
+    }, 750);
+    return () => window.clearTimeout(timer);
+  }, [
+    active,
+    activeProjectRoot,
+    getActiveProjectRoot,
+    lanePrTagsByLaneId,
+    laneVisiblePrRefreshVisibilityToken,
+    refreshLaneGithubPrTags,
+    visibleLaneIds,
+  ]);
 
   useEffect(() => {
     if (!active) return;
@@ -3289,6 +3342,9 @@ export function LanesPage({ active = true }: { active?: boolean } = {}) {
                       navigate(`/prs${buildPrsRouteSearch({
                         activeTab: "normal",
                         selectedPrId: target.linkedPrId,
+                        selectedPrNumber: target.githubPrNumber,
+                        repoOwner: target.repoOwner,
+                        repoName: target.repoName,
                         selectedRebaseItemId: null,
                       })}`);
                       return;

--- a/apps/desktop/src/renderer/components/lanes/LanesPage.tsx
+++ b/apps/desktop/src/renderer/components/lanes/LanesPage.tsx
@@ -52,6 +52,7 @@ import {
   resolveVisibleLaneIds,
   runLaneDeleteBatchWithConcurrency,
   selectLanePrs,
+  lanePrTagRoutePath,
   selectVisibleLanePrRefreshIds,
   selectLaneTabPrTags,
   shouldApplyLaneIdsDeepLink,
@@ -3338,15 +3339,9 @@ export function LanesPage({ active = true }: { active?: boolean } = {}) {
                   })}`)}
                   onActivate={(_event, selectedPr) => {
                     const target = selectedPr ?? lanePr;
-                    if (target.linkedPrId) {
-                      navigate(`/prs${buildPrsRouteSearch({
-                        activeTab: "normal",
-                        selectedPrId: target.linkedPrId,
-                        selectedPrNumber: target.githubPrNumber,
-                        repoOwner: target.repoOwner,
-                        repoName: target.repoName,
-                        selectedRebaseItemId: null,
-                      })}`);
+                    const prRoute = lanePrTagRoutePath(target);
+                    if (prRoute) {
+                      navigate(prRoute);
                       return;
                     }
                     if (target.githubUrl && isTrustedGitHubUrl(target.githubUrl)) {

--- a/apps/desktop/src/renderer/components/lanes/lanePageModel.ts
+++ b/apps/desktop/src/renderer/components/lanes/lanePageModel.ts
@@ -12,6 +12,7 @@ import type {
 import type { CreateLaneMode } from "./CreateLaneDialog";
 import { mergeUnique } from "./laneUtils";
 import { isTerminalPrState } from "../../lib/prState";
+import { prRouteCoordinatesMatch } from "../prs/prsRouteState";
 
 type CreateLaneRequest =
   | { kind: "child"; args: { name: string; parentLaneId: string } }
@@ -30,6 +31,9 @@ export type LaneTabPrTag = {
   linkedPrId: string | null;
   githubPrNumber: number;
   githubUrl: string;
+  /** Repository coordinates keep badge deep links usable before local hydration. */
+  repoOwner: string;
+  repoName: string;
   title: string;
   state: PrSummary["state"];
   /** A live PR follows the lane's current branch; previous PRs remain history on the lane. */
@@ -280,8 +284,10 @@ export function githubPrMatchesCurrentBranch(
   if (!laneBranch || !prHeadBranch || laneBranch !== prHeadBranch) return false;
   const headRepoOwner = pr.headRepoOwner?.trim();
   const headRepoName = pr.headRepoName?.trim();
-  if (headRepoOwner && pr.repoOwner && headRepoOwner.toLowerCase() !== pr.repoOwner.toLowerCase()) return false;
-  if (headRepoName && pr.repoName && headRepoName.toLowerCase() !== pr.repoName.toLowerCase()) return false;
+  if (!prRouteCoordinatesMatch(
+    { prNumber: null, repoOwner: headRepoOwner ?? null, repoName: headRepoName ?? null },
+    { prNumber: null, repoOwner: pr.repoOwner, repoName: pr.repoName },
+  )) return false;
   if (lane.laneType === "primary") {
     const baseBranch = normalizeLanePrBranch(lane.baseRef);
     if (laneBranch && baseBranch && laneBranch === baseBranch) return false;
@@ -312,6 +318,8 @@ function toLaneTabPrTagFromPrSummary(pr: PrSummary, laneRole?: "active" | "previ
     linkedPrId: pr.id,
     githubPrNumber: pr.githubPrNumber,
     githubUrl: pr.githubUrl,
+    repoOwner: pr.repoOwner,
+    repoName: pr.repoName,
     title: pr.title,
     state: pr.state,
     laneRole,
@@ -341,6 +349,8 @@ function toLaneTabPrTagFromGithubItem(
     linkedPrId,
     githubPrNumber: pr.githubPrNumber,
     githubUrl: pr.githubUrl,
+    repoOwner: pr.repoOwner,
+    repoName: pr.repoName,
     title: pr.title,
     state: pr.isDraft ? "draft" : pr.state,
     laneRole,

--- a/apps/desktop/src/renderer/components/lanes/lanePageModel.ts
+++ b/apps/desktop/src/renderer/components/lanes/lanePageModel.ts
@@ -12,7 +12,7 @@ import type {
 import type { CreateLaneMode } from "./CreateLaneDialog";
 import { mergeUnique } from "./laneUtils";
 import { isTerminalPrState } from "../../lib/prState";
-import { prRouteCoordinatesMatch } from "../prs/prsRouteState";
+import { buildPrsRouteSearch, prRouteCoordinatesMatch } from "../prs/prsRouteState";
 
 type CreateLaneRequest =
   | { kind: "child"; args: { name: string; parentLaneId: string } }
@@ -56,6 +56,25 @@ export type LaneTabPrTag = {
   author?: string | null;
   stack?: GitHubPrStackMembership | null;
 };
+
+export function lanePrTagRoutePath(
+  target: Pick<LaneTabPrTag, "linkedPrId" | "githubPrNumber" | "repoOwner" | "repoName">,
+): string | null {
+  if (
+    !Number.isInteger(target.githubPrNumber)
+    || target.githubPrNumber <= 0
+    || !target.repoOwner.trim()
+    || !target.repoName.trim()
+  ) return null;
+  return `/prs${buildPrsRouteSearch({
+    activeTab: target.linkedPrId ? "normal" : "github",
+    selectedPrId: target.linkedPrId,
+    selectedPrNumber: target.githubPrNumber,
+    repoOwner: target.repoOwner,
+    repoName: target.repoName,
+    selectedRebaseItemId: null,
+  })}`;
+}
 
 export const VISIBLE_LANE_PR_REFRESH_LIMIT = 4;
 export const VISIBLE_LANE_PR_REFRESH_STALE_MS = 15_000;

--- a/apps/desktop/src/renderer/components/prs/PRsPage.test.tsx
+++ b/apps/desktop/src/renderer/components/prs/PRsPage.test.tsx
@@ -2,9 +2,13 @@
 
 import React from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
 
 import type { PrSummary } from "../../../shared/types";
+
+const navigateMock = vi.hoisted(() => vi.fn());
+const locationMock = vi.hoisted(() => ({ pathname: "/prs", search: "", hash: "" }));
+const githubTabProps = vi.hoisted(() => ({ current: null as Record<string, unknown> | null }));
 
 // Mock the PRs context hook so we can drive { error, prs, loading } directly.
 const usePrsMock = vi.fn();
@@ -15,7 +19,10 @@ vi.mock("./state/PrsContext", () => ({
 
 // Stub the heavy tab subtrees: we only care about the page-level render branch.
 vi.mock("./tabs/GitHubTab", () => ({
-  GitHubTab: () => <div data-testid="github-tab" />,
+  GitHubTab: (props: Record<string, unknown>) => {
+    githubTabProps.current = props;
+    return <div data-testid="github-tab" />;
+  },
 }));
 vi.mock("./tabs/WorkflowsTab", () => ({
   WorkflowsTab: () => <div data-testid="workflows-tab" />,
@@ -26,8 +33,8 @@ vi.mock("./CreatePrModal", () => ({
 
 // Router + store + dialog bus stubs.
 vi.mock("react-router-dom", () => ({
-  useNavigate: () => vi.fn(),
-  useLocation: () => ({ pathname: "/prs", search: "" }),
+  useNavigate: () => navigateMock,
+  useLocation: () => locationMock,
 }));
 vi.mock("../../state/appStore", () => ({
   useAppStore: (selector: (state: any) => unknown) =>
@@ -49,6 +56,9 @@ function makePr(overrides: Partial<PrSummary> = {}): PrSummary {
     id: "pr-1",
     title: "Cached PR",
     githubPrNumber: 42,
+    repoOwner: "ade-dev",
+    repoName: "ade",
+    ...overrides,
   } as unknown as PrSummary;
 }
 
@@ -74,6 +84,12 @@ function baseValue(overrides: Record<string, unknown> = {}) {
 afterEach(() => {
   cleanup();
   usePrsMock.mockReset();
+  navigateMock.mockReset();
+  githubTabProps.current = null;
+  locationMock.pathname = "/prs";
+  locationMock.search = "";
+  locationMock.hash = "";
+  window.history.replaceState(null, "", "/");
 });
 
 describe("PRsPage error gating", () => {
@@ -104,5 +120,49 @@ describe("PRsPage error gating", () => {
 
     fireEvent.click(retry);
     expect(refresh).toHaveBeenCalledTimes(1);
+  });
+
+  it("reconciles a coordinate-only route with the matching local PR", async () => {
+    const routeSearch = "?tab=normal&pr=42&repoOwner=ade-dev&repoName=ade";
+    locationMock.search = routeSearch;
+    window.history.replaceState(null, "", `/prs${routeSearch}`);
+    const setSelectedPrId = vi.fn();
+    usePrsMock.mockReturnValue(baseValue({
+      prs: [makePr({ id: "local-pr" })],
+      setSelectedPrId,
+    }));
+
+    render(<PRsPage />);
+
+    await waitFor(() => {
+      expect(setSelectedPrId).toHaveBeenCalledWith("local-pr");
+    });
+    expect(githubTabProps.current?.selectedPrTarget).toEqual({
+      prId: null,
+      prNumber: 42,
+      repoOwner: "ade-dev",
+      repoName: "ade",
+    });
+  });
+
+  it("clears a PR target when the route switches to workflows", async () => {
+    const prRouteSearch = "?tab=normal&pr=42&repoOwner=ade-dev&repoName=ade";
+    locationMock.search = prRouteSearch;
+    window.history.replaceState(null, "", `/prs${prRouteSearch}`);
+    usePrsMock.mockReturnValue(baseValue({ prs: [makePr()] }));
+
+    const { rerender } = render(<PRsPage />);
+    await waitFor(() => {
+      expect(githubTabProps.current?.selectedPrTarget).not.toBeNull();
+    });
+
+    const workflowSearch = "?tab=workflows&workflow=integration";
+    locationMock.search = workflowSearch;
+    window.history.replaceState(null, "", `/prs${workflowSearch}`);
+    rerender(<PRsPage />);
+
+    await waitFor(() => {
+      expect(githubTabProps.current?.selectedPrTarget).toBeNull();
+    });
   });
 });

--- a/apps/desktop/src/renderer/components/prs/PRsPage.tsx
+++ b/apps/desktop/src/renderer/components/prs/PRsPage.tsx
@@ -294,19 +294,28 @@ function PRsPageInner() {
       repoOwner: localSelectedPr.repoOwner,
       repoName: localSelectedPr.repoName,
     } : null);
-    const hasPrNumber = target?.prNumber != null;
-    const hasCoordinates = Boolean(target?.repoOwner && target.repoName && hasPrNumber);
+    // A route can carry only a local id while the matching ADE row already
+    // provides coordinates. Enrich that partial target once, then serialize
+    // the single resolved target consistently.
+    const routeTarget = target && localSelectedPr ? {
+      ...target,
+      prNumber: target.prNumber ?? localSelectedPr.githubPrNumber,
+      repoOwner: target.repoOwner ?? localSelectedPr.repoOwner,
+      repoName: target.repoName ?? localSelectedPr.repoName,
+    } : target;
+    const hasPrNumber = routeTarget?.prNumber != null;
+    const hasCoordinates = Boolean(routeTarget?.repoOwner && routeTarget.repoName && hasPrNumber);
     // Coordinate targets deliberately omit a missing local id. This keeps the
     // route addressable on the GitHub surface instead of sending a foreign or
     // not-yet-hydrated ADE id back through PrsContext.
-    const routePrId = selectedPrId ?? (hasCoordinates ? null : target?.prId ?? null);
+    const routePrId = selectedPrId ?? (hasCoordinates ? null : routeTarget?.prId ?? null);
     // Preserve per-PR deep-link params (eventId/threadId/commitSha) as long as
     // the URL still points at the same selected PR, including coordinate-only
     // routes. When the PR changes, stale deep-link params get dropped.
     const sameCoordinateTarget = Boolean(
-      target?.prNumber != null
+      routeTarget?.prNumber != null
       && current.prNumber != null
-      && prRouteCoordinatesMatch(target, current),
+      && prRouteCoordinatesMatch(routeTarget, current),
     );
     const preserveDeepLinks =
       activeTab === "normal"
@@ -317,9 +326,9 @@ function PRsPageInner() {
     const nextSearch = buildPrsRouteSearch({
       activeTab,
       selectedPrId: routePrId,
-      selectedPrNumber: hasPrNumber ? target?.prNumber : localSelectedPr?.githubPrNumber ?? null,
-      repoOwner: hasCoordinates ? target?.repoOwner : localSelectedPr?.repoOwner ?? null,
-      repoName: hasCoordinates ? target?.repoName : localSelectedPr?.repoName ?? null,
+      selectedPrNumber: hasPrNumber ? routeTarget?.prNumber ?? null : null,
+      repoOwner: hasCoordinates ? routeTarget?.repoOwner ?? null : null,
+      repoName: hasCoordinates ? routeTarget?.repoName ?? null : null,
       selectedRebaseItemId,
       detailTab: activeTab === "normal" ? selectedDetailTab : null,
       ...deepLinks,

--- a/apps/desktop/src/renderer/components/prs/PRsPage.tsx
+++ b/apps/desktop/src/renderer/components/prs/PRsPage.tsx
@@ -15,9 +15,13 @@ import { SANS_FONT } from "../lanes/laneDesignTokens";
 import {
   buildPrsRouteSearch,
   parsePrsRouteState,
+  prRouteCoordinatesMatch,
+  prRouteSelectionTarget,
+  prRouteTargetsEqual,
   resolvePrsActiveTab,
   writeStoredPrsRoute,
   type PrDetailRouteTab,
+  type PrRouteSelectionTarget,
 } from "./prsRouteState";
 import { resolveRouteRebaseSelection } from "./shared/rebaseNeedUtils";
 import type { PrSummary } from "../../../shared/types";
@@ -131,6 +135,16 @@ function PRsPageInner() {
   const [integrationRefreshNonce, setIntegrationRefreshNonce] = React.useState(0);
   const [githubHeaderChrome, setGithubHeaderChrome] = React.useState<GitHubHeaderChromeState | null>(null);
   const lastRouteLocationKeyRef = React.useRef<string | null>(null);
+  const [selectedPrTarget, setSelectedPrTarget] = React.useState<PrRouteSelectionTarget | null>(() => {
+    try {
+      return prRouteSelectionTarget(parsePrsRouteState({
+        search: window.location.search,
+        hash: window.location.hash,
+      }));
+    } catch {
+      return null;
+    }
+  });
   const [selectedDetailTab, setSelectedDetailTab] = React.useState<PrDetailRouteTab | null>(() => {
     try {
       return parsePrsRouteState({ search: window.location.search, hash: window.location.hash }).detailTab;
@@ -162,6 +176,11 @@ function PRsPageInner() {
     if (!targeted) setIntegrationRefreshNonce((prev) => prev + 1);
   }, [refresh, refreshLanes]);
 
+  const handleSelectPr = React.useCallback((id: string | null, target: PrRouteSelectionTarget | null) => {
+    setSelectedPrId(id);
+    setSelectedPrTarget(target ? { ...target, prId: id ?? target.prId } : null);
+  }, [setSelectedPrId]);
+
   const openCreatePr = React.useCallback((props?: Record<string, unknown>) => {
     setCreatePrInitialValues(createInitialValuesFromDialogProps(props));
     setCreatePrOpen(true);
@@ -179,7 +198,13 @@ function PRsPageInner() {
     if (!first) return;
     setActiveTab("normal");
     setSelectedPrId(first.id);
-  }, [handleRefresh, setActiveTab, setSelectedPrId]);
+    setSelectedPrTarget({
+      prId: first.id,
+      prNumber: first.githubPrNumber,
+      repoOwner: first.repoOwner,
+      repoName: first.repoName,
+    });
+  }, [handleRefresh, setActiveTab, setSelectedPrId, setSelectedPrTarget]);
 
   React.useEffect(() => {
     const syncFromLocation = () => {
@@ -204,16 +229,37 @@ function PRsPageInner() {
         setActiveTab(resolved.activeTab);
 
         if (!resolved.isWorkflowRoute) {
-          const hasExplicitPrSelection = Boolean(routeState.prId) || routeState.prNumber != null;
+          const routeTarget = prRouteSelectionTarget(routeState);
+          const hasExplicitPrSelection = routeTarget !== null;
           const prNumberMatch = routeState.prNumber == null
             ? null
-            : prs.find((pr) => pr.githubPrNumber === routeState.prNumber)?.id ?? null;
+            : prs.find((pr) => prRouteCoordinatesMatch(
+              {
+                prNumber: pr.githubPrNumber,
+                repoOwner: pr.repoOwner,
+                repoName: pr.repoName,
+              },
+              routeState,
+            ))?.id ?? null;
+          const localRouteId = routeState.prId && (
+            loading || prs.some((pr) => pr.id === routeState.prId)
+          )
+            ? routeState.prId
+            : null;
           if (hasExplicitPrSelection || locationChanged) {
-            setSelectedPrId(routeState.prId ?? prNumberMatch);
+            // A coordinate route is still valid without an ADE row. Keep the
+            // route target alive, but only hand a local id to PrsContext once
+            // that row is actually present.
+            setSelectedPrId(localRouteId ?? prNumberMatch);
+            setSelectedPrTarget((previous) => (
+              prRouteTargetsEqual(previous, routeTarget) ? previous : routeTarget
+            ));
           }
           if (hasExplicitPrSelection || locationChanged || routeState.detailTab) {
             setSelectedDetailTab(routeState.detailTab);
           }
+        } else {
+          setSelectedPrTarget((previous) => previous === null ? previous : null);
         }
         if (resolved.effectiveWorkflow === "rebase") {
           setSelectedRebaseItemId(routeRebaseItemId);
@@ -237,23 +283,43 @@ function PRsPageInner() {
       window.removeEventListener("popstate", syncFromLocation);
       window.removeEventListener("hashchange", syncFromLocation);
     };
-  }, [location.search, prs, rebaseNeeds, setActiveTab, setSelectedPrId, setSelectedRebaseItemId]);
+  }, [location.hash, location.pathname, location.search, loading, prs, rebaseNeeds, setActiveTab, setSelectedPrId, setSelectedRebaseItemId]);
 
   React.useEffect(() => {
-    const current = parsePrsRouteState({ search: location.search });
+    const current = parsePrsRouteState({ search: location.search, hash: location.hash });
+    const localSelectedPr = selectedPrId ? prs.find((pr) => pr.id === selectedPrId) ?? null : null;
+    const target = selectedPrTarget ?? (localSelectedPr ? {
+      prId: localSelectedPr.id,
+      prNumber: localSelectedPr.githubPrNumber,
+      repoOwner: localSelectedPr.repoOwner,
+      repoName: localSelectedPr.repoName,
+    } : null);
+    const hasPrNumber = target?.prNumber != null;
+    const hasCoordinates = Boolean(target?.repoOwner && target.repoName && hasPrNumber);
+    // Coordinate targets deliberately omit a missing local id. This keeps the
+    // route addressable on the GitHub surface instead of sending a foreign or
+    // not-yet-hydrated ADE id back through PrsContext.
+    const routePrId = selectedPrId ?? (hasCoordinates ? null : target?.prId ?? null);
     // Preserve per-PR deep-link params (eventId/threadId/commitSha) as long as
-    // the URL still points at the currently selected PR. When the PR changes,
-    // stale deep-link params for the old PR get dropped.
+    // the URL still points at the same selected PR, including coordinate-only
+    // routes. When the PR changes, stale deep-link params get dropped.
+    const sameCoordinateTarget = Boolean(
+      target?.prNumber != null
+      && current.prNumber != null
+      && prRouteCoordinatesMatch(target, current),
+    );
     const preserveDeepLinks =
-      activeTab === "normal" &&
-      selectedPrId !== null &&
-      current.prId === selectedPrId;
+      activeTab === "normal"
+      && (current.prId === routePrId || sameCoordinateTarget);
     const deepLinks = preserveDeepLinks
       ? { eventId: current.eventId, threadId: current.threadId, commitSha: current.commitSha }
       : { eventId: null, threadId: null, commitSha: null };
     const nextSearch = buildPrsRouteSearch({
       activeTab,
-      selectedPrId,
+      selectedPrId: routePrId,
+      selectedPrNumber: hasPrNumber ? target?.prNumber : localSelectedPr?.githubPrNumber ?? null,
+      repoOwner: hasCoordinates ? target?.repoOwner : localSelectedPr?.repoOwner ?? null,
+      repoName: hasCoordinates ? target?.repoName : localSelectedPr?.repoName ?? null,
       selectedRebaseItemId,
       detailTab: activeTab === "normal" ? selectedDetailTab : null,
       ...deepLinks,
@@ -262,19 +328,24 @@ function PRsPageInner() {
     void navigate({ pathname: location.pathname, search: nextSearch }, { replace: true });
   }, [
     activeTab,
+    prs,
     selectedPrId,
+    selectedPrTarget,
     selectedRebaseItemId,
     selectedDetailTab,
     location.pathname,
     location.search,
+    location.hash,
     navigate,
   ]);
 
   React.useEffect(() => {
     if (location.pathname !== "/prs") return;
     if (readCreatePrRouteRequest({ search: location.search, hash: window.location.hash })) return;
-    writeStoredPrsRoute(`${location.pathname}${location.search}`, projectRoot);
-  }, [location.pathname, location.search, projectRoot]);
+    const hash = location.hash ?? "";
+    const hashRoute = hash.startsWith("#/prs") ? hash.slice(1) : null;
+    writeStoredPrsRoute(hashRoute ?? `${location.pathname}${location.search}`, projectRoot);
+  }, [location.hash, location.pathname, location.search, projectRoot]);
 
   const activeMode: SurfaceMode = activeTab === "normal" ? "github" : "workflows";
 
@@ -489,7 +560,8 @@ function PRsPageInner() {
             lanes={visibleLanes}
             mergeMethod={mergeMethod}
             selectedPrId={selectedPrId}
-            onSelectPr={setSelectedPrId}
+            selectedPrTarget={selectedPrTarget}
+            onSelectPr={handleSelectPr}
             selectedDetailTab={selectedDetailTab}
             onDetailTabChange={setSelectedDetailTab}
             onRefreshAll={handleRefresh}

--- a/apps/desktop/src/renderer/components/prs/detail/PrDetailPane.tsx
+++ b/apps/desktop/src/renderer/components/prs/detail/PrDetailPane.tsx
@@ -371,6 +371,8 @@ type PrDetailPaneProps = {
    */
   githubCoords?: PrGithubCoords | null;
   unmapped?: boolean;
+  /** The route has coordinates but GitHub has not resolved the row yet. */
+  provisional?: boolean;
   /**
    * Create-lane / map-to-lane controls surfaced as an in-pane banner when the
    * PR is unmapped. Provided by GitHubTab so this pane stays presentational.
@@ -498,6 +500,7 @@ export function PrDetailPane({
   unmapBusy = false,
   githubCoords = null,
   unmapped = false,
+  provisional = false,
   unmappedAffordance = null,
 }: PrDetailPaneProps) {
   const {
@@ -1456,7 +1459,9 @@ export function PrDetailPane({
                   {pr.title}
                 </span>
                 <span style={{ flexShrink: 0 }}>
-                  <InlinePrBadge {...getPrStateBadge(pr.state)} />
+                  <InlinePrBadge {...(provisional
+                    ? { label: "RESOLVING", color: COLORS.textMuted, bg: `${COLORS.textMuted}18`, border: `${COLORS.textMuted}30` }
+                    : getPrStateBadge(pr.state))} />
                 </span>
                 {pr.laneId ? (
                   <button

--- a/apps/desktop/src/renderer/components/prs/detail/PrDetailTimelineRails.test.tsx
+++ b/apps/desktop/src/renderer/components/prs/detail/PrDetailTimelineRails.test.tsx
@@ -9,6 +9,7 @@ import {
   PrDetailTimelineRails,
   buildCommitRailCommits,
   buildTimelineEvents,
+  buildTimelineVisibleEventHash,
   buildTimelineVisibleEventSearch,
 } from "./PrDetailTimelineRails";
 
@@ -89,6 +90,22 @@ describe("buildTimelineVisibleEventSearch", () => {
       prId: "gh:ade-dev/ade#123",
       eventId: "comment-new",
     })).toBe("?tab=normal&pr=123&repoOwner=ade-dev&repoName=ade&eventId=comment-new&detailTab=overview");
+  });
+
+  it("preserves a hash-based coordinate PR route when the visible event changes", () => {
+    const current = parsePrsRouteState({
+      hash: "#/prs?tab=normal&pr=123&repoOwner=ade-dev&repoName=ade&eventId=comment-old",
+    });
+    const nextSearch = buildTimelineVisibleEventSearch({
+      current,
+      prId: "gh:ade-dev/ade#123",
+      eventId: "comment-new",
+    });
+
+    expect(buildTimelineVisibleEventHash({
+      currentHash: "#/prs?tab=normal&pr=123&repoOwner=ade-dev&repoName=ade&eventId=comment-old",
+      nextSearch,
+    })).toBe("#/prs?tab=normal&pr=123&repoOwner=ade-dev&repoName=ade&eventId=comment-new");
   });
 });
 

--- a/apps/desktop/src/renderer/components/prs/detail/PrDetailTimelineRails.test.tsx
+++ b/apps/desktop/src/renderer/components/prs/detail/PrDetailTimelineRails.test.tsx
@@ -78,6 +78,18 @@ describe("buildTimelineVisibleEventSearch", () => {
       eventId: "comment-new",
     })).toBe("?tab=normal&prId=pr-1&eventId=comment-new&detailTab=overview");
   });
+
+  it("keeps coordinate-only routes coordinate-based while replacing the visible event", () => {
+    const current = parsePrsRouteState({
+      search: "?tab=normal&pr=123&repoOwner=ade-dev&repoName=ade&detailTab=overview",
+    });
+
+    expect(buildTimelineVisibleEventSearch({
+      current,
+      prId: "gh:ade-dev/ade#123",
+      eventId: "comment-new",
+    })).toBe("?tab=normal&pr=123&repoOwner=ade-dev&repoName=ade&eventId=comment-new&detailTab=overview");
+  });
 });
 
 describe("buildTimelineEvents fold", () => {

--- a/apps/desktop/src/renderer/components/prs/detail/PrDetailTimelineRails.tsx
+++ b/apps/desktop/src/renderer/components/prs/detail/PrDetailTimelineRails.tsx
@@ -126,6 +126,16 @@ export function buildTimelineVisibleEventSearch(args: {
   });
 }
 
+export function buildTimelineVisibleEventHash(args: {
+  currentHash: string;
+  nextSearch: string;
+}): string | null {
+  if (!args.currentHash.startsWith("#/prs")) return null;
+  const queryIndex = args.currentHash.indexOf("?");
+  const routePrefix = queryIndex >= 0 ? args.currentHash.slice(0, queryIndex) : args.currentHash;
+  return `${routePrefix}${args.nextSearch}`;
+}
+
 type Props = {
   pr: PrWithConflicts;
   detail: PrDetail | null;
@@ -846,8 +856,18 @@ export const PrDetailTimelineRails = forwardRef<PrDetailTimelineRailsRef, Props>
           );
         if (current.prId !== pr.id && !selectedByCoordinates) return;
         const nextSearch = buildTimelineVisibleEventSearch({ current, prId: pr.id, eventId });
-        if (nextSearch === locationSearchRef.current) return;
-        void navigate({ pathname: locationPathnameRef.current, search: nextSearch }, { replace: true });
+        const nextHash = buildTimelineVisibleEventHash({
+          currentHash: locationHashRef.current,
+          nextSearch,
+        });
+        if (nextHash
+          ? nextHash === locationHashRef.current
+          : nextSearch === locationSearchRef.current) return;
+        void navigate({
+          pathname: locationPathnameRef.current,
+          search: nextHash ? locationSearchRef.current : nextSearch,
+          ...(nextHash ? { hash: nextHash } : {}),
+        }, { replace: true });
       },
       [navigate, pr.githubPrNumber, pr.id, pr.repoName, pr.repoOwner],
     );

--- a/apps/desktop/src/renderer/components/prs/detail/PrDetailTimelineRails.tsx
+++ b/apps/desktop/src/renderer/components/prs/detail/PrDetailTimelineRails.tsx
@@ -2,7 +2,7 @@ import React, { forwardRef, useCallback, useEffect, useImperativeHandle, useMemo
 import { Group, Panel, Separator } from "react-resizable-panels";
 import { useLocation, useNavigate } from "react-router-dom";
 import { ArrowSquareOut, Stack } from "@phosphor-icons/react";
-import { buildPrsRouteSearch, parsePrsRouteState, type ParsedPrsRouteState } from "../prsRouteState";
+import { buildPrsRouteSearch, parsePrsRouteState, prRouteCoordinatesMatch, type ParsedPrsRouteState } from "../prsRouteState";
 import type {
   LaneSummary,
   MergeMethod,
@@ -114,7 +114,10 @@ export function buildTimelineVisibleEventSearch(args: {
   const tab = args.current.tab === "github" || args.current.tab === "normal" ? args.current.tab : "normal";
   return buildPrsRouteSearch({
     activeTab: tab,
-    selectedPrId: args.prId,
+    selectedPrId: args.current.prId ?? (args.current.prNumber != null ? null : args.prId),
+    selectedPrNumber: args.current.prNumber,
+    repoOwner: args.current.repoOwner,
+    repoName: args.current.repoName,
     selectedRebaseItemId: null,
     eventId: args.eventId,
     threadId: args.current.threadId,
@@ -820,22 +823,33 @@ export const PrDetailTimelineRails = forwardRef<PrDetailTimelineRailsRef, Props>
     // Scroll → URL round-trip. Write eventId to the URL (replace) as the user
     // scrolls, so the address bar reflects the current position for sharing.
     const locationSearchRef = useRef(location.search);
+    const locationHashRef = useRef(location.hash);
     const locationPathnameRef = useRef(location.pathname);
     useEffect(() => {
       locationSearchRef.current = location.search;
+      locationHashRef.current = location.hash;
       locationPathnameRef.current = location.pathname;
-    }, [location.pathname, location.search]);
+    }, [location.hash, location.pathname, location.search]);
     const handleVisibleEventChange = useCallback(
       (eventId: string | null) => {
-        const current = parsePrsRouteState({ search: locationSearchRef.current });
+        const current = parsePrsRouteState({
+          search: locationSearchRef.current,
+          hash: locationHashRef.current,
+        });
         if ((current.eventId ?? null) === eventId) return;
-        // Only write URL for PR-scoped tabs with a selected PR.
-        if (current.prId !== pr.id) return;
+        // Only write URL for the selected PR. Coordinate-only routes have no
+        // local id, so match those by repository and GitHub number.
+        const selectedByCoordinates = current.prNumber != null
+          && prRouteCoordinatesMatch(
+            { prNumber: current.prNumber, repoOwner: current.repoOwner, repoName: current.repoName },
+            { prNumber: pr.githubPrNumber, repoOwner: pr.repoOwner, repoName: pr.repoName },
+          );
+        if (current.prId !== pr.id && !selectedByCoordinates) return;
         const nextSearch = buildTimelineVisibleEventSearch({ current, prId: pr.id, eventId });
         if (nextSearch === locationSearchRef.current) return;
         void navigate({ pathname: locationPathnameRef.current, search: nextSearch }, { replace: true });
       },
-      [pr.id, navigate],
+      [navigate, pr.githubPrNumber, pr.id, pr.repoName, pr.repoOwner],
     );
 
     const summaryForTimeline = aiSummaryDismissed ? null : aiSummary ?? null;

--- a/apps/desktop/src/renderer/components/prs/prsRouteState.test.ts
+++ b/apps/desktop/src/renderer/components/prs/prsRouteState.test.ts
@@ -1,5 +1,14 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { buildPrsRouteSearch, parsePrsRouteState, readStoredPrsRoute, resolvePrsActiveTab, writeStoredPrsRoute } from "./prsRouteState";
+import {
+  buildPrsRouteSearch,
+  parsePrsRouteState,
+  prRouteCoordinatesEqual,
+  prRouteCoordinatesKey,
+  prRouteTargetsEqual,
+  readStoredPrsRoute,
+  resolvePrsActiveTab,
+  writeStoredPrsRoute,
+} from "./prsRouteState";
 
 describe("prsRouteState", () => {
   beforeEach(() => {
@@ -29,6 +38,8 @@ describe("prsRouteState", () => {
       laneId: null,
       prId: null,
       prNumber: null,
+      repoOwner: null,
+      repoName: null,
       eventId: null,
       threadId: null,
       commitSha: null,
@@ -48,6 +59,8 @@ describe("prsRouteState", () => {
       laneId: "lane-456",
       prId: "pr-789",
       prNumber: null,
+      repoOwner: null,
+      repoName: null,
       eventId: null,
       threadId: null,
       commitSha: null,
@@ -66,6 +79,8 @@ describe("prsRouteState", () => {
       laneId: null,
       prId: "pr-1",
       prNumber: null,
+      repoOwner: null,
+      repoName: null,
       eventId: "evt-99",
       threadId: "thr-12",
       commitSha: "abc123",
@@ -92,6 +107,36 @@ describe("prsRouteState", () => {
     expect(parsed.prNumber).toBe(123);
     expect(parsed.prId).toBeNull();
     expect(parsed.laneId).toBe("lane-1");
+  });
+
+  it("keeps repository coordinates with a PR number handoff", () => {
+    expect(parsePrsRouteState({
+      search: "?tab=normal&pr=123&repoOwner=ade-dev&repoName=ade",
+    })).toMatchObject({
+      prNumber: 123,
+      repoOwner: "ade-dev",
+      repoName: "ade",
+    });
+    expect(buildPrsRouteSearch({
+      activeTab: "normal",
+      selectedPrId: null,
+      selectedPrNumber: 123,
+      repoOwner: "ade-dev",
+      repoName: "ade",
+      selectedRebaseItemId: null,
+    })).toBe("?tab=normal&pr=123&repoOwner=ade-dev&repoName=ade");
+  });
+
+  it("uses one case-insensitive canonical coordinate identity", () => {
+    const uppercase = { prNumber: 123, repoOwner: "ADE-DEV", repoName: "ADE" };
+    const lowercase = { prNumber: 123, repoOwner: "ade-dev", repoName: "ade" };
+
+    expect(prRouteCoordinatesKey(uppercase)).toBe("ade-dev/ade#123");
+    expect(prRouteCoordinatesEqual(uppercase, lowercase)).toBe(true);
+    expect(prRouteTargetsEqual(
+      { prId: "pr-123", ...uppercase },
+      { prId: "pr-123", ...lowercase },
+    )).toBe(true);
   });
 
   it("builds normal and workflow route searches with the expected ids", () => {

--- a/apps/desktop/src/renderer/components/prs/prsRouteState.ts
+++ b/apps/desktop/src/renderer/components/prs/prsRouteState.ts
@@ -9,17 +9,93 @@ function scopedPrsRouteStorageKey(projectRoot?: string | null): string {
   return root ? `${PRS_LAST_ROUTE_STORAGE_KEY}:${root}` : PRS_LAST_ROUTE_STORAGE_KEY;
 }
 
+export type PrRouteSelectionTarget = {
+  /** ADE's local row id, when this PR is already mapped in the active project. */
+  prId: string | null;
+  /** GitHub coordinates remain usable when the local row is absent or foreign. */
+  prNumber: number | null;
+  repoOwner: string | null;
+  repoName: string | null;
+};
+
 export type ParsedPrsRouteState = {
   tab: "github" | "normal" | "workflows" | PrWorkflowTab | null;
   workflowTab: PrWorkflowTab | null;
   laneId: string | null;
   prId: string | null;
   prNumber: number | null;
+  repoOwner: string | null;
+  repoName: string | null;
   eventId: string | null;
   threadId: string | null;
   commitSha: string | null;
   detailTab: PrDetailRouteTab | null;
 };
+
+export function prRouteSelectionTarget(route: ParsedPrsRouteState): PrRouteSelectionTarget | null {
+  const hasTarget = Boolean(route.prId || route.prNumber != null);
+  if (!hasTarget) return null;
+  return {
+    prId: route.prId,
+    prNumber: route.prNumber,
+    repoOwner: route.repoOwner,
+    repoName: route.repoName,
+  };
+}
+
+export function prRouteTargetsEqual(
+  left: PrRouteSelectionTarget | null,
+  right: PrRouteSelectionTarget | null,
+): boolean {
+  if (left === right) return true;
+  if (!left || !right) return false;
+  return left.prId === right.prId && prRouteCoordinatesEqual(left, right);
+}
+
+export type PrRouteCoordinates = Pick<PrRouteSelectionTarget, "prNumber" | "repoOwner" | "repoName">;
+
+function normalizePrRouteCoordinates(coordinates: PrRouteCoordinates): PrRouteCoordinates {
+  const normalizeRepoPart = (value: string | null): string | null => {
+    const normalized = value?.trim().toLowerCase() ?? "";
+    return normalized || null;
+  };
+  return {
+    prNumber: coordinates.prNumber ?? null,
+    repoOwner: normalizeRepoPart(coordinates.repoOwner),
+    repoName: normalizeRepoPart(coordinates.repoName),
+  };
+}
+
+/** Stable, case-insensitive key for one GitHub PR coordinate. */
+export function prRouteCoordinatesKey(coordinates: PrRouteCoordinates): string {
+  const normalized = normalizePrRouteCoordinates(coordinates);
+  return `${normalized.repoOwner ?? ""}/${normalized.repoName ?? ""}#${normalized.prNumber ?? ""}`;
+}
+
+export function prRouteCoordinatesEqual(left: PrRouteCoordinates, right: PrRouteCoordinates): boolean {
+  return prRouteCoordinatesKey(left) === prRouteCoordinatesKey(right);
+}
+
+export function prRouteCoordinatesMatch(
+  left: PrRouteCoordinates,
+  right: PrRouteCoordinates,
+): boolean {
+  const normalizedLeft = normalizePrRouteCoordinates(left);
+  const normalizedRight = normalizePrRouteCoordinates(right);
+  return (normalizedLeft.prNumber == null || normalizedRight.prNumber == null || normalizedLeft.prNumber === normalizedRight.prNumber)
+    && (!normalizedLeft.repoOwner || !normalizedRight.repoOwner || normalizedLeft.repoOwner === normalizedRight.repoOwner)
+    && (!normalizedLeft.repoName || !normalizedRight.repoName || normalizedLeft.repoName === normalizedRight.repoName);
+}
+
+export function hasExplicitPrsRouteState(route: ParsedPrsRouteState): boolean {
+  return Boolean(
+    route.tab
+    || route.workflowTab
+    || prRouteSelectionTarget(route)
+    || route.laneId
+    || route.detailTab
+  );
+}
 
 function parseSearch(search: string): URLSearchParams {
   return new URLSearchParams(search.startsWith("?") ? search.slice(1) : search);
@@ -84,6 +160,8 @@ export function parsePrsRouteState(args: { search?: string | null; hash?: string
     laneId: pick("laneId"),
     prId: pick("prId"),
     prNumber: parseOptionalNumber(routeParams.get("pr")),
+    repoOwner: pick("repoOwner"),
+    repoName: pick("repoName"),
     eventId: pick("eventId"),
     threadId: pick("threadId"),
     commitSha: pick("commitSha"),

--- a/apps/desktop/src/renderer/components/prs/state/PrsContext.test.tsx
+++ b/apps/desktop/src/renderer/components/prs/state/PrsContext.test.tsx
@@ -249,7 +249,7 @@ describe("PrsContext refresh", () => {
     expect(window.ade.rebase.scanNeeds).not.toHaveBeenCalled();
     expect(window.ade.lanes.listAutoRebaseStatuses).not.toHaveBeenCalled();
     expect(window.ade.lanes.list).toHaveBeenCalledWith({ includeStatus: false });
-    expect(window.ade.prs.refresh).toHaveBeenCalledWith({}, null);
+    expect(window.ade.prs.refresh).not.toHaveBeenCalled();
   });
 
   it("replays a hidden lane lifecycle refresh when the PRs tab becomes visible", async () => {

--- a/apps/desktop/src/renderer/components/prs/state/PrsContext.tsx
+++ b/apps/desktop/src/renderer/components/prs/state/PrsContext.tsx
@@ -31,7 +31,7 @@ import type {
 import type { PrTimelineFilters } from "../shared/PrTimeline";
 import { buildPrAiResolutionContextKey } from "../../../../shared/types";
 import { getModelById, resolveProviderGroupForModel, type ModelProviderGroup } from "../../../../shared/modelRegistry";
-import { parsePrsRouteState, resolvePrsActiveTab } from "../prsRouteState";
+import { hasExplicitPrsRouteState, parsePrsRouteState, resolvePrsActiveTab } from "../prsRouteState";
 import { resolveRouteRebaseSelection } from "../shared/rebaseNeedUtils";
 import { selectActiveProjectRoot, useAppStore } from "../../../state/appStore";
 import { refreshPrsCoalesced } from "../../../lib/prReadCache";
@@ -314,13 +314,7 @@ function readInitialRouteState(fallback?: PrsContextWarmCache | null): {
       search: window.location.search,
       hash: window.location.hash,
     });
-    const hasExplicitRouteState = Boolean(
-      route.tab
-      || route.workflowTab
-      || route.prId
-      || route.laneId
-      || route.detailTab
-    );
+    const hasExplicitRouteState = hasExplicitPrsRouteState(route);
     if (!hasExplicitRouteState && fallback) {
       return {
         activeTab: fallback.activeTab,
@@ -753,6 +747,12 @@ export function PrsProvider({ active = true, children }: { active?: boolean; chi
       refreshPending.current = mergeRefreshCoreOptions(refreshPending.current, options);
       return;
     }
+    // The normal GitHub list has its own projected snapshot/read-through path and
+    // the runtime poller already reconciles stale rows. Do not start another
+    // fan-out refresh while the user is opening the list; workflow tabs still
+    // need the background refresh because their diagnostics are local-row based.
+    const runBackgroundGithubRefresh =
+      options.githubRefreshMode === "background" && activeTabRef.current !== "normal";
     const warmCacheAgeMs = Date.now() - warmCacheHydratedAtRef.current;
     const warmCacheUsable =
       warmCacheHydratedAtRef.current > 0
@@ -766,11 +766,11 @@ export function PrsProvider({ active = true, children }: { active?: boolean; chi
       const shouldLoadWorkflowDiagnostics =
         activeTabRef.current !== "normal" || selectedPrIdRef.current !== null || currentRouteRequestsPrDiagnostics();
       void applyLocalPrState({ forceRebaseDiagnostics: shouldLoadWorkflowDiagnostics })
-        .then(() => options.githubRefreshMode === "background"
+        .then(() => runBackgroundGithubRefresh
           ? refreshPrsCoalesced(options.githubRefreshArgs ?? {}, { projectRoot }).catch(() => null)
           : null)
         .then(() => {
-          if (options.githubRefreshMode === "background") {
+          if (runBackgroundGithubRefresh) {
             return applyLocalPrState({ forceRebaseDiagnostics: shouldLoadWorkflowDiagnostics });
           }
           return null;
@@ -799,7 +799,7 @@ export function PrsProvider({ active = true, children }: { active?: boolean; chi
       await applyLocalPrState({ forceRebaseDiagnostics: shouldLoadWorkflowDiagnostics });
       warmCacheHydratedAtRef.current = Date.now();
       setRefreshErrorRetryCount(0);
-      if (options.githubRefreshMode === "background") {
+      if (runBackgroundGithubRefresh) {
         void refreshPrsCoalesced(options.githubRefreshArgs ?? {}, { projectRoot })
           .then(() => applyLocalPrState({ forceRebaseDiagnostics: shouldLoadWorkflowDiagnostics }))
           .then(() => {

--- a/apps/desktop/src/renderer/components/prs/tabs/GitHubTab.test.tsx
+++ b/apps/desktop/src/renderer/components/prs/tabs/GitHubTab.test.tsx
@@ -6,6 +6,7 @@ import { act, fireEvent, render, screen, waitFor, within } from "@testing-librar
 import userEvent from "@testing-library/user-event";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { GitHubPrSnapshot, LaneSummary, MergeMethod } from "../../../../shared/types";
+import type { PrRouteSelectionTarget } from "../prsRouteState";
 
 vi.mock("react-resizable-panels", async () => {
   const harness = await import("./GitHubTab.testHarness");
@@ -52,6 +53,7 @@ describe("GitHubTab snapshot lifecycle", () => {
 
   function renderTab(overrides: Partial<{
     selectedPrId: string | null;
+    selectedPrTarget: PrRouteSelectionTarget | null;
     onSelectPr: ReturnType<typeof vi.fn>;
     onRefreshAll: ReturnType<typeof vi.fn>;
     lanes: LaneSummary[];
@@ -163,7 +165,7 @@ describe("GitHubTab snapshot lifecycle", () => {
 
     await user.click(screen.getByRole("button", { name: /^open/i }));
 
-    await waitFor(() => expect(onSelectPr).toHaveBeenLastCalledWith(null));
+    await waitFor(() => expect(onSelectPr).toHaveBeenLastCalledWith(null, null));
     expect(screen.queryByTestId("pr-detail-pane")).toBeNull();
   });
 
@@ -411,7 +413,7 @@ describe("GitHubTab snapshot lifecycle", () => {
       expect(screen.getByText("Open PR")).not.toBeNull();
     });
     await waitFor(() => {
-      expect(screen.getByTestId("pr-detail-pane").textContent).toContain("pr-open");
+      expect(screen.getByTestId("pr-detail-pane").textContent).toContain("gh:ade-dev/ade#101");
     });
     await waitFor(() => {
       expect(onRefreshAll).toHaveBeenCalledWith({ prId: "pr-open" });

--- a/apps/desktop/src/renderer/components/prs/tabs/GitHubTab.testHarness.tsx
+++ b/apps/desktop/src/renderer/components/prs/tabs/GitHubTab.testHarness.tsx
@@ -109,6 +109,7 @@ export function renderGitHubTab(
   Component: React.ComponentType<GitHubTabProps>,
   overrides: Partial<{
     selectedPrId: string | null;
+    selectedPrTarget: GitHubTabProps["selectedPrTarget"];
     onSelectPr: ReturnType<typeof vi.fn>;
     onRefreshAll: ReturnType<typeof vi.fn>;
     lanes: LaneSummary[];
@@ -122,6 +123,7 @@ export function renderGitHubTab(
         lanes={overrides.lanes ?? []}
         mergeMethod={"squash" satisfies MergeMethod}
         selectedPrId={overrides.selectedPrId ?? null}
+        selectedPrTarget={overrides.selectedPrTarget}
         onSelectPr={onSelectPr}
         onRefreshAll={onRefreshAll}
       />

--- a/apps/desktop/src/renderer/components/prs/tabs/GitHubTab.tsx
+++ b/apps/desktop/src/renderer/components/prs/tabs/GitHubTab.tsx
@@ -13,7 +13,6 @@ import { selectActiveProjectRoot, useAppStore, useAppStoreApi } from "../../../s
 import type { UnmappedAffordance } from "../detail/PrDetailPane";
 import { usePrs } from "../state/PrsContext";
 import {
-  prRouteCoordinatesEqual,
   type PrDetailRouteTab,
   type PrRouteSelectionTarget,
 } from "../prsRouteState";
@@ -456,19 +455,8 @@ export function GitHubTab({
     }
     // Prefer the local row by GitHub coordinates when a stale snapshot has lost
     // its link (or carries a foreign machine's link id).
-    return prs.find((pr) => prRouteCoordinatesEqual(
-      {
-        prNumber: pr.githubPrNumber,
-        repoOwner: pr.repoOwner,
-        repoName: pr.repoName,
-      },
-      {
-        prNumber: selectedItem.githubPrNumber,
-        repoOwner: selectedItem.repoOwner,
-        repoName: selectedItem.repoName,
-      },
-    )) ?? null;
-  }, [prs, prsByIdMap, selectedItem]);
+    return prsByCoordinateMap.get(githubCoordKey(selectedItem)) ?? null;
+  }, [prsByCoordinateMap, prsByIdMap, selectedItem]);
 
   const selectedLinkedPr = React.useMemo(
     (): PrWithConflicts | null => selectedLocalPr
@@ -499,15 +487,13 @@ export function GitHubTab({
   const syntheticUnmappedId = selectedIsUnmapped && selectedItem
     ? syntheticUnmappedPrId(selectedItem)
     : null;
+  const fallbackProjectId = prs[0]?.projectId ?? "cached-github-snapshot";
   const selectedUnmappedPr = React.useMemo(
     (): PrWithConflicts | null => {
       if (!selectedItem || !selectedIsUnmapped) return null;
-      const fallbackProjectId = prs[0]?.projectId ?? "cached-github-snapshot";
       return buildSyntheticUnmappedPr(selectedItem, fallbackProjectId);
     },
-    // syntheticUnmappedId keys identity; prs[0]?.projectId is captured at build time.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [syntheticUnmappedId, selectedItem, selectedIsUnmapped, prs],
+    [fallbackProjectId, syntheticUnmappedId, selectedItem, selectedIsUnmapped],
   );
   const selectedDisplayPr = selectedLinkedPr ?? selectedUnmappedPr;
 

--- a/apps/desktop/src/renderer/components/prs/tabs/GitHubTab.tsx
+++ b/apps/desktop/src/renderer/components/prs/tabs/GitHubTab.tsx
@@ -7,13 +7,16 @@ import type {
   LaneSummary,
   MergeMethod,
   PrEventPayload,
-  PrSummary,
   PrWithConflicts,
 } from "../../../../shared/types";
 import { selectActiveProjectRoot, useAppStore, useAppStoreApi } from "../../../state/appStore";
 import type { UnmappedAffordance } from "../detail/PrDetailPane";
 import { usePrs } from "../state/PrsContext";
-import type { PrDetailRouteTab } from "../prsRouteState";
+import {
+  prRouteCoordinatesEqual,
+  type PrDetailRouteTab,
+  type PrRouteSelectionTarget,
+} from "../prsRouteState";
 import { getGitHubSnapshotCoalesced } from "../../../lib/prReadCache";
 import {
   GITHUB_TAB_HISTORY_INITIAL_PAGE_LIMIT,
@@ -22,9 +25,9 @@ import {
   GITHUB_TAB_HOT_REFRESH_DELAY_MS,
   GITHUB_TAB_REVISIT_CACHE_TTL_MS,
   GITHUB_TAB_SNAPSHOT_FRESH_MS,
-  LINKED_HYDRATION_LIMIT,
   buildSyntheticUnmappedPr,
-  bucketForState,
+  githubCoordKey,
+  selectionTargetForItem,
   formatGitHubSnapshotError,
   initialGitHubFilterSelections,
   matchesFilter,
@@ -56,13 +59,17 @@ import {
 import { GitHubTabView } from "./GitHubTabView";
 import { branchNameFromRef } from "./githubPrBranch";
 import { useGitHubTabListModel } from "./useGitHubTabListModel";
+import { useGitHubTabSelection } from "./useGitHubTabSelection";
+import { useGitHubTargetHistory } from "./useGitHubTargetHistory";
 import { settingsRouteFor } from "../../settings/settingsManifest";
 
 export type GitHubTabProps = {
   lanes: LaneSummary[];
   mergeMethod: MergeMethod;
   selectedPrId: string | null;
-  onSelectPr: (id: string | null) => void;
+  /** Coordinate fallback for deep links whose ADE row is not local yet. */
+  selectedPrTarget?: PrRouteSelectionTarget | null;
+  onSelectPr: (id: string | null, target: PrRouteSelectionTarget | null) => void;
   selectedDetailTab?: PrDetailRouteTab | null;
   onDetailTabChange?: (tab: PrDetailRouteTab) => void;
   onRefreshAll: (args?: { prId?: string; prIds?: string[] }) => Promise<void>;
@@ -84,6 +91,7 @@ export function GitHubTab({
   lanes,
   mergeMethod,
   selectedPrId,
+  selectedPrTarget = null,
   onSelectPr,
   selectedDetailTab,
   onDetailTabChange,
@@ -142,7 +150,7 @@ export function GitHubTab({
   );
   const createLanePreflightRequestIdRef = React.useRef(0);
   const createLanePreflightRequestRef = React.useRef<{ id: number; itemKey: string } | null>(null);
-  const lastHandledSelectedRef = React.useRef<{ prId: string | null; bucket: GitHubFilter | null } | undefined>(undefined);
+  const lastHandledSelectedRef = React.useRef<{ key: string | null; bucket: GitHubFilter | null } | undefined>(undefined);
   const lastSeenRowByCoordRef = React.useRef<Map<string, GitHubPrListItem>>(new Map());
   const pendingSelectedItemIdRef = React.useRef<string | null>(null);
   const pendingRestoredSelectedItemIdRef = React.useRef<string | null>(null);
@@ -155,7 +163,6 @@ export function GitHubTab({
   const loadingSnapshotRequestCountRef = React.useRef(0);
   const lastSnapshotLoadedAtRef = React.useRef(initialWarmCacheRef.current?.cachedAt ?? 0);
   const missingLinkedPrHydrationRef = React.useRef<string | null>(null);
-  const visibleLinkedHydrationKeyRef = React.useRef<string>("");
   const filterRef = React.useRef(filter);
   const externalHistoryLoadedRef = React.useRef(externalHistoryLoaded);
   const projectRootRef = React.useRef(projectRoot);
@@ -171,9 +178,16 @@ export function GitHubTab({
 
   /* Build a lookup from linkedPrId -> PrSummary for CI/review indicators */
   const prsByIdMap = React.useMemo(() => {
-    const map = new Map<string, PrSummary>();
+    const map = new Map<string, PrWithConflicts>();
     for (const pr of prs) {
       map.set(pr.id, pr);
+    }
+    return map;
+  }, [prs]);
+  const prsByCoordinateMap = React.useMemo(() => {
+    const map = new Map<string, PrWithConflicts>();
+    for (const pr of prs) {
+      map.set(githubCoordKey(pr), pr);
     }
     return map;
   }, [prs]);
@@ -382,7 +396,6 @@ export function GitHubTab({
   const {
     displayedItems,
     filteredItems,
-    hydrationItems,
     listRows,
     filterCounts,
     canLoadOlderHistory,
@@ -394,96 +407,82 @@ export function GitHubTab({
     renderedHydrationItems,
     lastSeenRowByCoordRef,
     currentHistoryPageLimit,
+    prsByCoordinateMap,
+  });
+  useGitHubTargetHistory({
+    displayedItems,
+    loadSnapshot,
+    selectedPrId,
+    selectedPrTarget,
+    snapshot,
   });
   const showListLoadingIndicator = loading || syncing || loadingFilter !== null;
 
-  React.useEffect(() => {
-    if (!snapshot) return;
+  const { selectedItem, selectedTargetResolved } = useGitHubTabSelection({
+    displayedItems,
+    filteredItems,
+    filter,
+    onSelectPr,
+    selectedItemId,
+    selectedPrId,
+    selectedPrTarget,
+    snapshot,
+    setFilter,
+    setSelectedItemId,
+    setSelectedItemIdsByFilter,
+    lastHandledSelectedRef,
+    pendingSelectedItemIdRef,
+    pendingRestoredSelectedItemIdRef,
+    hasInitializedSelectionRef,
+  });
+  const selectedBucketMismatch = Boolean(
+    selectedItem
+    && selectedTargetResolved
+    && !matchesFilter(selectedItem, filter),
+  );
 
-    // Track the selected PR together with its current effective bucket, so a
-    // state transition (open -> merged) is followed even though `selectedPrId`
-    // is unchanged. A manual filter change leaves the selected PR's bucket
-    // untouched, so it never re-triggers the follow below.
-    const linkedItem = selectedPrId
-      ? displayedItems.find((item) => item.linkedPrId === selectedPrId) ?? null
-      : null;
-    const currentBucket = linkedItem ? bucketForState(linkedItem.state) : null;
-    const nextPrId = selectedPrId ?? null;
+  const handleHydrationItemsChange = React.useCallback((items: GitHubPrListItem[]) => {
+    setRenderedHydrationItems((prev) => {
+      if (prev.length === items.length && prev.every((item, index) => item.id === items[index]?.id)) return prev;
+      return items;
+    });
+  }, []);
 
-    const last = lastHandledSelectedRef.current;
-    if (last && last.prId === nextPrId && last.bucket === currentBucket) return;
-    const isNewSelection = !last || last.prId !== nextPrId;
-    const bucketChanged = !isNewSelection && last!.bucket !== currentBucket;
-    lastHandledSelectedRef.current = { prId: nextPrId, bucket: currentBucket };
-
-    if (!selectedPrId || !linkedItem) {
-      pendingSelectedItemIdRef.current = null;
-      return;
+  const selectedLocalPr = React.useMemo((): PrWithConflicts | null => {
+    if (!selectedItem) return null;
+    if (selectedItem.linkedPrId) {
+      const linked = prsByIdMap.get(selectedItem.linkedPrId);
+      if (linked) return linked;
     }
+    // Prefer the local row by GitHub coordinates when a stale snapshot has lost
+    // its link (or carries a foreign machine's link id).
+    return prs.find((pr) => prRouteCoordinatesEqual(
+      {
+        prNumber: pr.githubPrNumber,
+        repoOwner: pr.repoOwner,
+        repoName: pr.repoName,
+      },
+      {
+        prNumber: selectedItem.githubPrNumber,
+        repoOwner: selectedItem.repoOwner,
+        repoName: selectedItem.repoName,
+      },
+    )) ?? null;
+  }, [prs, prsByIdMap, selectedItem]);
 
-    pendingSelectedItemIdRef.current = linkedItem.id;
-    const linkedFilter = bucketForState(linkedItem.state);
-    setSelectedItemIdsByFilter((prev) => ({ ...prev, [linkedFilter]: linkedItem.id }));
-    // Follow the selection into its bucket on a fresh selection, or when the
-    // already-selected PR transitions to a new bucket (so a merge/close doesn't
-    // strand the user on a now-empty list). Never on a manual filter switch.
-    if ((isNewSelection || bucketChanged) && !matchesFilter(linkedItem, filter)) {
-      setFilter(linkedFilter);
-    }
-    setSelectedItemId(linkedItem.id);
-    hasInitializedSelectionRef.current = true;
-  }, [displayedItems, snapshot, selectedPrId, filter]);
+  const selectedLinkedPr = React.useMemo(
+    (): PrWithConflicts | null => selectedLocalPr
+      ? { ...selectedLocalPr, stack: selectedItem?.stack ?? selectedLocalPr.stack ?? null }
+      : null,
+    [selectedItem?.stack, selectedLocalPr],
+  );
 
-  React.useEffect(() => {
-    if (!snapshot) return;
-    if (pendingSelectedItemIdRef.current) {
-      if (selectedItemId === pendingSelectedItemIdRef.current) {
-        pendingSelectedItemIdRef.current = null;
-      } else {
-        return;
-      }
-    }
-
-    if (selectedItemId && filteredItems.some((item) => item.id === selectedItemId)) return;
-    if (!hasInitializedSelectionRef.current) {
-      const next = filteredItems[0] ?? null;
-      if (next) {
-        hasInitializedSelectionRef.current = true;
-        setSelectedItemId(next.id);
-        setSelectedItemIdsByFilter((prev) => ({ ...prev, [filter]: next.id }));
-        onSelectPr(next.linkedPrId ?? null);
-      }
-    }
-  }, [snapshot, filter, filteredItems, selectedItemId, onSelectPr]);
-
-  // The row backing the detail pane. Unlike the list highlight, it survives a
-  // state transition that moves the row out of the active filter's bucket, so
-  // the pane never blanks mid-transition. Cleared only when nothing is selected
-  // (`selectedItemId` null) — which is what a manual filter switch to an empty
-  // bucket produces. Falls back to the linked coordinate from PrsContext when
-  // the row itself has momentarily dropped from the list.
-  const selectedItem = React.useMemo((): GitHubPrListItem | null => {
-    if (!selectedItemId) return null;
-    const byId = displayedItems.find((candidate) => candidate.id === selectedItemId) ?? null;
-    if (byId) return byId;
-    if (selectedPrId) return displayedItems.find((candidate) => candidate.linkedPrId === selectedPrId) ?? null;
-    return null;
-  }, [displayedItems, selectedItemId, selectedPrId]);
-
-  // Whether the selected PR still belongs in the active filter. When false the
-  // detail pane shows a slim "now Merged/Closed" banner instead of blanking.
-  const selectedBucketMismatch = Boolean(selectedItem && !matchesFilter(selectedItem, filter));
-
-  React.useEffect(() => {
-    const pending = pendingRestoredSelectedItemIdRef.current;
-    if (!pending || !selectedItem || selectedItem.id !== pending) return;
-    // Restore selection only once the item is actually in the active filter's
-    // list — matching the original filter-scoped restore semantics.
-    if (!matchesFilter(selectedItem, filter)) return;
-    pendingRestoredSelectedItemIdRef.current = null;
-    onSelectPr(selectedItem.linkedPrId ?? null);
-  }, [filter, onSelectPr, selectedItem]);
-  const missingLinkedPrId = selectedItem?.linkedPrId && !prsByIdMap.has(selectedItem.linkedPrId)
+  // A GitHub row can carry a foreign or not-yet-hydrated linkedPrId. Until the
+  // local row arrives, treat it as coordinate-backed rather than manufacturing
+  // a row-backed PR id that cannot be read from this machine.
+  const selectedIsUnmapped = Boolean(selectedItem && !selectedLocalPr);
+  const selectedMappedPrId = selectedLocalPr?.id ?? selectedItem?.linkedPrId ?? null;
+  const missingLinkedPrId = selectedItem?.linkedPrId && !selectedLocalPr
     ? selectedItem.linkedPrId
     : null;
 
@@ -497,83 +496,18 @@ export function GitHubTab({
     void onRefreshAll({ prId: missingLinkedPrId }).catch(() => {});
   }, [missingLinkedPrId, onRefreshAll]);
 
-  React.useEffect(() => {
-    const prIds = hydrationItems
-      .slice(0, LINKED_HYDRATION_LIMIT)
-      .map((item) => item.linkedPrId)
-      .filter((prId): prId is string => Boolean(prId));
-    if (prIds.length === 0) return undefined;
-    const uniquePrIds = [...new Set(prIds)];
-    const key = uniquePrIds.join(",");
-    if (visibleLinkedHydrationKeyRef.current === key) return undefined;
-    visibleLinkedHydrationKeyRef.current = key;
-    const timer = window.setTimeout(() => {
-      void onRefreshAll({ prIds: uniquePrIds }).catch(() => {});
-    }, 250);
-    return () => window.clearTimeout(timer);
-  }, [hydrationItems, onRefreshAll]);
-
-  const handleHydrationItemsChange = React.useCallback((items: GitHubPrListItem[]) => {
-    setRenderedHydrationItems((prev) => {
-      if (prev.length === items.length && prev.every((item, index) => item.id === items[index]?.id)) return prev;
-      return items;
-    });
-  }, []);
-
-  const selectedLinkedPr = React.useMemo(
-    (): PrWithConflicts | null => {
-      if (!selectedItem?.linkedPrId) return null;
-      const linked = prs.find((pr) => pr.id === selectedItem.linkedPrId);
-      if (linked) {
-        return {
-          ...linked,
-          stack: selectedItem.stack ?? linked.stack ?? null,
-        };
-      }
-      const fallbackProjectId = prs[0]?.projectId ?? "cached-github-snapshot";
-      return {
-        id: selectedItem.linkedPrId,
-        laneId: selectedItem.linkedLaneId ?? "",
-        projectId: fallbackProjectId,
-        repoOwner: selectedItem.repoOwner,
-        repoName: selectedItem.repoName,
-        githubPrNumber: selectedItem.githubPrNumber,
-        githubUrl: selectedItem.githubUrl,
-        githubNodeId: null,
-        title: selectedItem.title,
-        state: selectedItem.state,
-        baseBranch: selectedItem.baseBranch ?? "",
-        headBranch: selectedItem.headBranch ?? "",
-        checksStatus: "none",
-        reviewStatus: "none",
-        additions: 0,
-        deletions: 0,
-        lastSyncedAt: null,
-        createdAt: selectedItem.createdAt,
-        updatedAt: selectedItem.updatedAt,
-        stack: selectedItem.stack ?? null,
-        conflictAnalysis: null,
-      };
-    },
-    [prs, selectedItem],
-  );
-
-  // For an unmapped selected PR (no linkedPrId) build a referentially-stable
-  // synthetic PR so it can render through the full PrDetailPane. Memoized on the
-  // stable synthetic id so the object identity (and React key) stays constant
-  // across renders while the same PR is selected.
-  const syntheticUnmappedId = selectedItem && !selectedItem.linkedPrId
+  const syntheticUnmappedId = selectedIsUnmapped && selectedItem
     ? syntheticUnmappedPrId(selectedItem)
     : null;
   const selectedUnmappedPr = React.useMemo(
     (): PrWithConflicts | null => {
-      if (!selectedItem || selectedItem.linkedPrId) return null;
+      if (!selectedItem || !selectedIsUnmapped) return null;
       const fallbackProjectId = prs[0]?.projectId ?? "cached-github-snapshot";
       return buildSyntheticUnmappedPr(selectedItem, fallbackProjectId);
     },
     // syntheticUnmappedId keys identity; prs[0]?.projectId is captured at build time.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [syntheticUnmappedId, selectedItem, prs],
+    [syntheticUnmappedId, selectedItem, selectedIsUnmapped, prs],
   );
   const selectedDisplayPr = selectedLinkedPr ?? selectedUnmappedPr;
 
@@ -704,7 +638,7 @@ export function GitHubTab({
     setSelectedItemId(item.id);
     setSelectedItemIdsByFilter((prev) => ({ ...prev, [filter]: item.id }));
     pendingRestoredSelectedItemIdRef.current = null;
-    onSelectPr(item.linkedPrId ?? null);
+    onSelectPr(item.linkedPrId ?? null, selectionTargetForItem(item));
     setLinkLaneId("");
   }, [filter, onSelectPr]);
 
@@ -730,14 +664,21 @@ export function GitHubTab({
     setFilter(state);
     setSelectedItemIdsByFilter((prev) => ({ ...prev, [filter]: selectedItemId, [state]: nextSelectedItemId }));
     setSelectedItemId(nextSelectedItemId);
+    // Clearing an explicit deep link via a filter switch is a deliberate
+    // empty selection. Do not let the snapshot auto-initializer immediately
+    // replace it with the first row in the new bucket.
+    if (!nextSelectedItem && (selectedPrId || selectedPrTarget)) {
+      hasInitializedSelectionRef.current = true;
+    }
     if (nextSelectedItemId && !nextSelectedItem) {
       pendingRestoredSelectedItemIdRef.current = nextSelectedItemId;
     } else {
       pendingRestoredSelectedItemIdRef.current = null;
-      onSelectPr(nextSelectedItem?.linkedPrId ?? null);
+      if (nextSelectedItem) onSelectPr(nextSelectedItem.linkedPrId ?? null, selectionTargetForItem(nextSelectedItem));
+      else onSelectPr(null, null);
     }
     setLinkLaneId("");
-  }, [displayedItems, filter, onSelectPr, selectedItemId, selectedItemIdsByFilter]);
+  }, [displayedItems, filter, onSelectPr, selectedItemId, selectedItemIdsByFilter, selectedPrId, selectedPrTarget]);
 
   const handleLink = React.useCallback(async () => {
     if (!selectedItem || !linkLaneId) return;
@@ -768,7 +709,7 @@ export function GitHubTab({
         closeOnGitHub: false,
         archiveLane: false,
       });
-      onSelectPr(null);
+      onSelectPr(null, selectionTargetForItem(item));
       setSelectedItemId(item.id);
       setSelectedItemIdsByFilter((prev) => ({ ...prev, [filterRef.current]: item.id }));
       await Promise.all([
@@ -845,7 +786,10 @@ export function GitHubTab({
           : current);
         setSelectedItemId(createLaneItem.id);
         setSelectedItemIdsByFilter((prev) => ({ ...prev, [filterRef.current]: createLaneItem.id }));
-        onSelectPr(mappedPrId);
+        onSelectPr(mappedPrId, {
+          ...selectionTargetForItem(createLaneItem),
+          prId: mappedPrId,
+        });
       }
       setCreateLaneItem(null);
       setCreateLanePreflight(null);
@@ -925,11 +869,14 @@ export function GitHubTab({
     onOpenRebaseTab,
     initialDetailTab: selectedDetailTab,
     onDetailTabChange,
-    onUnmap: selectedItem.linkedPrId ? () => handleUnlink(selectedItem) : undefined,
-    unmapBusy: Boolean(selectedItem.linkedPrId) && unlinkingPrId === selectedItem.linkedPrId,
-    unmapped: !selectedItem.linkedPrId,
-    githubCoords: selectedItem.linkedPrId ? null : selectedGithubCoords,
-    unmappedAffordance: selectedItem.linkedPrId ? null : unmappedAffordance,
+    onUnmap: !selectedIsUnmapped && selectedMappedPrId
+      ? () => handleUnlink({ ...selectedItem, linkedPrId: selectedMappedPrId })
+      : undefined,
+    unmapBusy: !selectedIsUnmapped && Boolean(selectedMappedPrId) && unlinkingPrId === selectedMappedPrId,
+    unmapped: selectedIsUnmapped,
+    provisional: Boolean(selectedPrTarget && !selectedTargetResolved),
+    githubCoords: selectedIsUnmapped ? selectedGithubCoords : null,
+    unmappedAffordance: selectedIsUnmapped && selectedTargetResolved ? unmappedAffordance : null,
   } : null;
 
   return (

--- a/apps/desktop/src/renderer/components/prs/tabs/GitHubTabCreateLaneDialog.tsx
+++ b/apps/desktop/src/renderer/components/prs/tabs/GitHubTabCreateLaneDialog.tsx
@@ -19,6 +19,7 @@ import {
   primaryButton,
 } from "../../lanes/laneDesignTokens";
 import { branchNameFromRef } from "./githubPrBranch";
+import { prRouteCoordinatesEqual, prRouteCoordinatesKey } from "../prsRouteState";
 
 type CreateLaneFromPrBranchApi = {
   preflightCreateLaneFromPrBranch: (
@@ -50,7 +51,11 @@ export function createLaneFromPrBranchArgs(item: GitHubPrListItem): CreateLaneFr
 }
 
 export function createLaneFromPrBranchRequestKey(item: GitHubPrListItem): string {
-  return `${item.repoOwner}/${item.repoName}#${Number(item.githubPrNumber)}`;
+  return prRouteCoordinatesKey({
+    prNumber: Number(item.githubPrNumber),
+    repoOwner: item.repoOwner,
+    repoName: item.repoName,
+  });
 }
 
 function preflightText(value: unknown): string | null {
@@ -132,9 +137,18 @@ export function canCreateLaneFromPrBranch(item: GitHubPrListItem, lanes: LaneSum
 }
 
 function sameGitHubPr(left: GitHubPrListItem, right: GitHubPrListItem): boolean {
-  return left.repoOwner === right.repoOwner
-    && left.repoName === right.repoName
-    && Number(left.githubPrNumber) === Number(right.githubPrNumber);
+  return prRouteCoordinatesEqual(
+    {
+      prNumber: Number(left.githubPrNumber),
+      repoOwner: left.repoOwner,
+      repoName: left.repoName,
+    },
+    {
+      prNumber: Number(right.githubPrNumber),
+      repoOwner: right.repoOwner,
+      repoName: right.repoName,
+    },
+  );
 }
 
 export function patchSnapshotWithMappedPr(

--- a/apps/desktop/src/renderer/components/prs/tabs/GitHubTabDeepLinks.test.tsx
+++ b/apps/desktop/src/renderer/components/prs/tabs/GitHubTabDeepLinks.test.tsx
@@ -1,0 +1,281 @@
+// @vitest-environment jsdom
+
+import React from "react";
+import { MemoryRouter } from "react-router-dom";
+import { act, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { GitHubPrSnapshot, LaneSummary } from "../../../../shared/types";
+import type { PrRouteSelectionTarget } from "../prsRouteState";
+
+vi.mock("react-resizable-panels", async () => {
+  const harness = await import("./GitHubTab.testHarness");
+  return {
+    Group: harness.MockPanelGroup,
+    Panel: harness.MockPanel,
+    Separator: harness.MockSeparator,
+  };
+});
+
+vi.mock("../state/PrsContext", async () => {
+  const { mockUsePrs } = await import("./GitHubTab.testHarness");
+  return { usePrs: () => mockUsePrs() };
+});
+
+vi.mock("../detail/PrDetailPane", async () => {
+  const { MockPrDetailPane } = await import("./GitHubTab.testHarness");
+  return { PrDetailPane: MockPrDetailPane };
+});
+
+import { GitHubTab } from "./GitHubTab";
+import {
+  cleanupGitHubTabTest,
+  mockUsePrs,
+  renderGitHubTab,
+  setupGitHubTabTest,
+} from "./GitHubTab.testHarness";
+import {
+  createDeferred,
+  makeGitHubPr,
+  makePrsContext,
+  snapshot,
+} from "./GitHubTab.testFixtures";
+
+describe("GitHubTab explicit coordinate targets", () => {
+  beforeEach(() => {
+    setupGitHubTabTest();
+  });
+
+  afterEach(() => {
+    cleanupGitHubTabTest();
+  });
+
+  function renderTab(overrides: Partial<{
+    selectedPrId: string | null;
+    selectedPrTarget: PrRouteSelectionTarget | null;
+    onSelectPr: ReturnType<typeof vi.fn>;
+    onRefreshAll: ReturnType<typeof vi.fn>;
+    lanes: LaneSummary[];
+  }> = {}) {
+    return renderGitHubTab(GitHubTab, overrides);
+  }
+
+  it("renders a coordinate deep link before the GitHub snapshot arrives", async () => {
+    const user = userEvent.setup();
+    const deferredSnapshot = createDeferred<GitHubPrSnapshot>();
+    vi.mocked(window.ade.prs.getGitHubSnapshot).mockReturnValueOnce(deferredSnapshot.promise);
+
+    renderTab({
+      selectedPrId: "pr-merged",
+      selectedPrTarget: {
+        prId: null,
+        prNumber: 200,
+        repoOwner: "ade-dev",
+        repoName: "ade",
+      },
+    });
+
+    expect(screen.getByTestId("pr-detail-pane").textContent).toContain("gh:ade-dev/ade#200");
+    await act(async () => {
+      deferredSnapshot.resolve(snapshot);
+      await deferredSnapshot.promise;
+    });
+
+    await user.click(screen.getByRole("button", { name: /^merged/i }));
+    expect(screen.queryByRole("button", { name: /Show in/i })).toBeNull();
+  });
+
+  it("does not auto-select the first row after clearing an unresolved coordinate target", async () => {
+    const user = userEvent.setup();
+    const onSelectPr = vi.fn();
+    const target: PrRouteSelectionTarget = {
+      prId: null,
+      prNumber: 200,
+      repoOwner: "ade-dev",
+      repoName: "ade",
+    };
+    function Harness() {
+      const [selection, setSelection] = React.useState<{
+        id: string | null;
+        target: PrRouteSelectionTarget | null;
+      }>({ id: null, target });
+      return (
+        <MemoryRouter>
+          <GitHubTab
+            lanes={[]}
+            mergeMethod="squash"
+            selectedPrId={selection.id}
+            selectedPrTarget={selection.target}
+            onSelectPr={(id, nextTarget) => {
+              onSelectPr(id, nextTarget ?? null);
+              setSelection({ id, target: nextTarget ?? null });
+            }}
+            onRefreshAll={vi.fn().mockResolvedValue(undefined)}
+          />
+        </MemoryRouter>
+      );
+    }
+
+    render(<Harness />);
+    expect((await screen.findByTestId("pr-detail-pane")).textContent).toContain("gh:ade-dev/ade#200");
+
+    await user.click(screen.getByRole("button", { name: /^merged/i }));
+
+    await waitFor(() => expect(onSelectPr).toHaveBeenLastCalledWith(null, null));
+    expect(screen.queryByTestId("pr-detail-pane")).toBeNull();
+  });
+
+  it("widens history for an unresolved closed coordinate target without blocking its shell", async () => {
+    const deferredHistory = createDeferred<GitHubPrSnapshot>();
+    const openOnlySnapshot: GitHubPrSnapshot = {
+      ...snapshot,
+      repoPullRequests: [makeGitHubPr()],
+    };
+    vi.mocked(window.ade.prs.getGitHubSnapshot)
+      .mockResolvedValueOnce(openOnlySnapshot)
+      .mockReturnValueOnce(deferredHistory.promise);
+
+    renderTab({
+      selectedPrId: null,
+      selectedPrTarget: {
+        prId: null,
+        prNumber: 200,
+        repoOwner: "ade-dev",
+        repoName: "ade",
+      },
+    });
+
+    expect(screen.getByTestId("pr-detail-pane").textContent).toContain("gh:ade-dev/ade#200");
+    await waitFor(() => {
+      expect(window.ade.prs.getGitHubSnapshot).toHaveBeenCalledWith({
+        force: false,
+        includeExternalClosed: true,
+        historyPageLimit: 2,
+      });
+    });
+    await act(async () => {
+      deferredHistory.resolve({
+        ...snapshot,
+        repoPullRequests: [makeGitHubPr({
+          id: "repo-closed-target",
+          githubPrNumber: 200,
+          state: "merged",
+          linkedPrId: null,
+          linkedLaneId: null,
+          linkedLaneName: null,
+        })],
+      });
+      await deferredHistory.promise;
+    });
+  });
+
+  it("uses a local coordinate match when the snapshot link id is foreign", async () => {
+    const user = userEvent.setup();
+    const targetSnapshot: GitHubPrSnapshot = {
+      ...snapshot,
+      repoPullRequests: [makeGitHubPr({ linkedPrId: "foreign-machine-pr" })],
+    };
+    vi.mocked(window.ade.prs.getGitHubSnapshot).mockResolvedValue(targetSnapshot);
+    mockUsePrs.mockReturnValue(makePrsContext([{
+      id: "local-pr",
+      githubPrNumber: 101,
+      repoOwner: "ade-dev",
+      repoName: "ade",
+      state: "open",
+    }]));
+
+    renderTab({
+      selectedPrId: null,
+      selectedPrTarget: {
+        prId: "foreign-machine-pr",
+        prNumber: 101,
+        repoOwner: "ade-dev",
+        repoName: "ade",
+      },
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("pr-detail-pane").textContent).toContain("local-pr");
+      expect(screen.getByTestId("pr-detail-pane").getAttribute("data-unmapped")).toBe("false");
+    });
+    const confirm = vi.spyOn(window, "confirm").mockReturnValue(true);
+    await user.click(screen.getByRole("button", { name: "Unmap from lane" }));
+    expect(window.ade.prs.delete).toHaveBeenCalledWith({
+      prId: "local-pr",
+      closeOnGitHub: false,
+      archiveLane: false,
+    });
+    confirm.mockRestore();
+  });
+
+  it("reconciles local PR state when snapshot repository casing differs", async () => {
+    const user = userEvent.setup();
+    vi.mocked(window.ade.prs.getGitHubSnapshot).mockResolvedValue({
+      ...snapshot,
+      repoPullRequests: [makeGitHubPr({
+        repoOwner: "ADE-DEV",
+        repoName: "ADE",
+        linkedPrId: null,
+        linkedLaneId: null,
+        linkedLaneName: null,
+        title: "Cached open title",
+        state: "open",
+      })],
+      externalPullRequests: [],
+    });
+    mockUsePrs.mockReturnValue(makePrsContext([{
+      id: "local-pr",
+      githubPrNumber: 101,
+      repoOwner: "ade-dev",
+      repoName: "ade",
+      title: "Local merged title",
+      state: "merged",
+      updatedAt: "2026-03-13T12:30:00.000Z",
+    }]));
+
+    renderTab();
+    await user.click(await screen.findByRole("button", { name: /^merged/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText("Local merged title")).not.toBeNull();
+    });
+    expect(screen.queryByText("Cached open title")).toBeNull();
+    expect(screen.getByTestId("pr-detail-pane").getAttribute("data-unmapped")).toBe("false");
+  });
+
+  it("resolves a coordinate deep link when the ADE row is not local", async () => {
+    const targetSnapshot: GitHubPrSnapshot = {
+      ...snapshot,
+      repoPullRequests: [
+        makeGitHubPr({
+          id: "repo-unmapped",
+          githubPrNumber: 200,
+          title: "Unmapped target",
+          linkedPrId: null,
+          linkedLaneId: null,
+          linkedLaneName: null,
+          adeKind: null,
+        }),
+        makeGitHubPr(),
+      ],
+    };
+    vi.mocked(window.ade.prs.getGitHubSnapshot).mockResolvedValue(targetSnapshot);
+    mockUsePrs.mockReturnValue(makePrsContext([]));
+
+    renderTab({
+      selectedPrId: null,
+      selectedPrTarget: {
+        prId: "pr-from-another-machine",
+        prNumber: 200,
+        repoOwner: "ade-dev",
+        repoName: "ade",
+      },
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("pr-detail-pane").textContent).toContain("gh:ade-dev/ade#200");
+    });
+    // The unresolved explicit target must not be replaced by the first row.
+    expect(screen.getByTestId("pr-detail-pane").textContent).not.toContain("gh:ade-dev/ade#101");
+  });
+});

--- a/apps/desktop/src/renderer/components/prs/tabs/GitHubTabRowsAndMapping.test.tsx
+++ b/apps/desktop/src/renderer/components/prs/tabs/GitHubTabRowsAndMapping.test.tsx
@@ -44,6 +44,7 @@ import {
   makePreflightResult,
   snapshot,
 } from "./GitHubTab.testFixtures";
+import { buildProvisionalGithubPrItem } from "./githubTabModel";
 
 describe("GitHubTab rows and mapping", () => {
   beforeEach(() => {
@@ -53,6 +54,17 @@ describe("GitHubTab rows and mapping", () => {
   afterEach(() => {
     cleanupGitHubTabTest();
   });
+
+  it.each([0, -1, 1.5, Number.NaN, Number.POSITIVE_INFINITY])(
+    "rejects invalid provisional PR number %s",
+    (prNumber) => {
+      expect(buildProvisionalGithubPrItem({
+        prNumber,
+        repoOwner: "ade-dev",
+        repoName: "ade",
+      })).toBeNull();
+    },
+  );
 
   function renderTab(overrides: Parameters<typeof renderGitHubTab>[1] = {}) {
     return renderGitHubTab(GitHubTab, overrides);
@@ -806,7 +818,12 @@ describe("GitHubTab rows and mapping", () => {
       });
     });
     await waitFor(() => {
-      expect(onSelectPr).toHaveBeenCalledWith("pr-created");
+      expect(onSelectPr).toHaveBeenLastCalledWith("pr-created", {
+        prId: "pr-created",
+        prNumber: 200,
+        repoOwner: "ade-dev",
+        repoName: "ade",
+      });
     });
     expect(onRefreshAll).toHaveBeenCalledWith({ prId: "pr-created" });
     expect(window.ade.lanes.list).toHaveBeenCalledWith({

--- a/apps/desktop/src/renderer/components/prs/tabs/GitHubTabRowsAndMapping.test.tsx
+++ b/apps/desktop/src/renderer/components/prs/tabs/GitHubTabRowsAndMapping.test.tsx
@@ -44,7 +44,11 @@ import {
   makePreflightResult,
   snapshot,
 } from "./GitHubTab.testFixtures";
-import { buildProvisionalGithubPrItem } from "./githubTabModel";
+import {
+  buildProvisionalGithubPrItem,
+  findSelectionTargetItem,
+  itemMatchesSelectionTarget,
+} from "./githubTabModel";
 
 describe("GitHubTab rows and mapping", () => {
   beforeEach(() => {
@@ -65,6 +69,26 @@ describe("GitHubTab rows and mapping", () => {
       })).toBeNull();
     },
   );
+
+  it("does not resolve an ambiguous number-only PR route across repositories", () => {
+    const target = {
+      prId: null,
+      prNumber: 224,
+      repoOwner: null,
+      repoName: null,
+    } as const;
+    const repoItem = makeGitHubPr({ githubPrNumber: 224 });
+    const secondRepoItem = makeGitHubPr({
+      id: "repo-pr-224-other",
+      repoOwner: "other-owner",
+      repoName: "other-repo",
+      githubPrNumber: 224,
+    });
+
+    expect(itemMatchesSelectionTarget(repoItem, target)).toBe(true);
+    expect(itemMatchesSelectionTarget(secondRepoItem, target)).toBe(true);
+    expect(findSelectionTargetItem([repoItem, secondRepoItem], target)).toBeNull();
+  });
 
   function renderTab(overrides: Parameters<typeof renderGitHubTab>[1] = {}) {
     return renderGitHubTab(GitHubTab, overrides);

--- a/apps/desktop/src/renderer/components/prs/tabs/GitHubTabView.tsx
+++ b/apps/desktop/src/renderer/components/prs/tabs/GitHubTabView.tsx
@@ -32,6 +32,7 @@ import {
   type GitHubFilter,
   type GitHubFilterCounts,
 } from "./githubTabModel";
+import { prRouteCoordinatesMatch } from "../prsRouteState";
 
 const FILTER_ACCENTS: Record<GitHubFilter, string> = {
   open: "#60A5FA",
@@ -347,8 +348,10 @@ export function GitHubTabView({ chrome, list, detail }: GitHubTabViewProps) {
                   <GitHubStackInspector
                     stack={selectedStack}
                     items={detail.displayedItems.filter(
-                      (item) => item.repoOwner === selectedStack.repoOwner
-                        && item.repoName === selectedStack.repoName,
+                      (item) => prRouteCoordinatesMatch(
+                        { prNumber: item.githubPrNumber, repoOwner: item.repoOwner, repoName: item.repoName },
+                        { prNumber: null, repoOwner: selectedStack.repoOwner, repoName: selectedStack.repoName },
+                      ),
                     )}
                     selectedPrNumber={selectedItem.githubPrNumber}
                     syncing={chrome.syncing}

--- a/apps/desktop/src/renderer/components/prs/tabs/githubTabModel.ts
+++ b/apps/desktop/src/renderer/components/prs/tabs/githubTabModel.ts
@@ -235,7 +235,28 @@ export function itemMatchesSelectionTarget(
     target,
   );
   const idMatches = Boolean(target.prId && itemId === target.prId && coordinatesMatch);
-  return idMatches || (coordinatesMatch && target.prNumber != null);
+  if (idMatches) return true;
+  if (target.prId && itemId !== target.prId) return false;
+  if (target.prNumber == null) return false;
+
+  const hasRepoOwner = Boolean(target.repoOwner?.trim());
+  const hasRepoName = Boolean(target.repoName?.trim());
+  if (hasRepoOwner !== hasRepoName) return false;
+  if (hasRepoOwner && hasRepoName) return coordinatesMatch;
+  // A legacy number-only route is safe to resolve only against ADE's current
+  // repository list. External PR rows may share the same number.
+  return item.scope === "repo" && coordinatesMatch;
+}
+
+export function findSelectionTargetItem(
+  items: GitHubPrListItem[],
+  target: PrRouteSelectionTarget,
+): GitHubPrListItem | null {
+  const matches = items.filter((item) => itemMatchesSelectionTarget(item, target));
+  if (matches.length === 0) return null;
+  const hasCoordinates = Boolean(target.repoOwner?.trim() && target.repoName?.trim());
+  if (target.prId || hasCoordinates) return matches[0] ?? null;
+  return matches.length === 1 ? matches[0] : null;
 }
 
 export function selectionTargetKey(

--- a/apps/desktop/src/renderer/components/prs/tabs/githubTabModel.ts
+++ b/apps/desktop/src/renderer/components/prs/tabs/githubTabModel.ts
@@ -6,8 +6,12 @@ import type {
 } from "../../../../shared/types";
 import { syntheticGithubPrId } from "../../../../shared/types/prs";
 import { isTerminalPrState } from "../../../lib/prState";
+import {
+  prRouteCoordinatesKey,
+  prRouteCoordinatesMatch,
+  type PrRouteSelectionTarget,
+} from "../prsRouteState";
 
-export const LINKED_HYDRATION_LIMIT = 8;
 export const GITHUB_TAB_VIRTUALIZE_AT = 50;
 export const GITHUB_TAB_REVISIT_CACHE_TTL_MS = 60_000;
 export const GITHUB_TAB_SNAPSHOT_FRESH_MS = 30_000;
@@ -145,7 +149,11 @@ export function githubCoordKey(item: {
   repoName: string;
   githubPrNumber: number;
 }): string {
-  return `${item.repoOwner}/${item.repoName}#${Number(item.githubPrNumber)}`;
+  return prRouteCoordinatesKey({
+    repoOwner: item.repoOwner,
+    repoName: item.repoName,
+    prNumber: Number(item.githubPrNumber),
+  });
 }
 
 function buildOverlayRowFromLastSeen(lastSeen: GitHubPrListItem, linkedPr: PrSummary): GitHubPrListItem {
@@ -185,7 +193,7 @@ export function mergeGitHubListItems(snapshot: GitHubPrSnapshot): GitHubPrListIt
   const combined = [...snapshot.repoPullRequests, ...snapshot.externalPullRequests];
   const seen = new Set<string>();
   return combined.filter((item) => {
-    const key = `${item.scope}:${item.repoOwner}/${item.repoName}#${item.githubPrNumber}`;
+    const key = `${item.scope}:${githubCoordKey(item)}`;
     if (seen.has(key)) return false;
     seen.add(key);
     return true;
@@ -202,6 +210,90 @@ export function countGitHubItemsByState(items: GitHubPrListItem[]): GitHubFilter
 
 export function syntheticUnmappedPrId(item: GitHubPrListItem): string {
   return syntheticGithubPrId(item);
+}
+
+export function selectionTargetForItem(item: GitHubPrListItem): PrRouteSelectionTarget {
+  return {
+    prId: item.linkedPrId ?? null,
+    prNumber: item.githubPrNumber,
+    repoOwner: item.repoOwner,
+    repoName: item.repoName,
+  };
+}
+
+export function itemMatchesSelectionTarget(
+  item: GitHubPrListItem,
+  target: PrRouteSelectionTarget,
+): boolean {
+  const itemId = item.linkedPrId ?? syntheticUnmappedPrId(item);
+  const coordinatesMatch = prRouteCoordinatesMatch(
+    {
+      prNumber: item.githubPrNumber,
+      repoOwner: item.repoOwner,
+      repoName: item.repoName,
+    },
+    target,
+  );
+  const idMatches = Boolean(target.prId && itemId === target.prId && coordinatesMatch);
+  return idMatches || (coordinatesMatch && target.prNumber != null);
+}
+
+export function selectionTargetKey(
+  selectedPrId: string | null,
+  selectedPrTarget: PrRouteSelectionTarget | null | undefined,
+): string | null {
+  if (selectedPrTarget) {
+    return [
+      selectedPrTarget.prId ?? "",
+      prRouteCoordinatesKey(selectedPrTarget),
+    ].join("/");
+  }
+  return selectedPrId;
+}
+
+export function buildProvisionalGithubPrItem(target: {
+  prNumber: number | null;
+  repoOwner: string | null;
+  repoName: string | null;
+}): GitHubPrListItem | null {
+  if (
+    typeof target.prNumber !== "number"
+    || !Number.isFinite(target.prNumber)
+    || !Number.isInteger(target.prNumber)
+    || target.prNumber <= 0
+    || !target.repoOwner?.trim()
+    || !target.repoName?.trim()
+  ) return null;
+  const repoOwner = target.repoOwner.trim();
+  const repoName = target.repoName.trim();
+  const githubPrNumber = target.prNumber;
+  const item = {
+    id: "",
+    scope: "repo" as const,
+    repoOwner,
+    repoName,
+    githubPrNumber,
+    githubUrl: `https://github.com/${repoOwner}/${repoName}/pull/${githubPrNumber}`,
+    title: `Pull request #${githubPrNumber}`,
+    state: "open" as const,
+    isDraft: false,
+    baseBranch: null,
+    headBranch: null,
+    author: null,
+    createdAt: "",
+    updatedAt: "",
+    linkedPrId: null,
+    linkedGroupId: null,
+    linkedLaneId: null,
+    linkedLaneName: null,
+    adeKind: null,
+    workflowDisplayState: null,
+    cleanupState: null,
+    labels: [],
+    isBot: false,
+    commentCount: 0,
+  } satisfies GitHubPrListItem;
+  return { ...item, id: syntheticUnmappedPrId(item) };
 }
 
 export function buildSyntheticUnmappedPr(item: GitHubPrListItem, projectId: string): PrWithConflicts {

--- a/apps/desktop/src/renderer/components/prs/tabs/useGitHubTabListModel.ts
+++ b/apps/desktop/src/renderer/components/prs/tabs/useGitHubTabListModel.ts
@@ -22,6 +22,7 @@ export function useGitHubTabListModel({
   snapshot,
   searchQuery,
   prsByIdMap,
+  prsByCoordinateMap,
   filter,
   renderedHydrationItems,
   lastSeenRowByCoordRef,
@@ -30,6 +31,7 @@ export function useGitHubTabListModel({
   snapshot: GitHubPrSnapshot | null;
   searchQuery: string;
   prsByIdMap: Map<string, PrSummary>;
+  prsByCoordinateMap: Map<string, PrSummary>;
   filter: GitHubFilter;
   renderedHydrationItems: GitHubPrListItem[];
   lastSeenRowByCoordRef: React.MutableRefObject<Map<string, GitHubPrListItem>>;
@@ -51,10 +53,12 @@ export function useGitHubTabListModel({
     [snapshot],
   );
   const reconciledItems = React.useMemo(
-    () => allItems.map((item) =>
-      reconcileLinkedPrState(item, item.linkedPrId ? prsByIdMap.get(item.linkedPrId) : null)
-    ),
-    [allItems, prsByIdMap],
+    () => allItems.map((item) => {
+      const linkedPr = item.linkedPrId ? prsByIdMap.get(item.linkedPrId) : null;
+      const coordinatePr = prsByCoordinateMap.get(githubCoordKey(item));
+      return reconcileLinkedPrState(item, linkedPr ?? coordinatePr);
+    }),
+    [allItems, prsByCoordinateMap, prsByIdMap],
   );
 
   React.useEffect(() => {

--- a/apps/desktop/src/renderer/components/prs/tabs/useGitHubTabSelection.ts
+++ b/apps/desktop/src/renderer/components/prs/tabs/useGitHubTabSelection.ts
@@ -1,0 +1,186 @@
+import React from "react";
+import type { GitHubPrListItem, GitHubPrSnapshot } from "../../../../shared/types";
+import type { PrRouteSelectionTarget } from "../prsRouteState";
+import {
+  buildProvisionalGithubPrItem,
+  bucketForState,
+  itemMatchesSelectionTarget,
+  matchesFilter,
+  selectionTargetForItem,
+  selectionTargetKey,
+  type GitHubFilter,
+  type GitHubFilterSelectionMap,
+} from "./githubTabModel";
+
+type SelectPr = (id: string | null, target: PrRouteSelectionTarget | null) => void;
+type SelectionState = { key: string | null; bucket: GitHubFilter | null } | undefined;
+
+type SelectionArgs = {
+  displayedItems: GitHubPrListItem[];
+  filteredItems: GitHubPrListItem[];
+  filter: GitHubFilter;
+  onSelectPr: SelectPr;
+  selectedItemId: string | null;
+  selectedPrId: string | null;
+  selectedPrTarget: PrRouteSelectionTarget | null | undefined;
+  snapshot: GitHubPrSnapshot | null;
+  setFilter: React.Dispatch<React.SetStateAction<GitHubFilter>>;
+  setSelectedItemId: React.Dispatch<React.SetStateAction<string | null>>;
+  setSelectedItemIdsByFilter: React.Dispatch<React.SetStateAction<GitHubFilterSelectionMap>>;
+  lastHandledSelectedRef: React.MutableRefObject<SelectionState>;
+  pendingSelectedItemIdRef: React.MutableRefObject<string | null>;
+  pendingRestoredSelectedItemIdRef: React.MutableRefObject<string | null>;
+  hasInitializedSelectionRef: React.MutableRefObject<boolean>;
+};
+
+export function useGitHubTabSelection({
+  displayedItems,
+  filteredItems,
+  filter,
+  onSelectPr,
+  selectedItemId,
+  selectedPrId,
+  selectedPrTarget,
+  snapshot,
+  setFilter,
+  setSelectedItemId,
+  setSelectedItemIdsByFilter,
+  lastHandledSelectedRef,
+  pendingSelectedItemIdRef,
+  pendingRestoredSelectedItemIdRef,
+  hasInitializedSelectionRef,
+}: SelectionArgs): {
+  selectedItem: GitHubPrListItem | null;
+  selectedTargetResolved: boolean;
+} {
+  React.useEffect(() => {
+    if (!snapshot) return;
+
+    // An explicit route target is authoritative even when its ADE row has not
+    // arrived yet. Resolve by local id first, then by GitHub coordinates (and
+    // the stable synthetic id used for unmapped rows).
+    const targetItem = selectedPrTarget
+      ? displayedItems.find((item) => itemMatchesSelectionTarget(item, selectedPrTarget)) ?? null
+      : null;
+    const linkedItem = targetItem
+      ?? (selectedPrId
+        ? displayedItems.find((item) => item.linkedPrId === selectedPrId) ?? null
+        : null);
+    const currentBucket = linkedItem ? bucketForState(linkedItem.state) : null;
+    const nextSelectionKey = selectionTargetKey(selectedPrId, selectedPrTarget);
+
+    const last = lastHandledSelectedRef.current;
+    if (last && last.key === nextSelectionKey && last.bucket === currentBucket) return;
+    const isNewSelection = !last || last.key !== nextSelectionKey;
+    const bucketChanged = !isNewSelection && last!.bucket !== currentBucket;
+    lastHandledSelectedRef.current = { key: nextSelectionKey, bucket: currentBucket };
+
+    if (!linkedItem) {
+      pendingSelectedItemIdRef.current = null;
+      if (selectedPrTarget) {
+        setSelectedItemId(null);
+        setSelectedItemIdsByFilter((prev) => prev[filter] == null ? prev : { ...prev, [filter]: null });
+      }
+      return;
+    }
+
+    pendingSelectedItemIdRef.current = linkedItem.id;
+    const linkedFilter = bucketForState(linkedItem.state);
+    setSelectedItemIdsByFilter((prev) => ({ ...prev, [linkedFilter]: linkedItem.id }));
+    // Follow the selection into its bucket on a fresh selection, or when the
+    // already-selected PR transitions to a new bucket (so a merge/close does
+    // not strand the user on a now-empty list). Never on a manual filter switch.
+    if ((isNewSelection || bucketChanged) && !matchesFilter(linkedItem, filter)) {
+      setFilter(linkedFilter);
+    }
+    setSelectedItemId(linkedItem.id);
+    hasInitializedSelectionRef.current = true;
+  }, [
+    displayedItems,
+    filter,
+    hasInitializedSelectionRef,
+    lastHandledSelectedRef,
+    pendingSelectedItemIdRef,
+    selectedPrId,
+    selectedPrTarget,
+    setFilter,
+    setSelectedItemId,
+    setSelectedItemIdsByFilter,
+    snapshot,
+  ]);
+
+  React.useEffect(() => {
+    if (!snapshot) return;
+    if (pendingSelectedItemIdRef.current) {
+      if (selectedItemId === pendingSelectedItemIdRef.current) {
+        pendingSelectedItemIdRef.current = null;
+      } else {
+        return;
+      }
+    }
+
+    if (selectedItemId && filteredItems.some((item) => item.id === selectedItemId)) return;
+    // Never replace an explicit deep-link target with the first row while the
+    // snapshot is still hydrating (or when GitHub does not return that PR).
+    const hasExplicitSelection = Boolean(
+      selectedPrId
+      || selectedPrTarget?.prId
+      || selectedPrTarget?.prNumber != null,
+    );
+    if (hasExplicitSelection || hasInitializedSelectionRef.current) return;
+
+    const next = filteredItems[0] ?? null;
+    if (next) {
+      hasInitializedSelectionRef.current = true;
+      setSelectedItemId(next.id);
+      setSelectedItemIdsByFilter((prev) => ({ ...prev, [filter]: next.id }));
+      onSelectPr(next.linkedPrId ?? null, selectionTargetForItem(next));
+    }
+  }, [
+    filter,
+    filteredItems,
+    hasInitializedSelectionRef,
+    onSelectPr,
+    pendingSelectedItemIdRef,
+    selectedItemId,
+    selectedPrId,
+    selectedPrTarget,
+    setSelectedItemId,
+    setSelectedItemIdsByFilter,
+    snapshot,
+  ]);
+
+  const selectedItem = React.useMemo((): GitHubPrListItem | null => {
+    if (!selectedPrTarget && !selectedItemId) return null;
+    if (selectedPrTarget) {
+      const byTarget = displayedItems.find((candidate) => itemMatchesSelectionTarget(candidate, selectedPrTarget)) ?? null;
+      if (byTarget) return byTarget;
+      // An explicit coordinate target is authoritative; never reuse the prior
+      // row while its snapshot/detail is still resolving.
+      return selectedPrTarget.prNumber != null
+        ? buildProvisionalGithubPrItem(selectedPrTarget)
+        : null;
+    }
+    if (selectedItemId) {
+      const byId = displayedItems.find((candidate) => candidate.id === selectedItemId) ?? null;
+      if (byId) return byId;
+    }
+    if (selectedPrId) return displayedItems.find((candidate) => candidate.linkedPrId === selectedPrId) ?? null;
+    return null;
+  }, [displayedItems, selectedItemId, selectedPrId, selectedPrTarget]);
+
+  const selectedTargetResolved = !selectedPrTarget
+    || displayedItems.some((item) => itemMatchesSelectionTarget(item, selectedPrTarget));
+
+  React.useEffect(() => {
+    const pending = pendingRestoredSelectedItemIdRef.current;
+    if (!pending || !selectedItem || selectedItem.id !== pending) return;
+    // Restore selection only once the item is actually in the active filter's
+    // list — matching the original filter-scoped restore semantics.
+    if (!matchesFilter(selectedItem, filter)) return;
+    pendingRestoredSelectedItemIdRef.current = null;
+    onSelectPr(selectedItem.linkedPrId ?? null, selectionTargetForItem(selectedItem));
+  }, [filter, onSelectPr, pendingRestoredSelectedItemIdRef, selectedItem]);
+
+  return { selectedItem, selectedTargetResolved };
+}

--- a/apps/desktop/src/renderer/components/prs/tabs/useGitHubTabSelection.ts
+++ b/apps/desktop/src/renderer/components/prs/tabs/useGitHubTabSelection.ts
@@ -4,7 +4,7 @@ import type { PrRouteSelectionTarget } from "../prsRouteState";
 import {
   buildProvisionalGithubPrItem,
   bucketForState,
-  itemMatchesSelectionTarget,
+  findSelectionTargetItem,
   matchesFilter,
   selectionTargetForItem,
   selectionTargetKey,
@@ -60,7 +60,7 @@ export function useGitHubTabSelection({
     // arrived yet. Resolve by local id first, then by GitHub coordinates (and
     // the stable synthetic id used for unmapped rows).
     const targetItem = selectedPrTarget
-      ? displayedItems.find((item) => itemMatchesSelectionTarget(item, selectedPrTarget)) ?? null
+      ? findSelectionTargetItem(displayedItems, selectedPrTarget)
       : null;
     const linkedItem = targetItem
       ?? (selectedPrId
@@ -153,7 +153,7 @@ export function useGitHubTabSelection({
   const selectedItem = React.useMemo((): GitHubPrListItem | null => {
     if (!selectedPrTarget && !selectedItemId) return null;
     if (selectedPrTarget) {
-      const byTarget = displayedItems.find((candidate) => itemMatchesSelectionTarget(candidate, selectedPrTarget)) ?? null;
+      const byTarget = findSelectionTargetItem(displayedItems, selectedPrTarget);
       if (byTarget) return byTarget;
       // An explicit coordinate target is authoritative; never reuse the prior
       // row while its snapshot/detail is still resolving.
@@ -170,7 +170,7 @@ export function useGitHubTabSelection({
   }, [displayedItems, selectedItemId, selectedPrId, selectedPrTarget]);
 
   const selectedTargetResolved = !selectedPrTarget
-    || displayedItems.some((item) => itemMatchesSelectionTarget(item, selectedPrTarget));
+    || findSelectionTargetItem(displayedItems, selectedPrTarget) !== null;
 
   React.useEffect(() => {
     const pending = pendingRestoredSelectedItemIdRef.current;

--- a/apps/desktop/src/renderer/components/prs/tabs/useGitHubTargetHistory.test.tsx
+++ b/apps/desktop/src/renderer/components/prs/tabs/useGitHubTargetHistory.test.tsx
@@ -1,0 +1,92 @@
+// @vitest-environment jsdom
+
+import React from "react";
+import { act, render } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { GitHubPrSnapshot } from "../../../../shared/types";
+import type { PrRouteSelectionTarget } from "../prsRouteState";
+import { useGitHubTargetHistory } from "./useGitHubTargetHistory";
+
+const target: PrRouteSelectionTarget = {
+  prId: null,
+  prNumber: 224,
+  repoOwner: "ade-dev",
+  repoName: "ade",
+};
+
+const staleSnapshot: GitHubPrSnapshot = {
+  repo: { owner: "ade-dev", name: "ade" },
+  viewerLogin: "octocat",
+  repoPullRequests: [],
+  externalPullRequests: [],
+  syncedAt: "2026-03-13T12:00:00.000Z",
+  history: {
+    includeExternalClosed: true,
+    pageLimit: 2,
+    repoPullRequestsLoaded: 2,
+    repoPullRequestsMayHaveMore: true,
+    repoPullRequestCounts: null,
+  },
+};
+
+function Harness({
+  loadSnapshot,
+  snapshot,
+}: {
+  loadSnapshot: (options?: {
+    force?: boolean;
+    silent?: boolean;
+    includeExternalClosed?: boolean;
+    historyPageLimit?: number;
+  }) => Promise<GitHubPrSnapshot | null>;
+  snapshot: GitHubPrSnapshot;
+}) {
+  useGitHubTargetHistory({
+    displayedItems: [],
+    loadSnapshot,
+    selectedPrId: null,
+    selectedPrTarget: target,
+    snapshot,
+  });
+  return null;
+}
+
+describe("useGitHubTargetHistory", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("backs off when a forced history fetch returns the same page limit", async () => {
+    const loadSnapshot = vi.fn().mockResolvedValue(staleSnapshot);
+    render(<Harness loadSnapshot={loadSnapshot} snapshot={staleSnapshot} />);
+
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(loadSnapshot).toHaveBeenCalledTimes(1);
+    expect(loadSnapshot).toHaveBeenCalledWith(expect.objectContaining({
+      force: true,
+      includeExternalClosed: true,
+      historyPageLimit: 4,
+      silent: true,
+    }));
+
+    await act(async () => {
+      vi.advanceTimersByTime(29_999);
+      await Promise.resolve();
+    });
+    expect(loadSnapshot).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      vi.advanceTimersByTime(1);
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(loadSnapshot).toHaveBeenCalledTimes(3);
+  });
+});

--- a/apps/desktop/src/renderer/components/prs/tabs/useGitHubTargetHistory.ts
+++ b/apps/desktop/src/renderer/components/prs/tabs/useGitHubTargetHistory.ts
@@ -1,0 +1,131 @@
+import React from "react";
+import type { GitHubPrListItem, GitHubPrSnapshot } from "../../../../shared/types";
+import type { PrRouteSelectionTarget } from "../prsRouteState";
+import {
+  GITHUB_TAB_HISTORY_INITIAL_PAGE_LIMIT,
+  GITHUB_TAB_HISTORY_MAX_PAGE_LIMIT,
+  GITHUB_TAB_HISTORY_PAGE_INCREMENT,
+  itemMatchesSelectionTarget,
+  selectionTargetKey,
+} from "./githubTabModel";
+
+type LoadSnapshot = (options?: {
+  force?: boolean;
+  silent?: boolean;
+  includeExternalClosed?: boolean;
+  historyPageLimit?: number;
+}) => Promise<GitHubPrSnapshot | null>;
+
+/** Resolve explicit closed/merged routes without delaying the coordinate shell. */
+export function useGitHubTargetHistory({
+  displayedItems,
+  loadSnapshot,
+  selectedPrId,
+  selectedPrTarget,
+  snapshot,
+}: {
+  displayedItems: GitHubPrListItem[];
+  loadSnapshot: LoadSnapshot;
+  selectedPrId: string | null;
+  selectedPrTarget: PrRouteSelectionTarget | null | undefined;
+  snapshot: GitHubPrSnapshot | null;
+}): void {
+  const requestRef = React.useRef<{
+    key: string;
+    retryAt: number;
+    inFlight: boolean;
+  } | null>(null);
+  const retryTimerRef = React.useRef<number | null>(null);
+
+  React.useEffect(() => () => {
+    if (retryTimerRef.current != null) window.clearTimeout(retryTimerRef.current);
+  }, []);
+
+  React.useEffect(() => {
+    const clearRetry = () => {
+      requestRef.current = null;
+      if (retryTimerRef.current != null) {
+        window.clearTimeout(retryTimerRef.current);
+        retryTimerRef.current = null;
+      }
+    };
+    if (!snapshot || selectedPrTarget?.prNumber == null) {
+      clearRetry();
+      return;
+    }
+    if (displayedItems.some((item) => itemMatchesSelectionTarget(item, selectedPrTarget))) {
+      clearRetry();
+      return;
+    }
+
+    const history = snapshot.history;
+    const currentLimit = history?.includeExternalClosed ? history.pageLimit : 0;
+    const canWidenHistory = Boolean(
+      history?.includeExternalClosed
+      && history.repoPullRequestsMayHaveMore
+      && currentLimit < GITHUB_TAB_HISTORY_MAX_PAGE_LIMIT,
+    );
+    // `includeExternalClosed` only says which query ran. A projected or
+    // paginated snapshot can still be incomplete, so keep widening it for an
+    // explicit target until GitHub says there are no more pages (or the
+    // bounded maximum is reached).
+    if (history?.includeExternalClosed && !canWidenHistory) {
+      clearRetry();
+      return;
+    }
+
+    const targetKey = selectionTargetKey(selectedPrId, selectedPrTarget);
+    if (!targetKey) return;
+    const previousRequest = requestRef.current;
+    if (previousRequest?.key === targetKey
+      && (previousRequest.inFlight || Date.now() < previousRequest.retryAt)) return;
+    if (previousRequest?.key !== targetKey && retryTimerRef.current != null) {
+      window.clearTimeout(retryTimerRef.current);
+      retryTimerRef.current = null;
+    }
+
+    const scheduleRetry = () => {
+      if (requestRef.current?.key !== targetKey) return;
+      requestRef.current = { key: targetKey, retryAt: Date.now() + 30_000, inFlight: false };
+      retryTimerRef.current = window.setTimeout(() => {
+        retryTimerRef.current = null;
+        if (requestRef.current?.key !== targetKey) return;
+        requestRef.current = null;
+        requestHistory(GITHUB_TAB_HISTORY_INITIAL_PAGE_LIMIT);
+      }, 30_000);
+    };
+    const requestHistory = (historyPageLimit: number): void => {
+      requestRef.current = { key: targetKey, retryAt: Date.now() + 5_000, inFlight: true };
+      // Open-only snapshots are intentionally cheap, but an explicit deep link
+      // may target a merged/closed PR outside that window. Keep the provisional
+      // coordinate pane visible and widen history asynchronously rather than
+      // blocking first paint. Continue paging when the response is partial.
+      void loadSnapshot({
+        force: history?.includeExternalClosed === true
+          || historyPageLimit > GITHUB_TAB_HISTORY_INITIAL_PAGE_LIMIT,
+        includeExternalClosed: true,
+        historyPageLimit,
+        silent: true,
+      }).then((loaded) => {
+        if (requestRef.current?.key !== targetKey) return;
+        if (!loaded?.history?.includeExternalClosed) {
+          scheduleRetry();
+          return;
+        }
+        if (loaded.history.repoPullRequestsMayHaveMore
+          && loaded.history.pageLimit < GITHUB_TAB_HISTORY_MAX_PAGE_LIMIT) {
+          requestHistory(Math.min(
+            GITHUB_TAB_HISTORY_MAX_PAGE_LIMIT,
+            loaded.history.pageLimit + GITHUB_TAB_HISTORY_PAGE_INCREMENT,
+          ));
+          return;
+        }
+        clearRetry();
+      }).catch(scheduleRetry);
+    };
+
+    requestHistory(canWidenHistory
+      ? Math.min(GITHUB_TAB_HISTORY_MAX_PAGE_LIMIT, currentLimit + GITHUB_TAB_HISTORY_PAGE_INCREMENT)
+      : GITHUB_TAB_HISTORY_INITIAL_PAGE_LIMIT);
+  }, [displayedItems, loadSnapshot, selectedPrId, selectedPrTarget, snapshot]);
+}

--- a/apps/desktop/src/renderer/components/prs/tabs/useGitHubTargetHistory.ts
+++ b/apps/desktop/src/renderer/components/prs/tabs/useGitHubTargetHistory.ts
@@ -5,7 +5,7 @@ import {
   GITHUB_TAB_HISTORY_INITIAL_PAGE_LIMIT,
   GITHUB_TAB_HISTORY_MAX_PAGE_LIMIT,
   GITHUB_TAB_HISTORY_PAGE_INCREMENT,
-  itemMatchesSelectionTarget,
+  findSelectionTargetItem,
   selectionTargetKey,
 } from "./githubTabModel";
 
@@ -53,7 +53,7 @@ export function useGitHubTargetHistory({
       clearRetry();
       return;
     }
-    if (displayedItems.some((item) => itemMatchesSelectionTarget(item, selectedPrTarget))) {
+    if (findSelectionTargetItem(displayedItems, selectedPrTarget)) {
       clearRetry();
       return;
     }
@@ -109,6 +109,13 @@ export function useGitHubTargetHistory({
       }).then((loaded) => {
         if (requestRef.current?.key !== targetKey) return;
         if (!loaded?.history?.includeExternalClosed) {
+          scheduleRetry();
+          return;
+        }
+        // A failed load can resolve with the previous snapshot. If the page
+        // limit did not advance, retry on the backoff timer instead of paging
+        // the same cached response in a tight loop.
+        if (loaded.history.pageLimit < historyPageLimit) {
           scheduleRetry();
           return;
         }

--- a/apps/desktop/src/renderer/components/terminals/LanePrBadge.test.tsx
+++ b/apps/desktop/src/renderer/components/terminals/LanePrBadge.test.tsx
@@ -40,6 +40,8 @@ function tag(overrides: Partial<LaneTabPrTag> = {}): LaneTabPrTag {
     linkedPrId: "pr-1",
     githubPrNumber: 101,
     githubUrl: "https://github.com/ade/desktop/pull/101",
+    repoOwner: "ade",
+    repoName: "desktop",
     title: "Current work",
     state: "open",
     checksStatus: "passing",

--- a/apps/desktop/src/renderer/components/terminals/SessionCard.test.tsx
+++ b/apps/desktop/src/renderer/components/terminals/SessionCard.test.tsx
@@ -1340,6 +1340,8 @@ describe("SessionCard where line", () => {
     id: "pr-1",
     laneId: "lane-1",
     githubPrNumber: 959,
+    repoOwner: "ade-dev",
+    repoName: "ade",
     state: "open",
     updatedAt: "2026-07-28T10:00:00.000Z",
   } as PrSummary;
@@ -1483,7 +1485,7 @@ describe("SessionCard where line", () => {
     expect(laneIdentity.parentElement?.nextElementSibling).toBe(titleSlot);
 
     fireEvent.click(badge);
-    expect(navigateMock).toHaveBeenCalledWith("/prs?tab=normal&prId=pr-1");
+    expect(navigateMock).toHaveBeenCalledWith("/prs?tab=normal&prId=pr-1&pr=959&repoOwner=ade-dev&repoName=ade");
     // The chip is nested inside the row's own click target, so it must not also
     // select the session.
     expect(onSelect).not.toHaveBeenCalled();

--- a/apps/desktop/src/renderer/components/terminals/useLanePrs.ts
+++ b/apps/desktop/src/renderer/components/terminals/useLanePrs.ts
@@ -7,6 +7,21 @@ import {
   selectGithubLanePrTags,
   selectLanePrs,
 } from "../lanes/lanePageModel";
+import { prRouteCoordinatesKey } from "../prs/prsRouteState";
+
+type LanePrCoordinateInput = {
+  repoOwner: string;
+  repoName: string;
+  githubPrNumber: number;
+};
+
+function lanePrCoordinateKey(pr: LanePrCoordinateInput): string {
+  return prRouteCoordinatesKey({
+    prNumber: pr.githubPrNumber,
+    repoOwner: pr.repoOwner,
+    repoName: pr.repoName,
+  });
+}
 
 function githubItemToLanePr(item: GitHubPrListItem, laneId: string): PrSummary {
   return {
@@ -75,19 +90,15 @@ export function buildLanePrsByLaneId(args: {
       .map((pr) => ({
         ...pr,
         stack: githubPrs.find((githubPr) => (
-          githubPr.githubPrNumber === pr.githubPrNumber
-          && githubPr.repoOwner.toLowerCase() === pr.repoOwner.toLowerCase()
-          && githubPr.repoName.toLowerCase() === pr.repoName.toLowerCase()
+          lanePrCoordinateKey(githubPr) === lanePrCoordinateKey(pr)
         ))?.stack
           ?? pr.stack
           ?? null,
       }));
     const mappedIds = new Set(mapped.map((pr) => pr.id));
-    const mappedRepoPrKeys = new Set(mapped.map((pr) => (
-      `${pr.repoOwner.toLowerCase()}/${pr.repoName.toLowerCase()}#${pr.githubPrNumber}`
-    )));
+    const mappedRepoPrKeys = new Set(mapped.map(lanePrCoordinateKey));
     const unmappedGithubPrs = githubPrs.filter((githubPr) => {
-      const repoPrKey = `${githubPr.repoOwner.toLowerCase()}/${githubPr.repoName.toLowerCase()}#${githubPr.githubPrNumber}`;
+      const repoPrKey = lanePrCoordinateKey(githubPr);
       return !mappedIds.has(githubPr.linkedPrId ?? "") && !mappedRepoPrKeys.has(repoPrKey);
     });
     const combined = [

--- a/apps/desktop/src/renderer/lib/lanePrBadge.test.ts
+++ b/apps/desktop/src/renderer/lib/lanePrBadge.test.ts
@@ -145,6 +145,9 @@ describe("lane PR attention", () => {
 describe("openLanePr", () => {
   const foreignPr = {
     id: "pr-on-other-machine",
+    repoOwner: "arul28",
+    repoName: "ADE",
+    githubPrNumber: 91,
     githubUrl: "https://github.com/arul28/ADE/pull/91",
   } as unknown as Parameters<typeof openLanePr>[0];
 
@@ -160,7 +163,9 @@ describe("openLanePr", () => {
     openLanePr(foreignPr, { foreign: false, navigate });
 
     expect(navigate).toHaveBeenCalledTimes(1);
-    expect(navigate).toHaveBeenCalledWith("/prs?tab=normal&prId=pr-on-other-machine");
+    expect(navigate).toHaveBeenCalledWith(
+      "/prs?tab=normal&prId=pr-on-other-machine&pr=91&repoOwner=arul28&repoName=ADE",
+    );
     expect(window.ade.app.openExternal).not.toHaveBeenCalled();
   });
 

--- a/apps/desktop/src/renderer/lib/lanePrBadge.ts
+++ b/apps/desktop/src/renderer/lib/lanePrBadge.ts
@@ -1,5 +1,6 @@
 import type { LaneSummary, PrState, PrSummary } from "../../shared/types";
 import { selectLanePrs } from "../components/lanes/lanePageModel";
+import { buildPrsRouteSearch } from "../components/prs/prsRouteState";
 import { COLORS } from "../components/lanes/laneDesignTokens";
 
 /**
@@ -163,7 +164,14 @@ export function lanePrStateColor(state: PrState): string {
 
 /** Deep link the PR chip opens, identical from every host so the target cannot drift. */
 export function lanePrDeepLinkPath(pr: PrSummary): string {
-  return `/prs?tab=normal&prId=${encodeURIComponent(pr.id)}`;
+  return `/prs${buildPrsRouteSearch({
+    activeTab: "normal",
+    selectedPrId: pr.id,
+    selectedPrNumber: pr.githubPrNumber,
+    repoOwner: pr.repoOwner,
+    repoName: pr.repoName,
+    selectedRebaseItemId: null,
+  })}`;
 }
 
 /**


### PR DESCRIPTION


<!-- ade:link v=1 type=pr repo=arul28/ADE branch=ade%2Fprs-faster-redirects-c39bb86f num=1053 -->
<p>
  <img src="https://ade-app.dev/logo.png" height="18" align="left" alt="ADE">
  &nbsp;&nbsp;<strong>Open in ADE</strong>
  &nbsp;·&nbsp; <a href="https://ade-app.dev/open?type=branch&amp;repo=arul28%2FADE&amp;branch=ade%2Fprs-faster-redirects-c39bb86f&amp;pr=1053">ade/prs-faster-redirects-c39bb86f branch</a>
  &nbsp;·&nbsp; <a href="https://ade-app.dev/open?type=pr&amp;repo=arul28%2FADE&amp;number=1053">PR #1053</a>
</p>
<!-- /ade:link -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * PR links now retain repository and pull request details across lanes, chats, toasts, timeline events, and direct URLs.
  * GitHub pull requests can be opened and resolved by repository coordinates, even while data is loading or when not locally mapped.
  * Unavailable PRs remain visible in a provisional state while details load.
* **Bug Fixes**
  * Improved deep-link handling, selection persistence, repository matching, and closed PR history loading.
  * Reduced unnecessary refreshes while preserving existing data when refreshes fail.
* **Tests**
  * Expanded coverage for coordinate-based navigation, loading states, refresh retries, and selection behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->