### PR TITLE
Tell a paired phone when its saved key is unreadable

### DIFF
--- a/apps/ios/ADE.xcodeproj/project.pbxproj
+++ b/apps/ios/ADE.xcodeproj/project.pbxproj
@@ -75,6 +75,7 @@
 		28CFE3D489EA1B208D231519 /* SyncService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 66B5024B0A05F3D9754101F1 /* SyncService.swift */; };
 		B70000000000000000000002 /* SyncRecoveryPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = B70000000000000000000001 /* SyncRecoveryPolicy.swift */; };
 		B70000000000000000000004 /* SyncRecoveryPolicyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B70000000000000000000003 /* SyncRecoveryPolicyTests.swift */; };
+		B7000000000000000000002F /* PairedHostCredentialStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7000000000000000000001F /* PairedHostCredentialStateTests.swift */; };
 		B70000000000000000000099 /* SyncAccountConnectRecoveryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B70000000000000000000098 /* SyncAccountConnectRecoveryTests.swift */; };
 		B90000000000000000000002 /* SyncTransportSelectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B90000000000000000000001 /* SyncTransportSelectionTests.swift */; };
 		B80000000000000000000002 /* SyncConnectionRace.swift in Sources */ = {isa = PBXBuildFile; fileRef = B80000000000000000000001 /* SyncConnectionRace.swift */; };
@@ -271,6 +272,7 @@
 		F2A1C9D8456E7B3C1D2E4F90 /* FilesCodeSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6F9B21C0E4A6D8F1B3C5A77 /* FilesCodeSupport.swift */; };
 		FBEEF09EFB4911FEAC6A7E87 /* RemoteModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 483C5F1818BAE74B19B84617 /* RemoteModels.swift */; };
 		C5B000000000000000000001 /* MobileTrustResetPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5A000000000000000000001 /* MobileTrustResetPolicy.swift */; };
+		C5B00000000000000000001F /* PairedHostCredentialState.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5A00000000000000000001F /* PairedHostCredentialState.swift */; };
 		C5B000000000000000000002 /* SSHBootstrapModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5A000000000000000000002 /* SSHBootstrapModels.swift */; };
 		C5B000000000000000000003 /* SSHPrivateKeyParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5A000000000000000000003 /* SSHPrivateKeyParser.swift */; };
 		C5B000000000000000000004 /* SSHGeneratedKey.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5A000000000000000000004 /* SSHGeneratedKey.swift */; };
@@ -477,6 +479,7 @@
 		66B5024B0A05F3D9754101F1 /* SyncService.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SyncService.swift; path = ADE/Services/SyncService.swift; sourceTree = "<group>"; };
 		B70000000000000000000001 /* SyncRecoveryPolicy.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SyncRecoveryPolicy.swift; path = ADE/Services/SyncRecoveryPolicy.swift; sourceTree = "<group>"; };
 		B70000000000000000000003 /* SyncRecoveryPolicyTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SyncRecoveryPolicyTests.swift; path = ADETests/SyncRecoveryPolicyTests.swift; sourceTree = "<group>"; };
+		B7000000000000000000001F /* PairedHostCredentialStateTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PairedHostCredentialStateTests.swift; path = ADETests/PairedHostCredentialStateTests.swift; sourceTree = "<group>"; };
 		B70000000000000000000098 /* SyncAccountConnectRecoveryTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SyncAccountConnectRecoveryTests.swift; path = ADETests/SyncAccountConnectRecoveryTests.swift; sourceTree = "<group>"; };
 		B90000000000000000000001 /* SyncTransportSelectionTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SyncTransportSelectionTests.swift; path = ADETests/SyncTransportSelectionTests.swift; sourceTree = "<group>"; };
 		B80000000000000000000001 /* SyncConnectionRace.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SyncConnectionRace.swift; path = ADE/Services/SyncConnectionRace.swift; sourceTree = "<group>"; };
@@ -568,6 +571,7 @@
 		D6F9B21C0E4A6D8F1B3C5A77 /* FilesCodeSupport.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = FilesCodeSupport.swift; path = ADE/Views/Components/FilesCodeSupport.swift; sourceTree = "<group>"; };
 		E3A5721EB84321D201716BC3 /* ADETests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ADETests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		C5A000000000000000000001 /* MobileTrustResetPolicy.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = MobileTrustResetPolicy.swift; path = ADE/Services/MobileTrustResetPolicy.swift; sourceTree = "<group>"; };
+		C5A00000000000000000001F /* PairedHostCredentialState.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PairedHostCredentialState.swift; path = ADE/Services/PairedHostCredentialState.swift; sourceTree = "<group>"; };
 		C5A000000000000000000002 /* SSHBootstrapModels.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SSHBootstrapModels.swift; path = ADE/Services/SSHBootstrapModels.swift; sourceTree = "<group>"; };
 		C5A000000000000000000003 /* SSHPrivateKeyParser.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SSHPrivateKeyParser.swift; path = ADE/Services/SSHPrivateKeyParser.swift; sourceTree = "<group>"; };
 		C5A000000000000000000004 /* SSHGeneratedKey.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SSHGeneratedKey.swift; path = ADE/Services/SSHGeneratedKey.swift; sourceTree = "<group>"; };
@@ -928,6 +932,7 @@
 				AD0000000000000000000A05 /* AccountEmailAuthFlow.swift */,
 				AD0000000000000000000A02 /* AccountDirectory.swift */,
 				C5A000000000000000000001 /* MobileTrustResetPolicy.swift */,
+				C5A00000000000000000001F /* PairedHostCredentialState.swift */,
 				C5A000000000000000000002 /* SSHBootstrapModels.swift */,
 				C5A000000000000000000003 /* SSHPrivateKeyParser.swift */,
 				C5A000000000000000000004 /* SSHGeneratedKey.swift */,
@@ -1088,6 +1093,7 @@
 				14C0DF7FEB4C2EB854BAC888 /* ADETests.swift */,
 				AD0000000000000000000A06 /* AccountEmailAuthFlowTests.swift */,
 				B70000000000000000000003 /* SyncRecoveryPolicyTests.swift */,
+				B7000000000000000000001F /* PairedHostCredentialStateTests.swift */,
 				B70000000000000000000098 /* SyncAccountConnectRecoveryTests.swift */,
 				B90000000000000000000001 /* SyncTransportSelectionTests.swift */,
 				AF00000000000000000000A4 /* PairingAndDpopTests.swift */,
@@ -1411,6 +1417,7 @@
 				0375D32BA5870617FA1758C6 /* KeychainService.swift in Sources */,
 				28CFE3D489EA1B208D231519 /* SyncService.swift in Sources */,
 				C5B000000000000000000001 /* MobileTrustResetPolicy.swift in Sources */,
+				C5B00000000000000000001F /* PairedHostCredentialState.swift in Sources */,
 				C5B000000000000000000002 /* SSHBootstrapModels.swift in Sources */,
 				C5B000000000000000000003 /* SSHPrivateKeyParser.swift in Sources */,
 				C5B000000000000000000004 /* SSHGeneratedKey.swift in Sources */,
@@ -1600,6 +1607,7 @@
 				7B70BE6839672E5D2D006B28 /* ADETests.swift in Sources */,
 				AD0000000000000000000B06 /* AccountEmailAuthFlowTests.swift in Sources */,
 				B70000000000000000000004 /* SyncRecoveryPolicyTests.swift in Sources */,
+				B7000000000000000000002F /* PairedHostCredentialStateTests.swift in Sources */,
 				B70000000000000000000099 /* SyncAccountConnectRecoveryTests.swift in Sources */,
 				B90000000000000000000002 /* SyncTransportSelectionTests.swift in Sources */,
 				AF00000000000000000000C4 /* PairingAndDpopTests.swift in Sources */,

--- a/apps/ios/ADE/App/ContentView.swift
+++ b/apps/ios/ADE/App/ContentView.swift
@@ -145,6 +145,7 @@ struct ContentView: View {
         accountLoading: accountService.phase == .loading,
         accountSignedIn: accountService.isSignedIn,
         hasPairedHost: syncService.hasPairedHost,
+        credentialUnreadable: syncService.pairedHostCredentialState == .credentialUnreadable,
         onContinue: {
           mobileLaunchAccess.grantAccess()
           if syncService.hasPairedHost, syncService.connectionState.isHostUnreachable {

--- a/apps/ios/ADE/Services/PairedHostCredentialState.swift
+++ b/apps/ios/ADE/Services/PairedHostCredentialState.swift
@@ -1,0 +1,40 @@
+import Foundation
+
+/// Why a saved pairing is or is not usable right now.
+///
+/// `hasPairedHost` used to answer this as one boolean, which made "this phone
+/// has never been paired" and "this phone is paired but cannot read its
+/// credential" indistinguishable. They need different words: the first is an
+/// instruction, the second is a fault, and showing the first when the second is
+/// true tells the user to do something they have already done.
+enum PairedHostCredentialState: Equatable {
+  /// No saved pairing at all. Pairing is the next step.
+  case notPaired
+  /// Saved pairing with a readable credential — the phone can connect.
+  case ready
+  /// A pairing was saved, but its credential cannot be read back. The Keychain
+  /// entry is missing, was cleared out from under the app, or the read failed
+  /// (`errSecMissingEntitlement`, a locked or reset Keychain). The pairing
+  /// cannot be used and must be redone.
+  case credentialUnreadable
+
+  /// Whether the phone can act on the saved pairing. This is the exact
+  /// predicate `hasPairedHost` has always answered.
+  var isUsable: Bool { self == .ready }
+}
+
+/// Classifies a saved pairing, given a credential lookup.
+///
+/// Pure and lookup-injected so the unreadable-credential branch can be tested
+/// directly. That branch is otherwise only reachable with a real Keychain
+/// fault, which is exactly the case that has shipped broken before.
+func syncPairedHostCredentialState(
+  profile: HostConnectionProfile?,
+  authKind: String? = nil,
+  credentialLookup: (HostConnectionProfile) -> String?
+) -> PairedHostCredentialState {
+  guard let profile else { return .notPaired }
+  let kind = authKind ?? profile.authKind
+  guard kind == "paired" else { return .notPaired }
+  return credentialLookup(profile) == nil ? .credentialUnreadable : .ready
+}

--- a/apps/ios/ADE/Services/SyncService.swift
+++ b/apps/ios/ADE/Services/SyncService.swift
@@ -18671,11 +18671,17 @@ final class SyncService: ObservableObject {
 
   /// True when this device is paired to a machine (active or last-saved
   /// profile). Push registration only runs while paired.
-  var hasPairedHost: Bool {
-    guard let profile = activeHostProfile ?? loadProfile(), profile.authKind == "paired" else {
-      return false
+  /// Whether a saved pairing exists and, separately, whether its credential can
+  /// still be read. A pairing whose credential is gone is not the same thing as
+  /// no pairing, and the difference is what the user is told.
+  var pairedHostCredentialState: PairedHostCredentialState {
+    syncPairedHostCredentialState(profile: activeHostProfile ?? loadProfile()) { profile in
+      tokenForProfile(profile)
     }
-    return tokenForProfile(profile) != nil
+  }
+
+  var hasPairedHost: Bool {
+    pairedHostCredentialState.isUsable
   }
 
   var pairingDeviceId: String { deviceId }

--- a/apps/ios/ADE/Views/Account/MobileAccessGateView.swift
+++ b/apps/ios/ADE/Views/Account/MobileAccessGateView.swift
@@ -5,6 +5,10 @@ struct MobileAccessGateView: View {
   let accountLoading: Bool
   let accountSignedIn: Bool
   let hasPairedHost: Bool
+  /// A saved pairing exists but its credential cannot be read back. Distinct
+  /// from "not paired": the user has already done the pairing step, so telling
+  /// them to do it again without saying why reads as the app ignoring them.
+  var credentialUnreadable: Bool = false
   let onContinue: () -> Void
 
   @EnvironmentObject private var syncService: SyncService
@@ -79,14 +83,31 @@ struct MobileAccessGateView: View {
                   presentedSheet = .pairMachine
                 }
               } label: {
-                Text("Continue without an account")
+                Text(credentialUnreadable ? "Pair again" : "Continue without an account")
                   .font(.subheadline.weight(.semibold))
-                  .foregroundStyle(ADEColor.textSecondary)
+                  .foregroundStyle(credentialUnreadable ? ADEColor.accent : ADEColor.textSecondary)
                   .frame(minHeight: 44)
                   .frame(maxWidth: .infinity)
                   .contentShape(Rectangle())
               }
               .buttonStyle(.plain)
+
+              // A pairing whose credential cannot be read is a fault, not a
+              // missing step. Without this the button re-presents the same
+              // connect sheet the user already completed, with nothing to
+              // explain why it did not take.
+              if credentialUnreadable {
+                Text(
+                  """
+                  This iPhone is paired with a computer, but the saved key for it \
+                  can no longer be read. Pair again to restore the connection.
+                  """
+                )
+                .font(.footnote)
+                .foregroundStyle(ADEColor.textMuted)
+                .multilineTextAlignment(.center)
+                .fixedSize(horizontal: false, vertical: true)
+              }
 
               if syncService.connectionState == .connecting,
                  let stage = syncService.accountConnectStageLabel {

--- a/apps/ios/ADETests/PairedHostCredentialStateTests.swift
+++ b/apps/ios/ADETests/PairedHostCredentialStateTests.swift
@@ -1,0 +1,73 @@
+import XCTest
+@testable import ADE
+
+/// A saved pairing whose credential cannot be read is a fault, not an
+/// instruction to pair. Conflating the two is what made a real Keychain failure
+/// present as "you have never paired" and silently re-open the connect sheet the
+/// user had already completed.
+final class PairedHostCredentialStateTests: XCTestCase {
+  private func pairedProfile(authKind: String = "paired") -> HostConnectionProfile {
+    HostConnectionProfile(
+      hostIdentity: "machine-identity",
+      hostName: "Arul's Mac Studio",
+      siteId: nil,
+      port: 8787,
+      authKind: authKind,
+      pairedDeviceId: "device-1",
+      lastRemoteDbVersion: 0,
+      lastHostDeviceId: "machine-identity",
+      lastSuccessfulAddress: "192.168.1.20",
+      savedAddressCandidates: ["192.168.1.20"],
+      discoveredLanAddresses: ["192.168.1.20"],
+      tailscaleAddress: nil,
+      savedRelayCandidates: nil
+    )
+  }
+
+  func testNoProfileIsNotPaired() {
+    XCTAssertEqual(
+      syncPairedHostCredentialState(profile: nil) { _ in "secret" },
+      .notPaired
+    )
+  }
+
+  func testReadableCredentialIsReadyAndUsable() {
+    let state = syncPairedHostCredentialState(profile: pairedProfile()) { _ in "secret" }
+    XCTAssertEqual(state, .ready)
+    XCTAssertTrue(state.isUsable)
+  }
+
+  /// The shipped failure: a persisted paired profile whose Keychain read fails.
+  /// On a real device this is a cleared or unreadable entry; the symptom that
+  /// exposed it was `errSecMissingEntitlement` (-34018), where every
+  /// `SecItemCopyMatching` returns nothing while the profile persists intact.
+  func testPersistedProfileWithFailingKeychainReadIsUnreadableNotUnpaired() {
+    var lookups = 0
+    let state = syncPairedHostCredentialState(profile: pairedProfile()) { _ in
+      lookups += 1
+      return nil  // stands in for the -34018 read failure
+    }
+
+    XCTAssertEqual(lookups, 1, "the credential must actually be consulted")
+    XCTAssertEqual(
+      state, .credentialUnreadable,
+      "a persisted pairing with an unreadable credential must not report as never-paired"
+    )
+    XCTAssertNotEqual(state, .notPaired)
+    XCTAssertFalse(state.isUsable, "an unusable credential must still gate entry")
+  }
+
+  /// `hasPairedHost` is defined as `isUsable`, so both failure modes keep
+  /// gating exactly as before — only the words the user sees change.
+  func testBothFailureModesRemainUnusable() {
+    let unreadable = syncPairedHostCredentialState(profile: pairedProfile()) { _ in nil }
+    let unpaired = syncPairedHostCredentialState(profile: nil) { _ in "secret" }
+    XCTAssertFalse(unreadable.isUsable)
+    XCTAssertFalse(unpaired.isUsable)
+  }
+
+  func testAccountAuthKindIsNotTreatedAsAPairing() {
+    let state = syncPairedHostCredentialState(profile: pairedProfile(authKind: "account")) { _ in nil }
+    XCTAssertEqual(state, .notPaired, "only a paired profile can have an unreadable pairing credential")
+  }
+}


### PR DESCRIPTION
A paired iPhone whose saved key cannot be read reported as **never paired**, so the accountless gate re-presented the same connect sheet the user had just completed — with nothing said about why.

## The bug

`hasPairedHost` answered two different questions with one boolean:

```swift
guard let profile = activeHostProfile ?? loadProfile(), profile.authKind == "paired" else { return false }
return tokenForProfile(profile) != nil   // ← a Keychain fault is indistinguishable from "no pairing"
```

`MobileAccessGateView` then does `if hasPairedHost { onContinue() } else { presentedSheet = .pairMachine }`. A user whose Keychain entry is missing, cleared, or unreadable pairs successfully, watches the sheet confirm the machine, taps continue — and gets the pairing sheet again. Forever. They have already done the thing it is asking for, so it reads as the app ignoring them.

This is the same user-facing class as the `token_unreadable` work in #1019. The accountless gate simply never got that treatment.

## The fix

`syncPairedHostCredentialState` separates the two states:

| state | meaning | what the user is told |
|---|---|---|
| `notPaired` | no saved pairing | "Continue without an account" → pair |
| `ready` | pairing + readable credential | continue into the app |
| `credentialUnreadable` | pairing saved, credential unreadable | **named as a fault**, with "Pair again" |

`hasPairedHost` is now defined as `pairedHostCredentialState.isUsable`, so **every existing gate keeps its exact behaviour** — an unusable credential still blocks entry, because without the secret the phone genuinely cannot use that pairing. Only the words change. "Pair again" is the existing repair vocabulary on this platform (`laneOfflineAction`), not a new affordance.

## Test

The classifier is pure and takes the credential lookup as a parameter, because the branch that matters is only reachable with a real Keychain fault. The test drives it with a persisted paired profile and a lookup returning nil — standing in for the `errSecMissingEntitlement` (-34018) read failure — and asserts the state is `credentialUnreadable`, is **not** `notPaired`, and still gates entry.

## How this was found

Diagnosing why a simulator build could pair over LAN and forget on relaunch. Evidence gathered:

- The pairing **record persists correctly** — `ade.sync.hostProfile` and `hostProfiles` are written on pair and survive relaunch (dumped from the app container before and after).
- Every keychain call from the process fails with `-34018 "Client has neither application-identifier nor keychain-access-groups entitlements"`.
- `codesign -d --entitlements :-` returns an empty dict for every local build variant, because iOS Simulator builds here carry no entitlements.
- That simulator's keychain already holds 6 items under access group `VQ372F39G6.com.ade.ios` from an earlier properly-entitled build — same code path, works when entitled.

So the thing that blocked local verification was **an unentitled build, not a product defect**, and real devices are unaffected by that symptom. But it surfaced this gate, which is real: a device whose Keychain entry goes bad gets the unexplained loop. That is what this PR fixes.

`MobileTrustResetPolicy` is not implicated — its flag stays unset precisely because `clearAllConnectionTokens()` returns false on the entitlement error, and it returns before its delete loop, so it deletes nothing.

## Verification

1306 tests, 13 failing cases — byte-identical to the clean-`main` baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR separates an absent pairing from a saved pairing whose credential cannot be read, while preserving the existing access gate for unusable credentials.
- Adds a three-state paired-host credential classifier and derives `hasPairedHost` from its usability.
- Shows an explicit credential-fault explanation and “Pair again” action in the accountless access gate.
- Adds unit coverage for absent, readable, unreadable, and non-paired profile states.
- Registers the new implementation and test files with the iOS project.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/ios/ADE/Services/PairedHostCredentialState.swift | Introduces the pure three-state classifier and retains `.ready` as the sole usable state. |
| apps/ios/ADE/Services/SyncService.swift | Exposes the detailed credential state and preserves the previous boolean gating semantics through `isUsable`. |
| apps/ios/ADE/Views/Account/MobileAccessGateView.swift | Distinguishes an unreadable saved credential from first-time pairing in the gate’s messaging and repair action. |
| apps/ios/ADE/App/ContentView.swift | Supplies the detailed credential-fault state to the mobile access gate. |
| apps/ios/ADETests/PairedHostCredentialStateTests.swift | Covers classifier behavior for missing profiles, readable credentials, failed lookups, and non-pairing authentication. |
| apps/ios/ADE.xcodeproj/project.pbxproj | Adds the classifier and its tests to their corresponding Xcode targets. |

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[Load active or saved host profile] --> B{Paired profile exists?}
  B -- No --> C[notPaired]
  B -- Yes --> D{Credential lookup succeeds?}
  D -- Yes --> E[ready]
  D -- No --> F[credentialUnreadable]
  C --> G[Offer initial pairing]
  E --> H[Continue into app]
  F --> I[Explain saved-key fault]
  I --> J[Offer Pair again]
```

<sub>Reviews (3): Last reviewed commit: ["fix(ios): tell a paired phone its saved ..."](https://github.com/arul28/ade/commit/d56fc639e5b51e38817487e4ccf6d1fd805f62a2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51719652)</sub>

<!-- /greptile_comment -->