### PR TITLE
Make the credential-store keychain trapdoor impossible

### DIFF
--- a/apps/ade-cli/README.md
+++ b/apps/ade-cli/README.md
@@ -201,10 +201,17 @@ Prefer `ade brain start`, `ade brain stop`, `ade brain status`, and `ade brain r
 ```bash
 ade brain status --text            # endpoint state, service state, sync state
 ade brain restart                  # refresh the login service after an update
+ade brain repair-credentials       # fix a credential store the brain cannot read
 ade brain pin generate             # generate a phone pairing PIN
 ade brain pin set 123456
 ade brain pin clear
 ```
+
+`ade brain repair-credentials` runs entirely locally and never contacts the
+brain — the state it repairs is the one that keeps the brain from starting, so a
+repair that needed a running brain would be unavailable exactly when it matters.
+`ade doctor` reports the same credential-store state from disk for the same
+reason.
 
 Older `ade runtime ...` and `ade sync pin ...` command aliases remain available for scripts, but docs and examples use the brain vocabulary.
 

--- a/apps/ade-cli/README.md
+++ b/apps/ade-cli/README.md
@@ -745,10 +745,13 @@ status row (`ok` / `warn` / `fail`) per check. It exits non-zero when any row is
 - **Publish health** — account-directory publish state from the brain's sync route health. `ok` when a publish succeeded recently, `fail` when it has been failing for ≥2 min, otherwise `warn`, with the slowest publish leg annotated.
 - **Relay** — relay route health as already computed by the brain. `ok` when the relay control is connected, the bridge is validated, and the end-to-end round-trip is verified; `fail` when the route is not fully validated; `warn` when relay is disabled or route health is unavailable. When another ADE process on this machine has claimed the relay slot, the brain deliberately stops redialing and this row reports that suppression ahead of any lower-level close error, so the detail names the fix (quit the rival process) instead of the symptom. `ade sync status --text` shows the same reason on its `relay` line, plus a `relay failing since` row for how long the current outage has run.
 - **Account** — whether this machine's brain is signed in to an ADE account (and the credential source), read via the brain's `account.call status`. `warn` when signed out or unavailable.
+- **Credentials** — whether the shared credential store (`$ADE_HOME/secrets/credentials.json.enc`) can be read, and whether an unreadable one was set aside earlier. `fail` when it cannot be read, naming the next step: a store sealed with a key this process cannot obtain is unlocked by opening the ADE app on this computer, while anything else needs a fresh sign-in. `warn` when a quarantined file is still waiting to be restored. Unlike every other row, this one is read **straight from disk** rather than through the brain — the failure it exists for is a brain that cannot start, so a check that needed a running brain would be silent exactly when it matters. It is non-creating: it never mints a machine key or OS key material, so running the diagnostic cannot change the state it reports. `ade brain repair-credentials` acts on the same reading.
 
-Default doctor does not call provider, GitHub, or Linear networks — it talks only
-to the local brain over its socket, and never prints secret values. The one
-optional network touch is the `--online` desktop-release lookup above.
+Default doctor does not call provider, GitHub, or Linear networks. Every row but
+**Credentials** comes from the local brain over its socket; **Credentials** is a
+read-only inspection of the machine's own secrets directory. It never prints
+secret values. The one optional network touch is the `--online` desktop-release
+lookup above.
 
 Agents starting an unfamiliar ADE session should begin with:
 

--- a/apps/ade-cli/src/cli.test.ts
+++ b/apps/ade-cli/src/cli.test.ts
@@ -14,6 +14,7 @@ import {
   buildCliPlan,
   checkLinearReadiness,
   detectAccountLoginMode,
+  describeLastFailureForStartupLog,
   detectUnmergedLaneCreateNudge,
   findProjectRoots,
   formatOutput,
@@ -11169,5 +11170,30 @@ describe("ADE CLI", () => {
     expect((summarized as any).visual).toContain(
       "\\- child (id: child) [feature]",
     );
+  });
+});
+
+describe("describeLastFailureForStartupLog", () => {
+  it("names the real cause instead of the 'unknown' bucket", () => {
+    // The credential-store decrypt failure that took a user's machine down for
+    // an evening classified as `unknown`, so the only line launchd printed was
+    // "after repeated failures: unknown".
+    expect(describeLastFailureForStartupLog({
+      code: "unknown",
+      detail: "Error: Unsupported state or unable to authenticate data\n    at Decipheriv.final",
+    })).toBe("unknown · Error: Unsupported state or unable to authenticate data");
+  });
+
+  it("falls back to the code alone when nothing was recorded", () => {
+    expect(describeLastFailureForStartupLog({ code: "disk_full" })).toBe("disk_full");
+  });
+
+  it("bounds a long detail so one startup line cannot flood the log", () => {
+    const described = describeLastFailureForStartupLog(
+      { code: "db_integrity", detail: "x".repeat(500) },
+      40,
+    );
+    expect(described.length).toBeLessThanOrEqual("db_integrity · ".length + 40);
+    expect(described.endsWith("…")).toBe(true);
   });
 });

--- a/apps/ade-cli/src/cli.ts
+++ b/apps/ade-cli/src/cli.ts
@@ -142,7 +142,10 @@ import {
 import { snoozeWakeLabel } from "../../desktop/src/renderer/lib/sessionSnooze";
 import type { AdeRuntime } from "./bootstrap";
 import { cleanupLegacyBundledAdeSkillsForCli } from "./bootstrap";
-import { EncryptedFileCredentialStore } from "./services/credentials/credentialStore";
+import {
+  EncryptedFileCredentialStore,
+  inspectCredentialStoreHealth,
+} from "./services/credentials/credentialStore";
 import type { AccountMachinePublisherService } from "./services/account/accountMachinePublisherService";
 import {
   ACCOUNT_PAIRING_AUTHENTICATION_REQUIRED_CODE,
@@ -16455,6 +16458,57 @@ export function includeHostProjectInCatalog<T extends { projectId: string }>(
   return [...recentProjects, hostProject];
 }
 
+/**
+ * One line of honest cause for the crash-loop backoff notice.
+ *
+ * `code` is a coarse bucket and is `unknown` whenever the classifier has no
+ * pattern for the error — the credential-store decrypt failure that took a
+ * user's machine down for an evening logged exactly that. The recorded detail
+ * is the error's own message, so prefer it and keep the bucket alongside.
+ */
+export function describeLastFailureForStartupLog(
+  report: { code: string; detail?: string; message?: string },
+  maxLength = 200,
+): string {
+  const detail = (report.detail ?? report.message ?? "").split("\n")[0]?.trim() ?? "";
+  const bounded = detail.length > maxLength ? `${detail.slice(0, maxLength - 1)}…` : detail;
+  return bounded ? `${report.code} · ${bounded}` : report.code;
+}
+
+/**
+ * Says, once per brain start, whether this process can read the shared
+ * credential store — and if not, why, in `launchd.err.log` where the person
+ * debugging a dead brain is already looking.
+ *
+ * Purely diagnostic: the store itself no longer fails a startup over an
+ * unreadable file, so this must not either.
+ */
+function reportBrainCredentialStoreHealth(secretsDir: string, logger: Logger): void {
+  try {
+    const health = inspectCredentialStoreHealth({
+      credentialsPath: path.join(secretsDir, "credentials.json.enc"),
+      machineKeyPath: path.join(secretsDir, ".machine-key"),
+    });
+    if (health.state !== "unreadable" && !health.quarantine) return;
+    const summary = health.state === "unreadable"
+      ? `ADE brain cannot read the stored account credentials (${health.reason}).`
+      : "ADE brain set aside an unreadable credential file earlier.";
+    const nextStep = health.quarantine?.recoverable === true
+      ? " Opening the ADE app on this Mac restores it; no sign-in needed."
+      : " Sign in again in the ADE app.";
+    process.stderr.write(`${summary}${nextStep}\n`);
+    logger.warn("brain.credential_store_unreadable", {
+      state: health.state,
+      reason: health.reason,
+      declaredBinding: health.declaredBinding,
+      quarantined: health.quarantine?.file ?? null,
+      quarantineRecoverable: health.quarantine?.recoverable ?? null,
+    });
+  } catch {
+    // A diagnostic must never be the thing that stops the brain starting.
+  }
+}
+
 async function runServe(
   rest: string[],
   options: GlobalOptions,
@@ -16478,8 +16532,12 @@ async function runServe(
   const previousFailure = readLastFailure({ kind: "machine" });
   const startupBackoffMs = computeStartupBackoffMs(previousFailure, Date.now());
   if (startupBackoffMs > 0 && previousFailure) {
+    // The bare `code` alone printed "unknown" for every failure the classifier
+    // had no pattern for — which is exactly the class you need the reason for.
+    // Lead with the recorded detail so the log says what actually broke.
+    const reason = describeLastFailureForStartupLog(previousFailure);
     process.stderr.write(
-      `ADE brain delaying startup ${startupBackoffMs / 1_000}s after repeated failures: ${previousFailure.code}\n`,
+      `ADE brain delaying startup ${startupBackoffMs / 1_000}s after repeated failures: ${reason}\n`,
     );
     await new Promise<void>((resolve) => setTimeout(resolve, startupBackoffMs));
   }
@@ -16527,6 +16585,7 @@ async function runServe(
   const headlessProjectLogger: Logger = createBrainLogger(
     path.join(layout.runtimeDir, "brain.jsonl"),
   );
+  reportBrainCredentialStoreHealth(layout.secretsDir, headlessProjectLogger);
   const {
     createProductAnalyticsService,
     defaultProductAnalyticsStateFile,

--- a/apps/ade-cli/src/cli.ts
+++ b/apps/ade-cli/src/cli.ts
@@ -16232,8 +16232,35 @@ async function runBrainCommand(
     }
   }
 
+  // Deliberately local and brain-free: the state this repairs is precisely the
+  // one that keeps the brain from starting, so routing it through the brain
+  // would make it unavailable exactly when it is needed. The desktop's Repair
+  // control runs the same `repairSync()` through `account.repairSession`.
+  if (sub === "repair-credentials") {
+    const { secretsDir } = resolveMachineAdeLayout();
+    const report = new EncryptedFileCredentialStore({ secretsDir }).repairSync();
+    const readable = report.state !== "unreadable";
+    return {
+      ok: readable,
+      action: "repair-credentials",
+      state: report.state,
+      reason: report.reason,
+      recoveredKeys: report.recoveredKeys,
+      quarantined: report.quarantine
+        ? { at: report.quarantine.at, recoverable: report.quarantine.recoverable }
+        : null,
+      message: !readable
+        ? "ADE could not read the stored credentials on this computer. Sign in again in the ADE app."
+        : report.recoveredKeys > 0
+          ? `Restored ${report.recoveredKeys} stored credential${report.recoveredKeys === 1 ? "" : "s"}. Run \`ade brain restart\` so the brain picks them up.`
+          : report.quarantine?.recoverable === false
+            ? "An unreadable credential file was set aside earlier. Sign in again in the ADE app."
+            : "Stored credentials are readable; nothing needed repairing.",
+    };
+  }
+
   throw new CliUsageError(
-    "brain supports status, show, start, stop, restart, update, or pin.",
+    "brain supports status, show, start, stop, restart, update, repair-credentials, or pin.",
   );
 }
 

--- a/apps/ade-cli/src/cli.ts
+++ b/apps/ade-cli/src/cli.ts
@@ -16515,6 +16515,13 @@ function reportBrainCredentialStoreHealth(secretsDir: string, logger: Logger): v
     const health = inspectCredentialStoreHealth({
       credentialsPath: path.join(secretsDir, "credentials.json.enc"),
       machineKeyPath: path.join(secretsDir, ".machine-key"),
+      // No key-material read at all on the startup path. Even the read-only
+      // accessor is a `security` call on macOS and a synchronous PowerShell
+      // unprotect budgeted at 30 s on Windows, and delaying every brain start
+      // to decorate a log line is not a trade worth making. The brain is the
+      // process without OS material by definition, so what it reports here is
+      // what its own credential reads will find anyway.
+      keyMaterial: { read: () => null, peerMayHoldMaterial: true },
     });
     if (health.state !== "unreadable" && !health.quarantine) return;
     const summary = health.state === "unreadable"

--- a/apps/ade-cli/src/cli.ts
+++ b/apps/ade-cli/src/cli.ts
@@ -16494,7 +16494,7 @@ function reportBrainCredentialStoreHealth(secretsDir: string, logger: Logger): v
       ? `ADE brain cannot read the stored account credentials (${health.reason}).`
       : "ADE brain set aside an unreadable credential file earlier.";
     const nextStep = health.quarantine?.recoverable === true
-      ? " Opening the ADE app on this Mac restores it; no sign-in needed."
+      ? " Opening the ADE app on this computer restores it; no sign-in needed."
       : " Sign in again in the ADE app.";
     process.stderr.write(`${summary}${nextStep}\n`);
     logger.warn("brain.credential_store_unreadable", {

--- a/apps/ade-cli/src/commands/doctor.test.ts
+++ b/apps/ade-cli/src/commands/doctor.test.ts
@@ -57,6 +57,15 @@ function healthyInput(): DoctorInput {
       source: "loopback",
       error: null,
     },
+    credentials: {
+      path: "/Users/tester/.ade/secrets/credentials.json.enc",
+      exists: true,
+      state: "available",
+      reason: null,
+      sealedBinding: "machine",
+      declaredBinding: "machine",
+      quarantine: null,
+    },
   };
 }
 
@@ -179,7 +188,48 @@ describe("doctor row evaluation", () => {
       ["publish", "ok"],
       ["relay", "ok"],
       ["account", "ok"],
+      ["credentials", "ok"],
     ]);
+  });
+
+  it("names the credential store's two bad states with the right next step", () => {
+    const lockedOut = healthyInput();
+    lockedOut.credentials = {
+      ...lockedOut.credentials!,
+      state: "unreadable",
+      reason: "no_os_key_material",
+      sealedBinding: null,
+      declaredBinding: "os",
+    };
+    const lockedRow = evaluateDoctorRows(lockedOut).find((row) => row.key === "credentials");
+    expect(lockedRow?.status).toBe("fail");
+    expect(lockedRow?.detail).toContain("open the ADE app");
+
+    const corrupt = healthyInput();
+    corrupt.credentials = {
+      ...corrupt.credentials!,
+      state: "unreadable",
+      reason: "decrypt_failure",
+      sealedBinding: null,
+    };
+    const corruptRow = evaluateDoctorRows(corrupt).find((row) => row.key === "credentials");
+    expect(corruptRow?.status).toBe("fail");
+    expect(corruptRow?.detail).toContain("sign in again");
+
+    const quarantined = healthyInput();
+    quarantined.credentials = {
+      ...quarantined.credentials!,
+      quarantine: {
+        version: 1,
+        at: "2026-07-23T11:00:00.000Z",
+        file: "credentials.json.enc.quarantined-2026-07-23T11-00-00-000Z",
+        reason: "no_os_key_material",
+        recoverable: true,
+      },
+    };
+    const quarantinedRow = evaluateDoctorRows(quarantined).find((row) => row.key === "credentials");
+    expect(quarantinedRow?.status).toBe("warn");
+    expect(quarantinedRow?.detail).toContain("open the ADE app");
   });
 
   it("warns for a recent wedge and alternate port with diagnosed holders", () => {

--- a/apps/ade-cli/src/commands/doctor.ts
+++ b/apps/ade-cli/src/commands/doctor.ts
@@ -793,8 +793,10 @@ function credentialsRow(health: CredentialStoreHealth | null): DoctorRow {
       label,
       status: "fail",
       detail: health.reason === "no_os_key_material"
-        ? "sealed to this Mac's keychain, which this process cannot read"
-          + " · open the ADE app on this Mac to unlock it"
+        // Platform-neutral on purpose: the same state is a macOS keychain item
+        // the brain cannot reach and a Windows DPAPI blob it cannot unprotect.
+        ? "sealed with a key this process cannot read"
+          + " · open the ADE app on this computer to unlock it"
         : `cannot be read (${health.reason}) · sign in again in the ADE app`,
     };
   }
@@ -805,7 +807,7 @@ function credentialsRow(health: CredentialStoreHealth | null): DoctorRow {
       label,
       status: "warn",
       detail: health.quarantine.recoverable
-        ? `an earlier credential file was set aside ${setAside} · open the ADE app on this Mac to restore it`
+        ? `an earlier credential file was set aside ${setAside} · open the ADE app on this computer to restore it`
         : `an unreadable credential file was set aside ${setAside} · sign in again in the ADE app`,
     };
   }

--- a/apps/ade-cli/src/commands/doctor.ts
+++ b/apps/ade-cli/src/commands/doctor.ts
@@ -16,6 +16,10 @@ import type {
 } from "../services/runtime/brainLoopWatchdog";
 import { readBrainLoopWatchdogLastWedge } from "../services/runtime/brainLoopWatchdog";
 import { BRAIN_WATCHDOG_KILL_COMMAND } from "../services/runtime/brainWatchdogCheck";
+import {
+  inspectCredentialStoreHealth,
+  type CredentialStoreHealth,
+} from "../services/credentials/credentialStore";
 import { resolveMachineAdeLayout } from "../services/projects/machineLayout";
 import { DEFAULT_SYNC_HOST_PORT } from "../services/sync/syncProtocol";
 import type {
@@ -32,7 +36,8 @@ export type DoctorRow = {
     | "sync_port"
     | "publish"
     | "relay"
-    | "account";
+    | "account"
+    | "credentials";
   label: string;
   status: DoctorRowStatus;
   detail: string;
@@ -75,6 +80,12 @@ export type DoctorInput = {
     source: string | null;
     error: string | null;
   };
+  /**
+   * Read straight off disk rather than through the brain. The failure this row
+   * exists for is a brain that cannot start, so a credential check that needs a
+   * running brain to answer would be silent in exactly the case it is for.
+   */
+  credentials: CredentialStoreHealth | null;
 };
 
 export type DoctorCommandOptions = {
@@ -135,6 +146,7 @@ export type DoctorCommandResult = {
   publishHealth: DoctorInput["publishHealth"];
   relayHealth: DoctorInput["relayHealth"];
   account: DoctorInput["account"];
+  credentials: DoctorInput["credentials"];
 };
 
 type DoctorBrainProbe = {
@@ -752,6 +764,62 @@ function accountRow(account: DoctorInput["account"]): DoctorRow {
   };
 }
 
+/**
+ * The credential file the desktop app, the brain and the CLI all share.
+ *
+ * Its two bad states have different next steps, and saying the wrong one costs
+ * the user their session: a store a peer process can still open is repaired by
+ * opening the app, while one nothing can open needs a fresh sign-in.
+ */
+function readCredentialStoreHealthForDoctor(secretsDir: string): CredentialStoreHealth | null {
+  try {
+    return inspectCredentialStoreHealth({
+      credentialsPath: path.join(secretsDir, "credentials.json.enc"),
+      machineKeyPath: path.join(secretsDir, ".machine-key"),
+    });
+  } catch {
+    return null;
+  }
+}
+
+function credentialsRow(health: CredentialStoreHealth | null): DoctorRow {
+  const label = "Credentials";
+  if (!health) {
+    return { key: "credentials", label, status: "warn", detail: "credential store not checked" };
+  }
+  if (health.state === "unreadable") {
+    return {
+      key: "credentials",
+      label,
+      status: "fail",
+      detail: health.reason === "no_os_key_material"
+        ? "sealed to this Mac's keychain, which this process cannot read"
+          + " · open the ADE app on this Mac to unlock it"
+        : `cannot be read (${health.reason}) · sign in again in the ADE app`,
+    };
+  }
+  if (health.quarantine) {
+    const setAside = health.quarantine.at;
+    return {
+      key: "credentials",
+      label,
+      status: "warn",
+      detail: health.quarantine.recoverable
+        ? `an earlier credential file was set aside ${setAside} · open the ADE app on this Mac to restore it`
+        : `an unreadable credential file was set aside ${setAside} · sign in again in the ADE app`,
+    };
+  }
+  if (health.state === "missing") {
+    return { key: "credentials", label, status: "ok", detail: "no stored credentials" };
+  }
+  return {
+    key: "credentials",
+    label,
+    status: "ok",
+    detail: `readable · ${health.sealedBinding === "os" ? "keychain-sealed (converging)" : "machine-sealed"}`,
+  };
+}
+
 export function evaluateDoctorRows(input: DoctorInput): DoctorRow[] {
   return [
     appRow(input.app),
@@ -761,6 +829,7 @@ export function evaluateDoctorRows(input: DoctorInput): DoctorRow[] {
     publishRow(input.publishHealth, input.nowMs),
     relayRow(input.relayHealth),
     accountRow(input.account),
+    credentialsRow(input.credentials),
   ];
 }
 
@@ -823,6 +892,7 @@ export async function runDoctorCommand<Options extends DoctorCommandOptions>(
     publishHealth,
     relayHealth,
     account: brainProbe.account,
+    credentials: readCredentialStoreHealthForDoctor(layout.secretsDir),
   };
   const rows = evaluateDoctorRows(input);
   return {
@@ -838,5 +908,6 @@ export async function runDoctorCommand<Options extends DoctorCommandOptions>(
     publishHealth,
     relayHealth,
     account: input.account,
+    credentials: input.credentials,
   };
 }

--- a/apps/ade-cli/src/services/credentials/credentialFileIo.ts
+++ b/apps/ade-cli/src/services/credentials/credentialFileIo.ts
@@ -231,9 +231,13 @@ function removeStaleLock(lockPath: string): void {
   }
 }
 
-export function withCredentialFileLock<T>(lockPath: string, fn: () => T): T {
+export function withCredentialFileLock<T>(
+  lockPath: string,
+  fn: () => T,
+  options: { timeoutMs?: number } = {},
+): T {
   ensureDirMode700(path.dirname(lockPath));
-  const deadline = Date.now() + LOCK_TIMEOUT_MS;
+  const deadline = Date.now() + (options.timeoutMs ?? LOCK_TIMEOUT_MS);
   let fd: number | null = null;
 
   while (fd === null) {

--- a/apps/ade-cli/src/services/credentials/credentialFileIo.ts
+++ b/apps/ade-cli/src/services/credentials/credentialFileIo.ts
@@ -1,0 +1,328 @@
+import fs from "node:fs";
+import path from "node:path";
+
+/**
+ * File-level plumbing shared by everything that reads or writes an ADE
+ * credential file: private-mode creation, atomic replacement, the cross-process
+ * advisory lock, and the stat-poll change watcher.
+ *
+ * Split out of `credentialStore.ts` because it is infrastructure, not policy —
+ * the store decides which key seals a file and what to do when it cannot be
+ * read; nothing here knows what a credential is. The quarantine module needs the
+ * same primitives, which is what forced the seam.
+ */
+
+/**
+ * How long a writer waits for the credential-file lock before giving up.
+ *
+ * Exported because cross-process protocols layered on the credential store have
+ * to out-wait it. In particular the account service polls for a peer's rotated
+ * refresh token after a definitive `invalid_grant`: if that poll window were
+ * shorter than this timeout, a peer that legitimately won the exchange but is
+ * still queued behind the lock would have its session declared dead by the
+ * loser.
+ */
+export const CREDENTIAL_FILE_LOCK_TIMEOUT_MS = 15_000;
+const LOCK_TIMEOUT_MS = CREDENTIAL_FILE_LOCK_TIMEOUT_MS;
+const LOCK_STALE_MS = 10_000;
+const LOCK_RETRY_MS = 25;
+
+type CredentialLockMetadata = {
+  pid?: number;
+  createdAt?: string;
+};
+
+export function ensureMode600(filePath: string): void {
+  if (process.platform === "win32") return;
+  try {
+    fs.chmodSync(filePath, 0o600);
+  } catch {
+    // Best effort; some filesystems do not support chmod.
+  }
+}
+
+export function ensureDirMode700(dirPath: string): void {
+  fs.mkdirSync(dirPath, { recursive: true, mode: 0o700 });
+  if (process.platform === "win32") return;
+  try {
+    fs.chmodSync(dirPath, 0o700);
+  } catch {
+    // Best effort; some filesystems do not support chmod.
+  }
+}
+
+export function writeFileAtomic(filePath: string, contents: string | Buffer): void {
+  ensureDirMode700(path.dirname(filePath));
+  const tmpPath = `${filePath}.${process.pid}.${Date.now()}.tmp`;
+  fs.writeFileSync(tmpPath, contents, { mode: 0o600 });
+  ensureMode600(tmpPath);
+  fs.renameSync(tmpPath, filePath);
+  ensureMode600(filePath);
+}
+
+export function isEnoent(error: unknown): boolean {
+  return typeof error === "object"
+    && error !== null
+    && "code" in error
+    && (error as { code?: unknown }).code === "ENOENT";
+}
+
+export function isEexist(error: unknown): boolean {
+  return typeof error === "object"
+    && error !== null
+    && "code" in error
+    && (error as { code?: unknown }).code === "EEXIST";
+}
+
+/**
+ * Windows does not report lock contention as EEXIST the way POSIX does.
+ *
+ * Deleting a file on Windows only unlinks the name once every open handle to it
+ * closes, so between one holder's unlink and the last handle drop the lock name
+ * still occupies the directory in a "delete pending" state. A concurrent
+ * `open(lockPath, "wx")` against that name fails with a delete-pending or
+ * sharing violation, which Node surfaces as EPERM, EACCES or EBUSY instead of
+ * EEXIST. Those are the same "someone else holds it, try again" condition, so
+ * they have to keep the acquisition loop running; treating them as fatal makes
+ * every concurrent credential write a coin flip on Windows.
+ */
+export function isLockContention(error: unknown): boolean {
+  if (isEexist(error)) return true;
+  if (process.platform !== "win32") return false;
+  if (typeof error !== "object" || error === null || !("code" in error)) return false;
+  const code = (error as { code?: unknown }).code;
+  return code === "EPERM" || code === "EACCES" || code === "EBUSY";
+}
+
+function sleepSync(ms: number): void {
+  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms);
+}
+
+export function defaultLockPath(credentialsPath: string): string {
+  return `${credentialsPath}.lock`;
+}
+
+export function isSamePath(left: string, right: string): boolean {
+  return path.resolve(left) === path.resolve(right);
+}
+
+export type CredentialFileStatSnapshot = {
+  ino: number;
+  mtimeMs: number;
+  size: number;
+} | null;
+
+function readCredentialFileStatSnapshot(filePath: string): CredentialFileStatSnapshot | undefined {
+  try {
+    const stat = fs.statSync(filePath);
+    return { ino: stat.ino, mtimeMs: stat.mtimeMs, size: stat.size };
+  } catch (error: unknown) {
+    if (isEnoent(error)) return null;
+    return undefined;
+  }
+}
+
+function isSameCredentialFileStat(
+  left: CredentialFileStatSnapshot,
+  right: CredentialFileStatSnapshot,
+): boolean {
+  if (left === null || right === null) return left === right;
+  return left.ino === right.ino
+    && left.mtimeMs === right.mtimeMs
+    && left.size === right.size;
+}
+
+export class CredentialFileStatWatcher {
+  private previous: CredentialFileStatSnapshot | undefined;
+  private timer: NodeJS.Timeout | null = null;
+
+  constructor(
+    private readonly filePath: string,
+    private readonly listener: () => void,
+    private readonly intervalMs: number | null,
+  ) {}
+
+  start(): void {
+    this.previous = readCredentialFileStatSnapshot(this.filePath);
+    if (this.intervalMs === null) return;
+    this.timer = setInterval(() => this.checkNow(), this.intervalMs);
+    this.timer.unref();
+  }
+
+  checkNow(): void {
+    const current = readCredentialFileStatSnapshot(this.filePath);
+    if (current === undefined) return;
+    if (this.previous === undefined) {
+      this.previous = current;
+      return;
+    }
+    if (isSameCredentialFileStat(current, this.previous)) return;
+    this.previous = current;
+    try {
+      this.listener();
+    } catch {
+      // Credential observers are best-effort; one subscriber must not stop
+      // the watcher or prevent sibling subscribers from seeing the change.
+    }
+  }
+
+  dispose(): void {
+    if (this.timer) clearInterval(this.timer);
+    this.timer = null;
+  }
+}
+
+function parseLockMetadata(raw: string): CredentialLockMetadata {
+  try {
+    const parsed = JSON.parse(raw) as unknown;
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return {};
+    const record = parsed as Record<string, unknown>;
+    return {
+      pid: Number.isSafeInteger(record.pid) && Number(record.pid) > 0 ? Number(record.pid) : undefined,
+      createdAt: typeof record.createdAt === "string" ? record.createdAt : undefined,
+    };
+  } catch {
+    return {};
+  }
+}
+
+function isProcessRunning(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error: unknown) {
+    return !(
+      typeof error === "object"
+      && error !== null
+      && "code" in error
+      && (error as { code?: unknown }).code === "ESRCH"
+    );
+  }
+}
+
+function isSameLockStat(left: fs.Stats, right: fs.Stats): boolean {
+  return left.dev === right.dev
+    && left.ino === right.ino
+    && left.size === right.size
+    && left.mtimeMs === right.mtimeMs;
+}
+
+function removeStaleLock(lockPath: string): void {
+  let originalStat: fs.Stats;
+  let originalRaw: string;
+  try {
+    originalStat = fs.statSync(lockPath);
+    if (Date.now() - originalStat.mtimeMs <= LOCK_STALE_MS) return;
+    originalRaw = fs.readFileSync(lockPath, "utf8");
+  } catch {
+    return;
+  }
+
+  const metadata = parseLockMetadata(originalRaw);
+  if (metadata.pid && isProcessRunning(metadata.pid)) return;
+
+  try {
+    const currentStat = fs.statSync(lockPath);
+    if (!isSameLockStat(currentStat, originalStat)) return;
+    if (fs.readFileSync(lockPath, "utf8") !== originalRaw) return;
+    fs.unlinkSync(lockPath);
+  } catch {
+    // Another process won the lock race or removed the stale file first.
+  }
+}
+
+export function withCredentialFileLock<T>(lockPath: string, fn: () => T): T {
+  ensureDirMode700(path.dirname(lockPath));
+  const deadline = Date.now() + LOCK_TIMEOUT_MS;
+  let fd: number | null = null;
+
+  while (fd === null) {
+    try {
+      const candidateFd = fs.openSync(lockPath, "wx", 0o600);
+      try {
+        fs.writeFileSync(
+          candidateFd,
+          JSON.stringify({ pid: process.pid, createdAt: new Date().toISOString() }),
+        );
+        fd = candidateFd;
+      } catch (error: unknown) {
+        try {
+          fs.closeSync(candidateFd);
+        } catch {
+          // ignore
+        }
+        try {
+          fs.unlinkSync(lockPath);
+        } catch {
+          // ignore
+        }
+        throw error;
+      }
+      ensureMode600(lockPath);
+    } catch (error: unknown) {
+      if (!isLockContention(error)) throw error;
+      removeStaleLock(lockPath);
+      if (Date.now() >= deadline) {
+        throw new Error("Timed out waiting for ADE credential store lock.", { cause: error });
+      }
+      sleepSync(LOCK_RETRY_MS);
+    }
+  }
+
+  try {
+    return fn();
+  } finally {
+    try {
+      fs.closeSync(fd);
+    } catch {
+      // ignore
+    }
+    try {
+      fs.unlinkSync(lockPath);
+    } catch {
+      // ignore
+    }
+  }
+}
+
+export function unlinkIfExists(filePath: string): void {
+  try {
+    fs.unlinkSync(filePath);
+  } catch (error: unknown) {
+    if (!isEnoent(error)) throw error;
+  }
+}
+
+export function withOptionalCredentialFileLock<T>(lockPath: string, skippedLockPath: string, fn: () => T): T {
+  if (isSamePath(lockPath, skippedLockPath)) return fn();
+  return withCredentialFileLock(lockPath, fn);
+}
+
+export function readJsonObject(filePath: string): Record<string, unknown> | null {
+  try {
+    const raw = fs.readFileSync(filePath, "utf8");
+    const parsed = JSON.parse(raw) as unknown;
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return null;
+    return parsed as Record<string, unknown>;
+  } catch (error: unknown) {
+    if (isEnoent(error)) return {};
+    throw error;
+  }
+}
+
+export async function readJsonObjectAsync(filePath: string): Promise<{
+  value: Record<string, unknown> | null;
+  exists: boolean;
+}> {
+  try {
+    const raw = await fs.promises.readFile(filePath, "utf8");
+    const parsed = JSON.parse(raw) as unknown;
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+      return { value: null, exists: true };
+    }
+    return { value: parsed as Record<string, unknown>, exists: true };
+  } catch (error: unknown) {
+    if (isEnoent(error)) return { value: {}, exists: false };
+    throw error;
+  }
+}

--- a/apps/ade-cli/src/services/credentials/credentialStore.test.ts
+++ b/apps/ade-cli/src/services/credentials/credentialStore.test.ts
@@ -391,7 +391,9 @@ new EncryptedFileCredentialStore({ secretsDir }).setSync(key, value);
 
     const brain = new EncryptedFileCredentialStore({
       secretsDir: tempDir,
-      keyMaterial: { read: () => null },
+      // Declared, not inherited from the test host: this is a machine where a
+      // PEER process holds keychain material, which is the whole scenario.
+      keyMaterial: { read: () => null, peerMayHoldMaterial: true },
     });
     expect(brain.getSync("account.session.v1")).toBeNull();
     expect(brain.getLastReadFailureReason()).toBe("no_os_key_material");
@@ -428,6 +430,11 @@ new EncryptedFileCredentialStore({ secretsDir }).setSync(key, value);
     });
     await expect(converging.get("account.session.v1")).resolves.toBe("legacy-async-windows-session");
     expect(syncProvider).not.toHaveBeenCalled();
+    // The rebind is deferred off the awaited read on purpose — it takes the file
+    // lock with a synchronous spin, and blocking the event loop for that is not
+    // something the caller asked for.
+    expect(fs.readFileSync(credentialsPath, "utf8")).toBe(legacyCiphertext);
+    converging.flushPendingRebindNow();
     expect(fs.readFileSync(credentialsPath, "utf8")).not.toBe(legacyCiphertext);
 
     expect(new EncryptedFileCredentialStore({
@@ -627,7 +634,7 @@ new EncryptedFileCredentialStore({ secretsDir }).setSync(key, value);
 
     const brain = new EncryptedFileCredentialStore({
       secretsDir: tempDir,
-      keyMaterial: { read: () => null },
+      keyMaterial: { read: () => null, peerMayHoldMaterial: true },
     });
     brain.setSync("sync.bootstrapToken.v1", "fresh-token");
     expect(brain.getSync("account.session.v1")).toBeNull();
@@ -655,7 +662,7 @@ new EncryptedFileCredentialStore({ secretsDir }).setSync(key, value);
 
     const brain = new EncryptedFileCredentialStore({
       secretsDir: tempDir,
-      keyMaterial: { read: () => null },
+      keyMaterial: { read: () => null, peerMayHoldMaterial: true },
     });
     brain.setSync("account.session.v1", "session-signed-in-again");
 
@@ -673,7 +680,7 @@ new EncryptedFileCredentialStore({ secretsDir }).setSync(key, value);
     sealLegacyOsBoundStore(tempDir, { "account.session.v1": "session-json" }, Buffer.from("gone"));
     new EncryptedFileCredentialStore({
       secretsDir: tempDir,
-      keyMaterial: { read: () => null },
+      keyMaterial: { read: () => null, peerMayHoldMaterial: true },
     }).setSync("sync.bootstrapToken.v1", "fresh-token");
     expect(readQuarantineMarker(tempDir).recoverable).toBe(true);
 
@@ -737,6 +744,51 @@ new EncryptedFileCredentialStore({ secretsDir }).setSync(key, value);
     expect(store.getSync("agent.token")).toBe("after");
   });
 
+  it("classifies peer-recoverability from the injected source, not the host OS", () => {
+    // CI runs on Linux, where no process can hold OS material — so reading this
+    // predicate from `process.platform` at the point of use made the store's
+    // classification depend on the machine the code happened to run on, and made
+    // the recoverable path untestable anywhere but macOS/Windows.
+    sealLegacyOsBoundStore(tempDir, { "agent.token": "secret" }, Buffer.from("peer-material"));
+    const credentialsPath = path.join(tempDir, "credentials.json.enc");
+    const machineKeyPath = path.join(tempDir, ".machine-key");
+
+    expect(inspectCredentialStoreHealth({
+      credentialsPath,
+      machineKeyPath,
+      keyMaterial: { read: () => null, peerMayHoldMaterial: true },
+    }).reason).toBe("no_os_key_material");
+
+    // Same bytes, same absent material — a platform where nothing can hold it.
+    expect(inspectCredentialStoreHealth({
+      credentialsPath,
+      machineKeyPath,
+      keyMaterial: { read: () => null, peerMayHoldMaterial: false },
+    }).reason).toBe("decrypt_failure");
+  });
+
+  it("does not create key material while inspecting a store", () => {
+    // The default reader MINTS on both platforms — a macOS keychain item, or a
+    // DPAPI key file behind a 30s synchronous PowerShell protect. A diagnostic
+    // that used it would create the state it was asked to report on.
+    const reads: string[] = [];
+    const health = inspectCredentialStoreHealth({
+      credentialsPath: path.join(tempDir, "credentials.json.enc"),
+      machineKeyPath: path.join(tempDir, ".machine-key"),
+      keyMaterial: {
+        read: (dir) => {
+          reads.push(dir);
+          return null;
+        },
+      },
+    });
+
+    expect(health.state).toBe("missing");
+    expect(fs.existsSync(path.join(tempDir, ".machine-key"))).toBe(false);
+    // A missing store never even asks for key material.
+    expect(reads).toEqual([]);
+  });
+
   it("survives a key-material read that throws, on both the sync and async paths", async () => {
     // Windows: every DPAPI failure — including a transient PowerShell cold-start
     // timeout — throws out of the material read. That exception used to travel
@@ -762,7 +814,7 @@ new EncryptedFileCredentialStore({ secretsDir }).setSync(key, value);
     sealLegacyOsBoundStore(tempDir, { "account.session.v1": "session-json" }, osMaterial);
     new EncryptedFileCredentialStore({
       secretsDir: tempDir,
-      keyMaterial: { read: () => null },
+      keyMaterial: { read: () => null, peerMayHoldMaterial: true },
     }).setSync("sync.bootstrapToken.v1", "fresh-token");
 
     const desktop = new EncryptedFileCredentialStore({
@@ -815,7 +867,7 @@ new EncryptedFileCredentialStore({ secretsDir }).setSync(key, value);
     const health = inspectCredentialStoreHealth({
       credentialsPath,
       machineKeyPath: path.join(tempDir, ".machine-key"),
-      keyMaterial: { read: () => null },
+      keyMaterial: { read: () => null, peerMayHoldMaterial: true },
     });
 
     expect(health.state).toBe("unreadable");

--- a/apps/ade-cli/src/services/credentials/credentialStore.test.ts
+++ b/apps/ade-cli/src/services/credentials/credentialStore.test.ts
@@ -1,4 +1,5 @@
 import { spawn } from "node:child_process";
+import crypto from "node:crypto";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
@@ -10,6 +11,7 @@ import {
   KeytarCredentialStore,
   CREDENTIAL_STORE_LOCK_TIMEOUT_MS,
   createDefaultCredentialStore,
+  inspectCredentialStoreHealth,
   isFileBackedCredentialKey,
 } from "./credentialStore";
 import {
@@ -31,6 +33,69 @@ import {
 } from "./windowsDpapiMaterial";
 
 let tempDir = "";
+
+/**
+ * Writes the shape an ADE build BEFORE this fix left on disk: a credential
+ * envelope sealed with the OS-bound key and no `binding` field.
+ *
+ * The store deliberately has no writer for that shape any more — sealing the
+ * shared file `os` is the trapdoor these tests exist to keep shut — so the
+ * legacy format is pinned here instead. The HKDF parameters are copied from
+ * `deriveOsBoundCredentialKey`; that duplication IS the compatibility contract.
+ */
+function sealLegacyOsBoundStore(
+  secretsDir: string,
+  values: Record<string, string>,
+  material: Buffer,
+  options: { declareBinding?: boolean } = {},
+): void {
+  fs.mkdirSync(secretsDir, { recursive: true, mode: 0o700 });
+  const machineKeyPath = path.join(secretsDir, ".machine-key");
+  let machineKey: Buffer;
+  if (fs.existsSync(machineKeyPath)) {
+    machineKey = Buffer.from(fs.readFileSync(machineKeyPath, "utf8").trim(), "base64");
+  } else {
+    machineKey = crypto.randomBytes(32);
+    fs.writeFileSync(machineKeyPath, `${machineKey.toString("base64")}\n`, { mode: 0o600 });
+  }
+  const key = Buffer.from(crypto.hkdfSync(
+    "sha256",
+    material,
+    machineKey,
+    Buffer.from("ade.credentials.file-store.v2"),
+    32,
+  ));
+  const iv = crypto.randomBytes(12);
+  const cipher = crypto.createCipheriv("aes-256-gcm", key, iv);
+  cipher.setAAD(Buffer.from("ade.credentials.v1"));
+  const ciphertext = Buffer.concat([
+    cipher.update(JSON.stringify(values), "utf8"),
+    cipher.final(),
+  ]);
+  fs.writeFileSync(
+    path.join(secretsDir, "credentials.json.enc"),
+    `${JSON.stringify({
+      version: 1,
+      alg: "aes-256-gcm",
+      ...(options.declareBinding ? { binding: "os" } : {}),
+      iv: iv.toString("base64"),
+      tag: cipher.getAuthTag().toString("base64"),
+      ciphertext: ciphertext.toString("base64"),
+    }, null, 2)}\n`,
+    { mode: 0o600 },
+  );
+}
+
+function readQuarantineMarker(secretsDir: string): {
+  file: string;
+  reason: string;
+  recoverable: boolean;
+} {
+  return JSON.parse(fs.readFileSync(
+    path.join(secretsDir, "credentials.json.enc.quarantine.json"),
+    "utf8",
+  )) as { file: string; reason: string; recoverable: boolean };
+}
 
 beforeEach(() => {
   tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "ade-credentials-"));
@@ -199,7 +264,7 @@ describe("EncryptedFileCredentialStore", () => {
     expect(fs.statSync(path.join(secretsDir, "credentials.json.enc")).mode & 0o777).toBe(0o600);
   });
 
-  it("fails closed and preserves ciphertext after the machine key is replaced", () => {
+  it("quarantines rather than overwrites ciphertext after the machine key is replaced", () => {
     const store = new EncryptedFileCredentialStore({ secretsDir: tempDir });
 
     store.setSync("agent.token", "secret");
@@ -209,8 +274,15 @@ describe("EncryptedFileCredentialStore", () => {
 
     expect(store.getSync("agent.token")).toBeNull();
     expect(store.getLastReadState()).toBe("unreadable");
-    expect(() => store.setSync("agent.other", "next-secret")).toThrow();
-    expect(fs.readFileSync(credentialPath, "utf8")).toBe(ciphertext);
+
+    // The write must still not destroy credentials it could not read — but it
+    // must also not throw, because throwing here is what crash-looped a brain
+    // whose first startup act is minting the sync bootstrap token.
+    expect(() => store.setSync("agent.other", "next-secret")).not.toThrow();
+    expect(store.getSync("agent.other")).toBe("next-secret");
+
+    const marker = readQuarantineMarker(tempDir);
+    expect(fs.readFileSync(path.join(tempDir, marker.file), "utf8")).toBe(ciphertext);
   });
 
   it("preserves concurrent writes from separate processes on first run", async () => {
@@ -279,53 +351,87 @@ new EncryptedFileCredentialStore({ secretsDir }).setSync(key, value);
     }
   }, 10000);
 
-  it("derives file encryption from OS-bound key material when available", async () => {
+  it("seals the shared store so a co-owner without OS key material can read it", () => {
+    // THE trapdoor. The desktop app has keychain material; the launchd brain
+    // does not. Whatever the app writes, the brain must be able to open — and
+    // the app must not "upgrade" what the brain wrote into something it cannot.
     const osMaterial = Buffer.from("test-os-material");
-    const store = new EncryptedFileCredentialStore({
+    const withMaterial = new EncryptedFileCredentialStore({
       secretsDir: tempDir,
       keyMaterial: { read: () => osMaterial },
     });
-
-    store.setSync("linear.token.v1", "lin_secret");
-
-    const reloaded = new EncryptedFileCredentialStore({
-      secretsDir: tempDir,
-      keyMaterial: { read: () => osMaterial },
-    });
-    expect(reloaded.getSync("linear.token.v1")).toBe("lin_secret");
-
-    const unbound = new EncryptedFileCredentialStore({
+    const withoutMaterial = new EncryptedFileCredentialStore({
       secretsDir: tempDir,
       keyMaterial: { read: () => null },
     });
-    expect(unbound.getSync("linear.token.v1")).toBeNull();
+
+    withMaterial.setSync("linear.token.v1", "lin_secret");
+    expect(withoutMaterial.getSync("linear.token.v1")).toBe("lin_secret");
+
+    // ...and the reverse direction, including the read that used to re-seal.
+    withoutMaterial.setSync("account.session.v1", "session-json");
+    expect(withMaterial.getSync("account.session.v1")).toBe("session-json");
+    expect(withoutMaterial.getSync("account.session.v1")).toBe("session-json");
+    expect(withoutMaterial.getLastReadState()).toBe("available");
+
+    const envelope = JSON.parse(
+      fs.readFileSync(path.join(tempDir, "credentials.json.enc"), "utf8"),
+    ) as { binding?: string; version: number };
+    expect(envelope.binding).toBe("machine");
+    // Still version 1: a build that predates the binding field has to keep
+    // reading this file, or a downgrade repeats the incident.
+    expect(envelope.version).toBe(1);
   });
 
-  it("atomically binds legacy Windows ciphertext on the first asynchronous credential read", async () => {
-    const legacyStore = new EncryptedFileCredentialStore({
+  it("converges an os-sealed store from an older build to the machine key", () => {
+    const osMaterial = Buffer.from("legacy-os-material");
+    sealLegacyOsBoundStore(tempDir, { "account.session.v1": "session-json" }, osMaterial);
+
+    const brain = new EncryptedFileCredentialStore({
       secretsDir: tempDir,
       keyMaterial: { read: () => null },
     });
-    legacyStore.setSync("account.session.v1", "legacy-async-windows-session");
+    expect(brain.getSync("account.session.v1")).toBeNull();
+    expect(brain.getLastReadFailureReason()).toBe("no_os_key_material");
+
+    // The desktop app, which CAN open it, re-seals it to the shared binding on
+    // a plain read. No user action, no sign-in.
+    const desktop = new EncryptedFileCredentialStore({
+      secretsDir: tempDir,
+      keyMaterial: { read: () => osMaterial },
+    });
+    expect(desktop.getSync("account.session.v1")).toBe("session-json");
+
+    expect(brain.getSync("account.session.v1")).toBe("session-json");
+    expect(brain.getLastReadState()).toBe("available");
+  });
+
+  it("converges an os-sealed store to the machine key on the asynchronous read path", async () => {
+    const osMaterial = Buffer.from("windows-async-account-bound-material");
+    sealLegacyOsBoundStore(
+      tempDir,
+      { "account.session.v1": "legacy-async-windows-session" },
+      osMaterial,
+      { declareBinding: true },
+    );
     const credentialsPath = path.join(tempDir, "credentials.json.enc");
     const legacyCiphertext = fs.readFileSync(credentialsPath, "utf8");
-    const osMaterial = Buffer.from("windows-async-account-bound-material");
 
-    const upgraded = new EncryptedFileCredentialStore({
-      secretsDir: tempDir,
-      keyMaterial: {
-        read: () => {
-          throw new Error("async migration must not use synchronous key access");
-        },
-        readAsync: async () => osMaterial,
-      },
+    const syncProvider = vi.fn((): Buffer | null => {
+      throw new Error("async convergence must not use synchronous key access");
     });
-    await expect(upgraded.get("account.session.v1")).resolves.toBe("legacy-async-windows-session");
+    const converging = new EncryptedFileCredentialStore({
+      secretsDir: tempDir,
+      keyMaterial: { read: syncProvider, readAsync: async () => osMaterial },
+    });
+    await expect(converging.get("account.session.v1")).resolves.toBe("legacy-async-windows-session");
+    expect(syncProvider).not.toHaveBeenCalled();
     expect(fs.readFileSync(credentialsPath, "utf8")).not.toBe(legacyCiphertext);
+
     expect(new EncryptedFileCredentialStore({
       secretsDir: tempDir,
       keyMaterial: { read: () => null },
-    }).getSync("account.session.v1")).toBeNull();
+    }).getSync("account.session.v1")).toBe("legacy-async-windows-session");
   });
 
   it("uses the asynchronous key-material path for asynchronous reads", async () => {
@@ -366,46 +472,71 @@ new EncryptedFileCredentialStore({ secretsDir }).setSync(key, value);
     expect(fs.existsSync(path.join(tempDir, ".machine-key"))).toBe(false);
   });
 
-  it.each(["{}", "null"])("fails closed on an existing invalid async credential store: %s", async (raw) => {
-    const credentialPath = path.join(tempDir, "credentials.json.enc");
-    fs.writeFileSync(credentialPath, raw, "utf8");
-    const asyncProvider = vi.fn(async () => Buffer.from("unused"));
-    const reader = new EncryptedFileCredentialStore({
-      secretsDir: tempDir,
-      keyMaterial: { read: () => null, readAsync: asyncProvider },
-    });
+  it.each(["{}", "null"])(
+    "reports an existing invalid async credential store as unreadable rather than throwing: %s",
+    async (raw) => {
+      const credentialPath = path.join(tempDir, "credentials.json.enc");
+      fs.writeFileSync(credentialPath, raw, "utf8");
+      const asyncProvider = vi.fn(async () => Buffer.from("unused"));
+      const reader = new EncryptedFileCredentialStore({
+        secretsDir: tempDir,
+        keyMaterial: { read: () => null, readAsync: asyncProvider },
+      });
 
-    await expect(reader.get("github.token.v1")).rejects.toThrow(
-      "Unsupported ADE credential store format.",
-    );
-    expect(reader.getLastReadState()).toBe("unreadable");
-    expect(asyncProvider).not.toHaveBeenCalled();
-  });
+      // A read reports; it does not throw. The brain's startup path reads before
+      // it writes, and a throw here is an exit code under launchd.
+      await expect(reader.get("github.token.v1")).resolves.toBeNull();
+      expect(reader.getLastReadState()).toBe("unreadable");
+      expect(reader.getLastReadFailureReason()).toBe("store_format");
+      expect(asyncProvider).not.toHaveBeenCalled();
+    },
+  );
 
-  it("atomically binds legacy Windows ciphertext on the first synchronous credential read", () => {
-    const legacy = new EncryptedFileCredentialStore({
+  it.each(["{}", "null"])(
+    "quarantines rather than silently replacing an invalid credential file on write: %s",
+    (raw) => {
+      const credentialPath = path.join(tempDir, "credentials.json.enc");
+      fs.writeFileSync(credentialPath, raw, "utf8");
+      const store = new EncryptedFileCredentialStore({
+        secretsDir: tempDir,
+        keyMaterial: { read: () => null },
+      });
+
+      expect(store.getSync("github.token.v1")).toBeNull();
+      expect(store.getLastReadFailureReason()).toBe("store_format");
+      store.setSync("github.token.v1", "ghp_next");
+
+      const marker = readQuarantineMarker(tempDir);
+      expect(marker.reason).toBe("store_format");
+      expect(marker.recoverable).toBe(false);
+      expect(fs.readFileSync(path.join(tempDir, marker.file), "utf8")).toBe(raw);
+      expect(store.getSync("github.token.v1")).toBe("ghp_next");
+    },
+  );
+
+  it("leaves an already machine-sealed store byte-identical on read", () => {
+    const store = new EncryptedFileCredentialStore({
       secretsDir: tempDir,
       keyMaterial: { read: () => null },
     });
-    legacy.setSync("agent.token", "legacy_secret");
+    store.setSync("agent.token", "legacy_secret");
     const credentialPath = path.join(tempDir, "credentials.json.enc");
-    const legacyCiphertext = fs.readFileSync(credentialPath, "utf8");
+    const ciphertext = fs.readFileSync(credentialPath, "utf8");
 
-    const upgraded = new EncryptedFileCredentialStore({
+    // The process WITH key material used to rewrite this file into a binding the
+    // writer above could never open again. It must now leave it alone.
+    const withMaterial = new EncryptedFileCredentialStore({
       secretsDir: tempDir,
       keyMaterial: { read: () => Buffer.from("test-os-material") },
     });
-    expect(upgraded.getSync("agent.token")).toBe("legacy_secret");
-    expect(fs.readFileSync(credentialPath, "utf8")).not.toBe(legacyCiphertext);
-    expect(legacy.getSync("agent.token")).toBeNull();
+    expect(withMaterial.getSync("agent.token")).toBe("legacy_secret");
+    expect(fs.readFileSync(credentialPath, "utf8")).toBe(ciphertext);
+    expect(store.getSync("agent.token")).toBe("legacy_secret");
   });
 
   it("re-reads key material once and self-heals a decrypt failure caused by stale cached material", () => {
     const winner = Buffer.from("os-material-winner");
-    new EncryptedFileCredentialStore({
-      secretsDir: tempDir,
-      keyMaterial: { read: () => winner },
-    }).setSync("account.session.v1", "session-json");
+    sealLegacyOsBoundStore(tempDir, { "account.session.v1": "session-json" }, winner);
 
     // This store cached the secret it minted before the peer's item won the
     // keychain race, so its first decrypt attempt fails.
@@ -427,10 +558,7 @@ new EncryptedFileCredentialStore({ secretsDir }).setSync(key, value);
   });
 
   it("does not re-ask for key material on every read while it keeps failing", () => {
-    new EncryptedFileCredentialStore({
-      secretsDir: tempDir,
-      keyMaterial: { read: () => Buffer.from("os-material-A") },
-    }).setSync("agent.token", "secret");
+    sealLegacyOsBoundStore(tempDir, { "agent.token": "secret" }, Buffer.from("os-material-A"));
 
     let material = Buffer.from("os-material-B");
     const invalidateKeyMaterial = vi.fn(() => {
@@ -443,9 +571,9 @@ new EncryptedFileCredentialStore({ secretsDir }).setSync(key, value);
       keyMaterial: { read: () => material, invalidate: invalidateKeyMaterial },
     });
 
-    expect(() => store.getSync("agent.token")).toThrow();
-    expect(() => store.getSync("agent.token")).toThrow();
-    expect(() => store.getSync("agent.token")).toThrow();
+    expect(store.getSync("agent.token")).toBeNull();
+    expect(store.getSync("agent.token")).toBeNull();
+    expect(store.getSync("agent.token")).toBeNull();
     expect(invalidateKeyMaterial).toHaveBeenCalledTimes(1);
     expect(store.getLastReadState()).toBe("unreadable");
     expect(store.getLastReadFailureReason()).toBe("decrypt_failure");
@@ -464,33 +592,185 @@ new EncryptedFileCredentialStore({ secretsDir }).setSync(key, value);
     expect(store.getLastReadFailureReason()).toBe("store_format");
   });
 
-  it("fails safe instead of wiping ciphertext when OS-bound key material rotates", () => {
-    const written = new EncryptedFileCredentialStore({
-      secretsDir: tempDir,
-      keyMaterial: { read: () => Buffer.from("os-material-A") },
-    });
-    written.setSync("agent.token", "secret");
-
+  it("preserves ciphertext when OS-bound key material rotates under an older store", () => {
+    sealLegacyOsBoundStore(tempDir, { "agent.token": "secret" }, Buffer.from("os-material-A"));
     const cipherPath = path.join(tempDir, "credentials.json.enc");
     const before = fs.readFileSync(cipherPath, "utf8");
 
-    // Rotated OS material: neither the newly-derived key nor the bare machine key
-    // can decrypt ciphertext that was sealed with material A. The store must throw
-    // (preserving the ciphertext) instead of silently rewriting an empty store.
+    // Rotated OS material: neither the newly-derived key nor the bare machine
+    // key decrypts ciphertext sealed with material A. The store must preserve
+    // that ciphertext rather than write an empty store over it — but it must
+    // keep serving its caller, not throw.
     const rotated = new EncryptedFileCredentialStore({
       secretsDir: tempDir,
       keyMaterial: { read: () => Buffer.from("os-material-B") },
     });
-    expect(() => rotated.getSync("agent.token")).toThrow();
-    expect(() => rotated.setSync("agent.token", "wiped")).toThrow();
+    expect(rotated.getSync("agent.token")).toBeNull();
+    rotated.setSync("agent.token", "written-after-quarantine");
 
-    // Ciphertext file untouched: the original credential is recoverable with material A.
-    expect(fs.readFileSync(cipherPath, "utf8")).toBe(before);
-    const recovered = new EncryptedFileCredentialStore({
+    const marker = readQuarantineMarker(tempDir);
+    expect(fs.readFileSync(path.join(tempDir, marker.file), "utf8")).toBe(before);
+  });
+
+  it("merges a quarantined store back in once a peer process can decrypt it", () => {
+    // The full self-heal for a machine already in the broken state: the brain
+    // (no OS material) quarantines the os-sealed store and boots signed out, and
+    // the desktop app puts the session back without anyone signing in again.
+    const osMaterial = Buffer.from("desktop-only-material");
+    sealLegacyOsBoundStore(
+      tempDir,
+      { "account.session.v1": "session-json", "linear.token.v1": "lin_secret" },
+      osMaterial,
+    );
+
+    const brain = new EncryptedFileCredentialStore({
       secretsDir: tempDir,
-      keyMaterial: { read: () => Buffer.from("os-material-A") },
+      keyMaterial: { read: () => null },
     });
-    expect(recovered.getSync("agent.token")).toBe("secret");
+    brain.setSync("sync.bootstrapToken.v1", "fresh-token");
+    expect(brain.getSync("account.session.v1")).toBeNull();
+    expect(readQuarantineMarker(tempDir).recoverable).toBe(true);
+
+    const desktop = new EncryptedFileCredentialStore({
+      secretsDir: tempDir,
+      keyMaterial: { read: () => osMaterial },
+    });
+    expect(desktop.getSync("account.session.v1")).toBe("session-json");
+
+    // Recovered into the live store, so the brain sees it too...
+    expect(brain.getSync("account.session.v1")).toBe("session-json");
+    expect(brain.getSync("linear.token.v1")).toBe("lin_secret");
+    // ...without losing what the brain wrote after the quarantine...
+    expect(brain.getSync("sync.bootstrapToken.v1")).toBe("fresh-token");
+    // ...and the recovered copy is not left decryptable on disk.
+    expect(fs.existsSync(path.join(tempDir, "credentials.json.enc.quarantine.json"))).toBe(false);
+    expect(fs.readdirSync(tempDir).filter((entry) => entry.includes(".quarantined-"))).toEqual([]);
+  });
+
+  it("never resurrects a quarantined value the live store has already replaced", () => {
+    const osMaterial = Buffer.from("desktop-only-material");
+    sealLegacyOsBoundStore(tempDir, { "account.session.v1": "old-session" }, osMaterial);
+
+    const brain = new EncryptedFileCredentialStore({
+      secretsDir: tempDir,
+      keyMaterial: { read: () => null },
+    });
+    brain.setSync("account.session.v1", "session-signed-in-again");
+
+    const desktop = new EncryptedFileCredentialStore({
+      secretsDir: tempDir,
+      keyMaterial: { read: () => osMaterial },
+    });
+    expect(desktop.getSync("account.session.v1")).toBe("session-signed-in-again");
+  });
+
+  it("stops promising a repair once the process holding the key has tried and failed", () => {
+    // The destroyed-keychain-item case: the store is os-sealed, the item is
+    // gone, so NOTHING on this Mac opens it. Telling the user to open the app
+    // is only right until the app has tried.
+    sealLegacyOsBoundStore(tempDir, { "account.session.v1": "session-json" }, Buffer.from("gone"));
+    new EncryptedFileCredentialStore({
+      secretsDir: tempDir,
+      keyMaterial: { read: () => null },
+    }).setSync("sync.bootstrapToken.v1", "fresh-token");
+    expect(readQuarantineMarker(tempDir).recoverable).toBe(true);
+
+    const desktop = new EncryptedFileCredentialStore({
+      secretsDir: tempDir,
+      keyMaterial: { read: () => Buffer.from("a-different-item") },
+    });
+    expect(desktop.getSync("account.session.v1")).toBeNull();
+
+    const marker = readQuarantineMarker(tempDir);
+    expect(marker.recoverable).toBe(false);
+    // The ciphertext itself is kept for diagnostics rather than deleted.
+    expect(fs.existsSync(path.join(tempDir, marker.file))).toBe(true);
+  });
+
+  it("survives a key-material read that throws, on both the sync and async paths", async () => {
+    // Windows: every DPAPI failure — including a transient PowerShell cold-start
+    // timeout — throws out of the material read. That exception used to travel
+    // straight out of getSync, and on the brain's startup path an exception is a
+    // process exit and a launchd/Task Scheduler restart loop.
+    const failing = {
+      read: (): Buffer | null => {
+        throw new Error("Windows DPAPI credential protection timed out.");
+      },
+      readAsync: async (): Promise<Buffer | null> => {
+        throw new Error("Windows DPAPI credential protection timed out.");
+      },
+    };
+    const store = new EncryptedFileCredentialStore({ secretsDir: tempDir, keyMaterial: failing });
+
+    expect(() => store.setSync("sync.bootstrapToken.v1", "token")).not.toThrow();
+    expect(store.getSync("sync.bootstrapToken.v1")).toBe("token");
+    await expect(store.get("sync.bootstrapToken.v1")).resolves.toBe("token");
+  });
+
+  it("repairSync converges and recovers on demand, and reports what it found", () => {
+    const osMaterial = Buffer.from("desktop-only-material");
+    sealLegacyOsBoundStore(tempDir, { "account.session.v1": "session-json" }, osMaterial);
+    new EncryptedFileCredentialStore({
+      secretsDir: tempDir,
+      keyMaterial: { read: () => null },
+    }).setSync("sync.bootstrapToken.v1", "fresh-token");
+
+    const desktop = new EncryptedFileCredentialStore({
+      secretsDir: tempDir,
+      keyMaterial: { read: () => osMaterial },
+    });
+    const repair = desktop.repairSync();
+
+    expect(repair.state).toBe("available");
+    expect(repair.reason).toBeNull();
+    expect(repair.recoveredKeys).toBe(1);
+    expect(repair.quarantine).toBeNull();
+    expect(desktop.getSync("account.session.v1")).toBe("session-json");
+  });
+
+  it("keeps an unrecoverable quarantine for diagnostics and reports it", () => {
+    const store = new EncryptedFileCredentialStore({ secretsDir: tempDir });
+    store.setSync("agent.token", "secret");
+    fs.writeFileSync(path.join(tempDir, ".machine-key"), `${Buffer.alloc(32, 7).toString("base64")}\n`);
+    store.setSync("agent.token", "after");
+
+    const health = inspectCredentialStoreHealth({
+      credentialsPath: path.join(tempDir, "credentials.json.enc"),
+      machineKeyPath: path.join(tempDir, ".machine-key"),
+      keyMaterial: { read: () => null },
+    });
+    expect(health.state).toBe("available");
+    expect(health.sealedBinding).toBe("machine");
+    expect(health.quarantine?.recoverable).toBe(false);
+    expect(fs.existsSync(path.join(tempDir, health.quarantine!.file))).toBe(true);
+  });
+
+  it("inspects a store without creating a machine key", () => {
+    const health = inspectCredentialStoreHealth({
+      credentialsPath: path.join(tempDir, "credentials.json.enc"),
+      machineKeyPath: path.join(tempDir, ".machine-key"),
+      keyMaterial: { read: () => null },
+    });
+
+    expect(health.state).toBe("missing");
+    expect(health.reason).toBeNull();
+    expect(fs.existsSync(path.join(tempDir, ".machine-key"))).toBe(false);
+  });
+
+  it("reports an os-sealed store this process cannot open, without touching it", () => {
+    sealLegacyOsBoundStore(tempDir, { "agent.token": "secret" }, Buffer.from("peer-material"));
+    const credentialsPath = path.join(tempDir, "credentials.json.enc");
+    const before = fs.readFileSync(credentialsPath, "utf8");
+
+    const health = inspectCredentialStoreHealth({
+      credentialsPath,
+      machineKeyPath: path.join(tempDir, ".machine-key"),
+      keyMaterial: { read: () => null },
+    });
+
+    expect(health.state).toBe("unreadable");
+    expect(health.reason).toBe("no_os_key_material");
+    expect(fs.readFileSync(credentialsPath, "utf8")).toBe(before);
   });
 });
 
@@ -590,10 +870,7 @@ describe("ElectronSafeStorageCredentialStore", () => {
     const legacyPath = path.join(tempDir, "credentials.json.enc");
     const machineKeyPath = path.join(tempDir, ".machine-key");
     const safePath = path.join(tempDir, "credentials.safe.enc");
-    new EncryptedFileCredentialStore({
-      secretsDir: tempDir,
-      keyMaterial: { read: () => Buffer.from("os-material-A") },
-    }).setSync("linear.token.v1", "lin_secret");
+    sealLegacyOsBoundStore(tempDir, { "linear.token.v1": "lin_secret" }, Buffer.from("os-material-A"));
     const ciphertextBefore = fs.readFileSync(legacyPath, "utf8");
     const machineKeyBefore = fs.readFileSync(machineKeyPath, "utf8");
 

--- a/apps/ade-cli/src/services/credentials/credentialStore.test.ts
+++ b/apps/ade-cli/src/services/credentials/credentialStore.test.ts
@@ -13,7 +13,9 @@ import {
   createDefaultCredentialStore,
   inspectCredentialStoreHealth,
   isFileBackedCredentialKey,
+  readCredentialStoreQuarantine,
 } from "./credentialStore";
+import { quarantineCredentialFile } from "./credentialStoreQuarantine";
 import {
   ACCOUNT_SESSION_CREDENTIAL_KEY,
   ACCOUNT_SESSION_ROTATION_JOURNAL_KEY,
@@ -685,6 +687,37 @@ new EncryptedFileCredentialStore({ secretsDir }).setSync(key, value);
     expect(marker.recoverable).toBe(false);
     // The ciphertext itself is kept for diagnostics rather than deleted.
     expect(fs.existsSync(path.join(tempDir, marker.file))).toBe(true);
+  });
+
+  it("quarantines by copying, leaving the original for the caller's atomic write", () => {
+    // Windows cannot rename or delete a file while any handle to it is open, so
+    // a peer process mid-read turns a rename into EPERM/EACCES/EBUSY — and this
+    // path throwing is the crash loop quarantine exists to prevent. Copying
+    // leaves the original for the ordinary atomic write to replace, which is an
+    // operation every credential write already performs.
+    const credentialsPath = path.join(tempDir, "credentials.json.enc");
+    fs.mkdirSync(tempDir, { recursive: true });
+    fs.writeFileSync(credentialsPath, "ciphertext-that-cannot-be-read", "utf8");
+
+    const record = quarantineCredentialFile({
+      credentialsPath,
+      reason: "no_os_key_material",
+      recoverable: true,
+    });
+
+    expect(record?.recoverable).toBe(true);
+    expect(fs.readFileSync(credentialsPath, "utf8")).toBe("ciphertext-that-cannot-be-read");
+    expect(fs.readFileSync(path.join(tempDir, record!.file), "utf8"))
+      .toBe("ciphertext-that-cannot-be-read");
+    expect(readCredentialStoreQuarantine(credentialsPath)).toEqual(record);
+    // Nothing to set aside is not a failure: a peer may have replaced the file
+    // between the failed read and this call.
+    fs.unlinkSync(credentialsPath);
+    expect(quarantineCredentialFile({
+      credentialsPath,
+      reason: "decrypt_failure",
+      recoverable: false,
+    })).toBeNull();
   });
 
   it("quarantines an unreadable store exactly once, however the write ends", () => {

--- a/apps/ade-cli/src/services/credentials/credentialStore.test.ts
+++ b/apps/ade-cli/src/services/credentials/credentialStore.test.ts
@@ -687,6 +687,23 @@ new EncryptedFileCredentialStore({ secretsDir }).setSync(key, value);
     expect(fs.existsSync(path.join(tempDir, marker.file))).toBe(true);
   });
 
+  it("quarantines an unreadable store exactly once, however the write ends", () => {
+    const store = new EncryptedFileCredentialStore({ secretsDir: tempDir });
+    store.setSync("agent.token", "secret");
+    fs.writeFileSync(path.join(tempDir, ".machine-key"), `${Buffer.alloc(32, 3).toString("base64")}\n`);
+
+    // Neither of these reaches a write: delete finds no key, and the updater
+    // declines. Both still have to leave the store in a readable state, or the
+    // next call quarantines the same file again — one copy per attempt.
+    store.deleteSync("agent.token");
+    store.updateSync(() => false);
+    store.setSync("agent.token", "after");
+
+    const quarantined = fs.readdirSync(tempDir).filter((entry) => entry.includes(".quarantined-"));
+    expect(quarantined).toHaveLength(1);
+    expect(store.getSync("agent.token")).toBe("after");
+  });
+
   it("survives a key-material read that throws, on both the sync and async paths", async () => {
     // Windows: every DPAPI failure — including a transient PowerShell cold-start
     // timeout — throws out of the material read. That exception used to travel

--- a/apps/ade-cli/src/services/credentials/credentialStore.ts
+++ b/apps/ade-cli/src/services/credentials/credentialStore.ts
@@ -31,6 +31,7 @@ import {
 import {
   invalidateDefaultOsBoundKeyMaterialCache,
   platformSupportsOsBoundKeyMaterial,
+  readExistingOsBoundKeyMaterial,
   readDefaultOsBoundKeyMaterial,
   readDefaultOsBoundKeyMaterialAsync,
 } from "./osBoundKeyMaterial";
@@ -100,6 +101,17 @@ export {
 
 /** Bounds how often a store re-stats the quarantine marker on a clean read. */
 const QUARANTINE_PROBE_INTERVAL_MS = 5_000;
+/**
+ * Lock budget for the deferred, best-effort rebind off the asynchronous read.
+ *
+ * The lock is acquired with a synchronous `Atomics.wait` spin, so whatever this
+ * value is, the event loop stops for it — and the process that reaches this
+ * path is the desktop main process, where that means IPC stops. The full 15 s
+ * peer timeout is the wrong budget for work nobody is waiting on: if a peer
+ * holds the lock right now, skipping costs nothing, because the next read
+ * converges the store anyway.
+ */
+const REBIND_LOCK_TIMEOUT_MS = 250;
 
 export type SyncCredentialStore = CredentialStore & {
   getSync(key: string): string | null;
@@ -417,6 +429,17 @@ function isSameKeyMaterial(left: Buffer | null, right: Buffer | null): boolean {
  */
 export type CredentialKeyMaterialSource = {
   read(keyBindingDir: string): Buffer | null;
+  /**
+   * Could SOME process on this machine hold OS material for this store, even if
+   * this one cannot? It decides whether ciphertext this process cannot open is
+   * classified as recoverable-by-a-peer or as corruption.
+   *
+   * A property of the material source, not of the store — and injected rather
+   * than read from `process.platform` at the point of use, because otherwise the
+   * classification depends on the host the code happens to run on and cannot be
+   * exercised on any other. Defaults to `platformSupportsOsBoundKeyMaterial()`.
+   */
+  peerMayHoldMaterial?: boolean;
   /** Defaults to an asynchronous wrapper around `read()`. */
   readAsync?(keyBindingDir: string): Promise<Buffer | null>;
   /**
@@ -430,6 +453,17 @@ const DEFAULT_KEY_MATERIAL_SOURCE: Required<CredentialKeyMaterialSource> = {
   read: readDefaultOsBoundKeyMaterial,
   readAsync: readDefaultOsBoundKeyMaterialAsync,
   invalidate: invalidateDefaultOsBoundKeyMaterialCache,
+  peerMayHoldMaterial: platformSupportsOsBoundKeyMaterial(),
+};
+
+/**
+ * The source a health check uses: read-only, so inspecting a store can never
+ * mint a keychain item or a DPAPI key file, and never spends the platform's
+ * create budget doing it.
+ */
+const INSPECTION_KEY_MATERIAL_SOURCE: CredentialKeyMaterialSource = {
+  read: readExistingOsBoundKeyMaterial,
+  peerMayHoldMaterial: platformSupportsOsBoundKeyMaterial(),
 };
 
 type CredentialDecodeAttempt =
@@ -467,6 +501,7 @@ function decodeCredentialStore(
   raw: Record<string, unknown> | null,
   machineKey: Buffer,
   material: Buffer | null,
+  peerMayHoldMaterial: boolean,
 ): CredentialDecodeAttempt {
   if (raw == null || Object.keys(raw).length === 0) {
     return { ok: true, values: {}, sealedBinding: "machine" };
@@ -511,9 +546,7 @@ function decodeCredentialStore(
   // for — every store sealed before the field existed — so it has to guess. It
   // guesses "a peer may hold the key", because being wrong that way costs a
   // marker nobody acts on, while the other way costs the user their session.
-  const mayBeOsSealed = !hasOsKey
-    && declared !== "machine"
-    && platformSupportsOsBoundKeyMaterial();
+  const mayBeOsSealed = !hasOsKey && declared !== "machine" && peerMayHoldMaterial;
   return {
     ok: false,
     error: lastError,
@@ -534,9 +567,15 @@ function retryDecodeWithRefreshedKeyMaterial(args: {
   machineKey: Buffer;
   previous: Buffer | null;
   refreshed: Buffer | null;
+  peerMayHoldMaterial: boolean;
 }): CredentialDecodeAttempt | null {
   if (isSameKeyMaterial(args.refreshed, args.previous)) return null;
-  const retried = decodeCredentialStore(args.raw, args.machineKey, args.refreshed);
+  const retried = decodeCredentialStore(
+    args.raw,
+    args.machineKey,
+    args.refreshed,
+    args.peerMayHoldMaterial,
+  );
   return retried.ok ? retried : null;
 }
 
@@ -597,7 +636,7 @@ export function inspectCredentialStoreHealth(args: {
       sealedBinding: null,
     };
   }
-  const keyMaterial = args.keyMaterial ?? DEFAULT_KEY_MATERIAL_SOURCE;
+  const keyMaterial = args.keyMaterial ?? INSPECTION_KEY_MATERIAL_SOURCE;
   let material: Buffer | null;
   try {
     material = keyMaterial.read(path.dirname(args.machineKeyPath));
@@ -606,7 +645,12 @@ export function inspectCredentialStoreHealth(args: {
     // and a diagnostic that throws tells the user nothing.
     material = null;
   }
-  const attempt = decodeCredentialStore(raw, machineKey, material);
+  const attempt = decodeCredentialStore(
+    raw,
+    machineKey,
+    material,
+    keyMaterial.peerMayHoldMaterial ?? platformSupportsOsBoundKeyMaterial(),
+  );
   return attempt.ok
     ? {
       ...base,
@@ -635,10 +679,13 @@ export class EncryptedFileCredentialStore implements SyncCredentialStore {
   private readonly credentialChangePollIntervalMs: number | null;
   private readonly credentialFileWatchers = new Set<CredentialFileStatWatcher>();
   private readonly invalidateKeyMaterial: (() => void) | null;
+  private readonly peerMayHoldOsMaterial: boolean;
   private lastReadState: CredentialStoreReadState = "missing";
   private lastReadFailureReason: CredentialStoreReadFailureReason | null = null;
   private lastKeyMaterialSelfHealAt = 0;
   private lastQuarantineProbeAt = 0;
+  private pendingRebind: NodeJS.Timeout | null = null;
+  private lastAsyncKeyMaterial: Buffer | null = null;
 
   constructor(args: {
     secretsDir?: string;
@@ -688,6 +735,8 @@ export class EncryptedFileCredentialStore implements SyncCredentialStore {
     this.invalidateKeyMaterial = keyMaterial.invalidate
       ? () => keyMaterial.invalidate?.(keyBindingDir)
       : null;
+    this.peerMayHoldOsMaterial = keyMaterial.peerMayHoldMaterial
+      ?? platformSupportsOsBoundKeyMaterial();
     this.credentialChangePollIntervalMs = args.credentialChangePollIntervalMs === undefined
       ? CREDENTIAL_CHANGE_POLL_INTERVAL_MS
       : args.credentialChangePollIntervalMs;
@@ -876,7 +925,7 @@ export class EncryptedFileCredentialStore implements SyncCredentialStore {
     }
     const machineKey = readOrCreateMachineKey(this.machineKeyPath);
     const material = this.readKeyMaterial();
-    let attempt = decodeCredentialStore(raw, machineKey, material);
+    let attempt = decodeCredentialStore(raw, machineKey, material, this.peerMayHoldOsMaterial);
     if (
       !attempt.ok
       && attempt.reason !== "store_format"
@@ -904,6 +953,7 @@ export class EncryptedFileCredentialStore implements SyncCredentialStore {
         machineKey,
         previous: material,
         refreshed: this.readKeyMaterial(),
+        peerMayHoldMaterial: this.peerMayHoldOsMaterial,
       });
       if (retried) attempt = retried;
     }
@@ -1005,6 +1055,7 @@ export class EncryptedFileCredentialStore implements SyncCredentialStore {
         readQuarantinedStoreFile(this.credentialsPath, record),
         machineKey,
         material,
+        this.peerMayHoldOsMaterial,
       );
     } catch {
       return null;
@@ -1087,7 +1138,7 @@ export class EncryptedFileCredentialStore implements SyncCredentialStore {
     }
     const machineKey = await readOrCreateMachineKeyAsync(this.machineKeyPath);
     const material = await this.readKeyMaterialAsync();
-    let attempt = decodeCredentialStore(raw, machineKey, material);
+    let attempt = decodeCredentialStore(raw, machineKey, material, this.peerMayHoldOsMaterial);
     if (
       !attempt.ok
       && attempt.reason !== "store_format"
@@ -1098,6 +1149,7 @@ export class EncryptedFileCredentialStore implements SyncCredentialStore {
         machineKey,
         previous: material,
         refreshed: await this.readKeyMaterialAsync(),
+        peerMayHoldMaterial: this.peerMayHoldOsMaterial,
       });
       if (retried) attempt = retried;
     }
@@ -1111,7 +1163,7 @@ export class EncryptedFileCredentialStore implements SyncCredentialStore {
     }
     this.lastReadState = "available";
     this.lastReadFailureReason = null;
-    if (attempt.sealedBinding !== "machine") this.rebindToMachineKeyUnderLock(material);
+    if (attempt.sealedBinding !== "machine") this.scheduleRebindToMachineKey(material);
     return attempt.values;
   }
 
@@ -1126,6 +1178,38 @@ export class EncryptedFileCredentialStore implements SyncCredentialStore {
       this.credentialsPath,
       `${JSON.stringify(serializeStore(values, machineKey, "machine"), null, 2)}\n`,
     );
+  }
+
+  /**
+   * Runs the rebind after the awaited read has returned.
+   *
+   * `rebindToMachineKeyUnderLock` acquires the file lock with a synchronous
+   * spin, so calling it inline from the asynchronous path made the read block
+   * the event loop until the lock was free. Nobody is waiting on this work — the
+   * caller already has its plaintext values — so it goes off the awaited path
+   * and takes a short lock budget instead of the peer timeout.
+   */
+  private scheduleRebindToMachineKey(material: Buffer | null): void {
+    if (this.pendingRebind) clearTimeout(this.pendingRebind);
+    this.lastAsyncKeyMaterial = material;
+    const timer = setTimeout(() => {
+      this.pendingRebind = null;
+      this.rebindToMachineKeyUnderLock(material);
+    }, 0);
+    timer.unref?.();
+    this.pendingRebind = timer;
+  }
+
+  /**
+   * Runs a scheduled rebind now instead of on the next tick, the same way
+   * `checkForChangesNow()` runs the production poller's comparison without
+   * waiting for its interval.
+   */
+  flushPendingRebindNow(): void {
+    if (!this.pendingRebind) return;
+    clearTimeout(this.pendingRebind);
+    this.pendingRebind = null;
+    this.rebindToMachineKeyUnderLock(this.lastAsyncKeyMaterial);
   }
 
   /**
@@ -1147,17 +1231,23 @@ export class EncryptedFileCredentialStore implements SyncCredentialStore {
       this.withLock(() => {
         const machineKey = readOrCreateMachineKey(this.machineKeyPath);
         const raw = readJsonObject(this.credentialsPath);
-        const attempt = decodeCredentialStore(raw, machineKey, material);
+        const attempt = decodeCredentialStore(
+          raw,
+          machineKey,
+          material,
+          this.peerMayHoldOsMaterial,
+        );
         if (!attempt.ok || attempt.sealedBinding === "machine") return;
         this.writeAll(attempt.values);
-      });
+      }, { timeoutMs: REBIND_LOCK_TIMEOUT_MS });
     } catch {
-      // Preserve read compatibility if the rebind cannot happen right now.
+      // A peer holds the lock, or the rebind failed: the ciphertext still reads
+      // as it is, and the next read converges it.
     }
   }
 
-  private withLock<T>(fn: () => T): T {
-    return withCredentialFileLock(this.lockPath, fn);
+  private withLock<T>(fn: () => T, options: { timeoutMs?: number } = {}): T {
+    return withCredentialFileLock(this.lockPath, fn, options);
   }
 }
 

--- a/apps/ade-cli/src/services/credentials/credentialStore.ts
+++ b/apps/ade-cli/src/services/credentials/credentialStore.ts
@@ -3,8 +3,8 @@ import fs from "node:fs";
 import path from "node:path";
 import { resolveMachineAdeLayout } from "../projects/machineLayout";
 import {
-  expectsOsBoundKeyMaterial,
   invalidateDefaultOsBoundKeyMaterialCache,
+  platformSupportsOsBoundKeyMaterial,
   readDefaultOsBoundKeyMaterial,
   readDefaultOsBoundKeyMaterialAsync,
 } from "./osBoundKeyMaterial";
@@ -18,6 +18,36 @@ export interface CredentialStore {
 export type CredentialStoreReadState = "available" | "missing" | "unreadable";
 
 /**
+ * Which key sealed a stored envelope.
+ *
+ * `machine` is the bare `.machine-key` file next to the ciphertext. `os` is that
+ * key stretched with OS-held material (macOS keychain item / Windows DPAPI blob).
+ *
+ * ADE only ever WRITES `machine` for this store, and the reason is the whole
+ * point of this module: `credentials.json.enc` is co-owned by processes that do
+ * not have equal access to OS-held material. The ADE brain runs as a launchd
+ * agent (or a Windows scheduled task) with no UI, so a keychain item whose ACL
+ * belongs to the desktop app cannot be read by it — `security` fails closed and
+ * the brain derives the bare machine key. The desktop app, meanwhile, reads that
+ * item fine. A store sealed by either process under ITS binding is unreadable by
+ * the other, and for the brain that used to mean a decrypt throw on every
+ * startup, forever.
+ *
+ * `os` therefore survives only as a READ capability, so stores sealed by older
+ * builds still open and can be converged back to `machine`. There is no writer.
+ *
+ * What that costs: an attacker who copies `~/.ade/secrets` off the machine gets
+ * the ciphertext AND the key beside it. That was already true of every other
+ * secret in that directory (`machine-identity-signing.json`,
+ * `sync-cloud-relay.json` are plain JSON), and OS binding never protected
+ * against the realistic attacker — anyone running as this user can ask the
+ * keychain or DPAPI for the material directly. Single-writer secrets that want
+ * real OS protection have a home already: the Electron-only safeStorage store
+ * below.
+ */
+export type CredentialStoreBinding = "machine" | "os";
+
+/**
  * Why the last synchronous read could not produce values. Coarse by design: it
  * is surfaced to product analytics so field incidence of the "brain cannot read
  * the credential file the app just wrote" class becomes measurable.
@@ -26,14 +56,32 @@ export type CredentialStoreReadFailureReason =
   /** The ciphertext exists but no available key decrypts it. */
   | "decrypt_failure"
   /**
-   * OS-held key material was expected but the key was derived without it. On
-   * darwin that is an unreadable keychain item; on win32 a DPAPI failure throws
-   * out of the read instead of returning null, so it never lands here. The name
-   * stays platform-neutral because the condition it describes is.
+   * The envelope was sealed with OS-held key material this process cannot
+   * obtain — an older build's `os` binding, read by a process (typically the
+   * brain) that the keychain will not answer for. A PEER process may still be
+   * able to open it, which is why this reason never counts as corruption.
    */
   | "no_os_key_material"
   /** The file exists but is not a recognised credential envelope. */
   | "store_format";
+
+/**
+ * A credential file that could not be read and was moved aside so the process
+ * that hit it could keep running.
+ *
+ * `recoverable` means a peer process may still hold the key (an `os`-sealed
+ * store quarantined by the brain, which the desktop app can open). Those are
+ * merged back automatically by the first store instance that can decrypt them —
+ * see `recoverQuarantinedStore`. Anything else is kept purely for diagnostics.
+ */
+export type CredentialStoreQuarantineRecord = {
+  version: 1;
+  at: string;
+  /** Basename of the quarantined ciphertext, in the same directory. */
+  file: string;
+  reason: CredentialStoreReadFailureReason;
+  recoverable: boolean;
+};
 
 export type SyncCredentialStore = CredentialStore & {
   getSync(key: string): string | null;
@@ -52,6 +100,18 @@ export type SyncCredentialStore = CredentialStore & {
 type StoredCredentialEnvelope = {
   version: 1;
   alg: "aes-256-gcm";
+  /**
+   * Which key sealed this file. Absent on envelopes written before ADE recorded
+   * it, which is why every reader still has to be able to try both keys.
+   *
+   * Deliberately OUTSIDE the AAD and on `version: 1`: a build that predates this
+   * field must keep decrypting files this one writes, or a downgrade turns into
+   * the same dead-brain incident this field exists to end. That makes it an
+   * unauthenticated hint, and it is safe as one — AES-GCM decides whether a key
+   * is right, so a tampered hint can only cost a wasted decrypt attempt, never
+   * accept the wrong key.
+   */
+  binding?: CredentialStoreBinding;
   iv: string;
   tag: string;
   ciphertext: string;
@@ -142,6 +202,15 @@ const LOCK_RETRY_MS = 25;
 const CREDENTIAL_CHANGE_POLL_INTERVAL_MS = 250;
 /** Bounds OS key-material re-reads when a store keeps failing to decrypt. */
 const KEY_MATERIAL_SELF_HEAL_INTERVAL_MS = 30_000;
+/**
+ * How long a recoverable quarantine keeps being retried before ADE stops
+ * expecting a peer to turn up with the key. Generous on purpose: the peer here
+ * is usually "the user opens the desktop app", which can be a fortnight away on
+ * a machine that only runs the brain.
+ */
+const QUARANTINE_RETENTION_MS = 30 * 24 * 60 * 60 * 1_000;
+/** Bounds how often a store re-stats the quarantine marker on a clean read. */
+const QUARANTINE_PROBE_INTERVAL_MS = 5_000;
 
 type CredentialLockMetadata = {
   pid?: number;
@@ -469,6 +538,17 @@ function isStoredCredentialEnvelope(value: unknown): value is StoredCredentialEn
     && typeof candidate.ciphertext === "string";
 }
 
+/**
+ * The declared binding, or null when the envelope predates the field.
+ *
+ * An unrecognised value is read as "not declared" rather than rejected: the hint
+ * is advisory, and a future binding name must not make an otherwise valid file
+ * unreadable to this build.
+ */
+function readDeclaredBinding(raw: StoredCredentialEnvelope): CredentialStoreBinding | null {
+  return raw.binding === "machine" || raw.binding === "os" ? raw.binding : null;
+}
+
 function isStoredCredentialEnvelopeBuffer(value: Buffer): boolean {
   try {
     return isStoredCredentialEnvelope(JSON.parse(value.toString("utf8")) as unknown);
@@ -500,7 +580,11 @@ export function isElectronSafeStorageCredentialFile(credentialsPath: string): bo
   }
 }
 
-function serializeStore(values: Record<string, string>, machineKey: Buffer): StoredCredentialEnvelope {
+function serializeStore(
+  values: Record<string, string>,
+  machineKey: Buffer,
+  binding: CredentialStoreBinding,
+): StoredCredentialEnvelope {
   const iv = crypto.randomBytes(12);
   const cipher = crypto.createCipheriv("aes-256-gcm", machineKey, iv);
   cipher.setAAD(STORE_AAD);
@@ -511,6 +595,7 @@ function serializeStore(values: Record<string, string>, machineKey: Buffer): Sto
   return {
     version: 1,
     alg: "aes-256-gcm",
+    binding,
     iv: iv.toString("base64"),
     tag: cipher.getAuthTag().toString("base64"),
     ciphertext: ciphertext.toString("base64"),
@@ -649,52 +734,90 @@ type CredentialDecodeAttempt =
   | {
     ok: true;
     values: Record<string, string>;
-    /** The key the store SHOULD be sealed with, whichever one actually read it. */
-    key: Buffer;
-    rewriteWithCurrentKey: boolean;
+    /** Which key actually opened it, so the caller knows whether to re-seal. */
+    sealedBinding: CredentialStoreBinding;
   }
-  | { ok: false; error: unknown; osBound: boolean; reason: CredentialStoreReadFailureReason };
+  | {
+    ok: false;
+    error: unknown;
+    reason: CredentialStoreReadFailureReason;
+    /**
+     * True when a PEER process on this machine plausibly holds the key: the
+     * envelope is (or may be) `os`-sealed and this process has no OS material.
+     * Callers must never treat these as corruption — the desktop app opening
+     * them is exactly how an already-broken machine heals itself.
+     */
+    recoverableByPeer: boolean;
+  };
 
 /**
- * One decrypt attempt for a given piece of OS key material.
+ * One decrypt attempt against the keys this process can actually derive.
  *
- * The os-bound key is tried first; a failure there falls back to the bare
- * machine key so genuine legacy ciphertext can be rewritten. If that fallback
- * also fails the ciphertext is left untouched — a rotated/foreign key must
- * never cause an empty store to be written over real credentials.
+ * Both keys are tried whenever both exist, ordered by the envelope's declared
+ * binding, because the previous version's fixed "os key, then machine key"
+ * order was the trapdoor: a process WITH keychain material could open a
+ * machine-sealed store through the fallback and then re-seal it `os`, while a
+ * process WITHOUT material had no fallback at all and was locked out for good.
+ * Reading is symmetric now, and the only re-seal direction is toward `machine`
+ * — the binding every co-owner of this file can derive.
  */
 function decodeCredentialStore(
   raw: Record<string, unknown> | null,
   machineKey: Buffer,
   material: Buffer | null,
 ): CredentialDecodeAttempt {
-  const formatIsUnsupported = raw != null
-    && Object.keys(raw).length > 0
-    && !isStoredCredentialEnvelope(raw);
-  const key = deriveOsBoundCredentialKey(machineKey, material);
-  const osBound = !key.equals(machineKey);
-  // The os-bound key first, then the bare machine key. Anything decrypted by a
-  // later candidate is genuine legacy ciphertext and may be rewritten.
-  const candidates = osBound ? [key, machineKey] : [machineKey];
+  if (raw == null || Object.keys(raw).length === 0) {
+    return { ok: true, values: {}, sealedBinding: "machine" };
+  }
+  if (!isStoredCredentialEnvelope(raw)) {
+    return {
+      ok: false,
+      error: new Error("Unsupported ADE credential store format."),
+      reason: "store_format",
+      recoverableByPeer: false,
+    };
+  }
+  const declared = readDeclaredBinding(raw);
+  const osKey = deriveOsBoundCredentialKey(machineKey, material);
+  const hasOsKey = !osKey.equals(machineKey);
+  const osCandidate: Array<{ key: Buffer; binding: CredentialStoreBinding }> = hasOsKey
+    ? [{ key: osKey, binding: "os" }]
+    : [];
+  const machineCandidate = { key: machineKey, binding: "machine" as const };
+  // Declared binding only picks the order. A wrong hint costs one extra
+  // decrypt, never a false "unreadable".
+  const candidates = declared === "machine"
+    ? [machineCandidate, ...osCandidate]
+    : [...osCandidate, machineCandidate];
   let lastError: unknown;
-  for (const [index, candidate] of candidates.entries()) {
+  for (const candidate of candidates) {
     try {
       return {
         ok: true,
-        values: deserializeStore(raw, candidate, { emptyOnDecryptFailure: false }),
-        key,
-        rewriteWithCurrentKey: index > 0,
+        values: deserializeStore(raw, candidate.key, { emptyOnDecryptFailure: false }),
+        sealedBinding: candidate.binding,
       };
     } catch (error) {
       lastError = error;
     }
   }
-  const reason: CredentialStoreReadFailureReason = formatIsUnsupported
-    ? "store_format"
-    : !osBound && expectsOsBoundKeyMaterial()
-      ? "no_os_key_material"
-      : "decrypt_failure";
-  return { ok: false, error: lastError, osBound, reason };
+  // No OS material here plus an envelope that is not declared machine-sealed is
+  // the launchd-brain case, not a broken file: say so, and let the caller keep
+  // the ciphertext for the peer that can open it.
+  //
+  // An undeclared binding is the common shape on the machines this fix exists
+  // for — every store sealed before the field existed — so it has to guess. It
+  // guesses "a peer may hold the key", because being wrong that way costs a
+  // marker nobody acts on, while the other way costs the user their session.
+  const mayBeOsSealed = !hasOsKey
+    && declared !== "machine"
+    && platformSupportsOsBoundKeyMaterial();
+  return {
+    ok: false,
+    error: lastError,
+    reason: mayBeOsSealed ? "no_os_key_material" : "decrypt_failure",
+    recoverableByPeer: mayBeOsSealed,
+  };
 }
 
 /**
@@ -715,6 +838,129 @@ function retryDecodeWithRefreshedKeyMaterial(args: {
   return retried.ok ? retried : null;
 }
 
+function quarantineMarkerPath(credentialsPath: string): string {
+  return `${credentialsPath}.quarantine.json`;
+}
+
+function isQuarantineRecord(value: unknown): value is CredentialStoreQuarantineRecord {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return false;
+  const record = value as Partial<CredentialStoreQuarantineRecord>;
+  return record.version === 1
+    && typeof record.at === "string"
+    && Number.isFinite(Date.parse(record.at))
+    && typeof record.file === "string"
+    // A marker names a sibling file, never a path: it is read by processes that
+    // may be less trusted than whatever wrote it, and following `../` out of the
+    // secrets directory is not a thing this format needs to support.
+    && record.file.length > 0
+    && !record.file.includes("/")
+    && !record.file.includes("\\")
+    && record.file !== "."
+    && record.file !== ".."
+    && (record.reason === "decrypt_failure"
+      || record.reason === "no_os_key_material"
+      || record.reason === "store_format")
+    && typeof record.recoverable === "boolean";
+}
+
+export function readCredentialStoreQuarantine(
+  credentialsPath: string,
+): CredentialStoreQuarantineRecord | null {
+  try {
+    const parsed = JSON.parse(
+      fs.readFileSync(quarantineMarkerPath(credentialsPath), "utf8"),
+    ) as unknown;
+    return isQuarantineRecord(parsed) ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Health of a credential file, read without touching it.
+ *
+ * Deliberately non-creating: `ade doctor` runs this on machines whose brain is
+ * already down, and a diagnostic that mints a machine key (or a keychain item)
+ * changes the very state it was asked to describe.
+ */
+export type CredentialStoreHealth = {
+  path: string;
+  exists: boolean;
+  state: CredentialStoreReadState;
+  reason: CredentialStoreReadFailureReason | null;
+  sealedBinding: CredentialStoreBinding | null;
+  /** The declared binding, even when the file could not be opened. */
+  declaredBinding: CredentialStoreBinding | null;
+  quarantine: CredentialStoreQuarantineRecord | null;
+};
+
+export function inspectCredentialStoreHealth(args: {
+  credentialsPath: string;
+  machineKeyPath: string;
+  keyMaterial?: CredentialKeyMaterialSource;
+}): CredentialStoreHealth {
+  const quarantine = readCredentialStoreQuarantine(args.credentialsPath);
+  const base = {
+    path: args.credentialsPath,
+    declaredBinding: null as CredentialStoreBinding | null,
+    quarantine,
+  };
+  let raw: Record<string, unknown> | null;
+  try {
+    raw = readJsonObject(args.credentialsPath);
+  } catch {
+    return { ...base, exists: true, state: "unreadable", reason: "store_format", sealedBinding: null };
+  }
+  if (!fs.existsSync(args.credentialsPath)) {
+    return { ...base, exists: false, state: "missing", reason: null, sealedBinding: null };
+  }
+  if (raw == null) {
+    // Valid JSON that is not an object (`readJsonObject` reports that as null).
+    return { ...base, exists: true, state: "unreadable", reason: "store_format", sealedBinding: null };
+  }
+  const declaredBinding = isStoredCredentialEnvelope(raw) ? readDeclaredBinding(raw) : null;
+  const machineKey = readMachineKeyIfExists(args.machineKeyPath);
+  if (!machineKey) {
+    // No key file at all next to real ciphertext: nothing on this machine can
+    // open it, and creating one here would only hide that.
+    return {
+      ...base,
+      declaredBinding,
+      exists: true,
+      state: "unreadable",
+      reason: "decrypt_failure",
+      sealedBinding: null,
+    };
+  }
+  const keyMaterial = args.keyMaterial ?? DEFAULT_KEY_MATERIAL_SOURCE;
+  let material: Buffer | null;
+  try {
+    material = keyMaterial.read(path.dirname(args.machineKeyPath));
+  } catch {
+    // Same reasoning as the store's own reader: a Windows DPAPI failure throws,
+    // and a diagnostic that throws tells the user nothing.
+    material = null;
+  }
+  const attempt = decodeCredentialStore(raw, machineKey, material);
+  return attempt.ok
+    ? {
+      ...base,
+      declaredBinding,
+      exists: true,
+      state: "available",
+      reason: null,
+      sealedBinding: attempt.sealedBinding,
+    }
+    : {
+      ...base,
+      declaredBinding,
+      exists: true,
+      state: "unreadable",
+      reason: attempt.reason,
+      sealedBinding: null,
+    };
+}
+
 export class EncryptedFileCredentialStore implements SyncCredentialStore {
   private readonly credentialsPath: string;
   private readonly machineKeyPath: string;
@@ -727,6 +973,7 @@ export class EncryptedFileCredentialStore implements SyncCredentialStore {
   private lastReadState: CredentialStoreReadState = "missing";
   private lastReadFailureReason: CredentialStoreReadFailureReason | null = null;
   private lastKeyMaterialSelfHealAt = 0;
+  private lastQuarantineProbeAt = 0;
 
   constructor(args: {
     secretsDir?: string;
@@ -744,10 +991,33 @@ export class EncryptedFileCredentialStore implements SyncCredentialStore {
     const keyBindingDir = path.dirname(this.machineKeyPath);
     this.lockPath = args.lockPath ?? defaultLockPath(this.credentialsPath);
     const keyMaterial = args.keyMaterial ?? DEFAULT_KEY_MATERIAL_SOURCE;
-    this.readKeyMaterial = () => keyMaterial.read(keyBindingDir);
-    this.readKeyMaterialAsync = async () => (
-      keyMaterial.readAsync ? keyMaterial.readAsync(keyBindingDir) : keyMaterial.read(keyBindingDir)
-    );
+    // A key-material read that THROWS must not escape a credential read. On
+    // Windows `readOrCreateWindowsDpapiMaterial` throws for every DPAPI failure
+    // — including a transient PowerShell cold-start timeout — and that
+    // exception used to travel straight out of `getSync`, which on the brain's
+    // startup path is a process exit and a launchd restart loop.
+    //
+    // Degrading to null is safe now in a way it was not before: no writer seals
+    // with OS material any more, so "no material" cannot silently re-seal a
+    // bound store unbound. It reads as `no_os_key_material`, which is the
+    // recoverable classification, and the next read that does get material
+    // merges anything that was set aside back in.
+    this.readKeyMaterial = () => {
+      try {
+        return keyMaterial.read(keyBindingDir);
+      } catch {
+        return null;
+      }
+    };
+    this.readKeyMaterialAsync = async () => {
+      try {
+        return keyMaterial.readAsync
+          ? await keyMaterial.readAsync(keyBindingDir)
+          : keyMaterial.read(keyBindingDir);
+      } catch {
+        return null;
+      }
+    };
     // An injected source owns its own cache lifetime, so self-heal is available
     // only when that source supplies the matching invalidation hook.
     this.invalidateKeyMaterial = keyMaterial.invalidate
@@ -779,10 +1049,11 @@ export class EncryptedFileCredentialStore implements SyncCredentialStore {
 
   getSync(key: string): string | null {
     const normalized = normalizeKey(key);
-    // Locked because the read may bind legacy ciphertext to the OS-bound key,
-    // and that rewrite has to exclude concurrent writers.
+    // Locked because the read may re-seal an `os`-bound store to the machine
+    // key (and merge a recovered quarantine back in), and those writes have to
+    // exclude concurrent writers.
     return this.withLock(
-      () => this.readAll({ allowRewrite: false, migrateLegacy: true })[normalized] ?? null,
+      () => this.readAll({ forWrite: false, rebind: true })[normalized] ?? null,
     );
   }
 
@@ -803,7 +1074,7 @@ export class EncryptedFileCredentialStore implements SyncCredentialStore {
       return;
     }
     this.withLock(() => {
-      const values = this.readAll({ allowRewrite: true });
+      const values = this.readAll({ forWrite: true });
       values[normalized] = nextValue;
       this.writeAll(values);
     });
@@ -812,7 +1083,7 @@ export class EncryptedFileCredentialStore implements SyncCredentialStore {
   deleteSync(key: string): void {
     const normalized = normalizeKey(key);
     this.withLock(() => {
-      const values = this.readAll({ allowRewrite: true });
+      const values = this.readAll({ forWrite: true });
       if (!(normalized in values)) return;
       delete values[normalized];
       this.writeAll(values);
@@ -843,7 +1114,7 @@ export class EncryptedFileCredentialStore implements SyncCredentialStore {
 
   updateSync(updater: (values: Record<string, string>) => boolean | void): void {
     this.withLock(() => {
-      const values = this.readAll({ allowRewrite: true });
+      const values = this.readAll({ forWrite: true });
       const shouldWrite = updater(values);
       if (shouldWrite !== false) {
         this.writeAll(values);
@@ -851,8 +1122,41 @@ export class EncryptedFileCredentialStore implements SyncCredentialStore {
     });
   }
 
+  /**
+   * What the "Can't read your sign-in" surface actually runs.
+   *
+   * Forces the two self-healing steps a read only performs opportunistically —
+   * converge an `os`-bound store to the machine key, and merge back anything a
+   * peer process quarantined — and reports what state that left the store in, so
+   * the caller can say "fixed" or "sign in again" instead of restarting a
+   * service and hoping.
+   */
+  repairSync(): {
+    state: CredentialStoreReadState;
+    reason: CredentialStoreReadFailureReason | null;
+    recoveredKeys: number;
+    quarantine: CredentialStoreQuarantineRecord | null;
+  } {
+    return this.withLock(() => {
+      // The probe throttle exists to keep ordinary reads cheap; an explicit
+      // repair is the one caller that must never be throttled out.
+      this.lastQuarantineProbeAt = 0;
+      const before = Object.keys(this.readAll({ forWrite: false, rebind: false })).length;
+      this.lastQuarantineProbeAt = 0;
+      const after = Object.keys(this.readAll({ forWrite: false, rebind: true })).length;
+      return {
+        state: this.lastReadState,
+        reason: this.lastReadFailureReason,
+        recoveredKeys: Math.max(0, after - before),
+        quarantine: readCredentialStoreQuarantine(this.credentialsPath),
+      };
+    });
+  }
+
   readAllForMigration(): Record<string, string> {
-    return this.readAll({ allowRewrite: false });
+    // No rebind: the migration may be about to delete this file entirely, and
+    // re-sealing it first would only be write amplification.
+    return this.readAll({ forWrite: false, rebind: false });
   }
 
   /**
@@ -866,15 +1170,45 @@ export class EncryptedFileCredentialStore implements SyncCredentialStore {
   }
 
   /**
-   * `migrateLegacy` binds pre-OS-bound ciphertext to the current key on a plain
-   * READ, not just on a write. Only callers that already hold this store's lock
-   * may pass it — the rewrite it performs is not itself locked.
+   * The one synchronous read. EVERY caller already holds this store's lock,
+   * because a read can write: it re-seals an `os`-bound store to the machine
+   * key, merges a recovered quarantine back in, and — in `forWrite` mode —
+   * quarantines ciphertext it cannot open.
+   *
+   * `forWrite` says a write follows. It never changes how the file is decoded,
+   * only what happens when decoding fails: a read can honestly report nothing,
+   * but a write about to persist `{}` over real credentials cannot, so it moves
+   * the unreadable file aside first. `rebind` opts out of the re-seal for a
+   * caller that is about to delete the file anyway.
    */
   private readAll(
-    args: { allowRewrite: boolean; migrateLegacy?: boolean },
+    args: { forWrite: boolean; rebind?: boolean },
   ): Record<string, string> {
     const credentialsExist = fs.existsSync(this.credentialsPath);
-    const raw = readJsonObject(this.credentialsPath);
+    let raw: Record<string, unknown> | null;
+    try {
+      raw = readJsonObject(this.credentialsPath);
+    } catch (error) {
+      return this.onUnreadable({
+        error,
+        reason: "store_format",
+        recoverableByPeer: false,
+        forWrite: args.forWrite,
+      });
+    }
+    if (credentialsExist && (raw == null || Object.keys(raw).length === 0)) {
+      // A file that exists but holds `{}`, `null`, or any non-object JSON.
+      // `readJsonObject` reports both as "no keys", which decodes as an empty
+      // store — and an empty store is writable, so a truncated or half-written
+      // file would be silently replaced. The asynchronous path has always
+      // rejected this shape; the synchronous one has to agree.
+      return this.onUnreadable({
+        error: new Error("Unsupported ADE credential store format."),
+        reason: "store_format",
+        recoverableByPeer: false,
+        forWrite: args.forWrite,
+      });
+    }
     const machineKey = readOrCreateMachineKey(this.machineKeyPath);
     const material = this.readKeyMaterial();
     let attempt = decodeCredentialStore(raw, machineKey, material);
@@ -909,26 +1243,223 @@ export class EncryptedFileCredentialStore implements SyncCredentialStore {
       if (retried) attempt = retried;
     }
     if (!attempt.ok) {
-      // Preserve the historical fail-closed empty read while exposing why the
-      // account record could not be obtained to publisher health.
-      this.lastReadState = "unreadable";
-      this.lastReadFailureReason = attempt.reason;
-      if (attempt.osBound || args.allowRewrite) throw attempt.error;
-      return {};
+      return this.onUnreadable({
+        error: attempt.error,
+        reason: attempt.reason,
+        recoverableByPeer: attempt.recoverableByPeer,
+        forWrite: args.forWrite,
+      });
     }
     this.lastReadState = credentialsExist ? "available" : "missing";
     this.lastReadFailureReason = null;
-    if (attempt.rewriteWithCurrentKey && (args.allowRewrite || args.migrateLegacy)) {
+    let values = attempt.values;
+    if (args.rebind !== false) {
+      // A store this process could open under the `os` binding is exactly the
+      // one a launchd brain cannot: converge it to the binding every co-owner
+      // derives. Only ever in this direction.
+      if (attempt.sealedBinding !== "machine") {
+        try {
+          this.writeAll(values);
+        } catch {
+          // Best effort — the ciphertext still reads as it is.
+        }
+      }
+      const recovered = this.recoverQuarantinedStore(values, machineKey, material);
+      if (recovered) values = recovered;
+    }
+    return values;
+  }
+
+  /**
+   * The single place an unopenable credential file is turned into a decision.
+   *
+   * A plain read reports nothing and says why. A read that a write depends on
+   * cannot do that — persisting `{}` would replace real credentials with an
+   * empty store — so it moves the ciphertext aside instead, records a marker,
+   * and lets the caller proceed on an empty base. Nothing is ever deleted: the
+   * "never write empty over real credentials" invariant is kept by preserving
+   * the bytes, not by refusing to run. Refusing is what crash-looped the brain.
+   */
+  private onUnreadable(args: {
+    error: unknown;
+    reason: CredentialStoreReadFailureReason;
+    recoverableByPeer: boolean;
+    forWrite: boolean;
+  }): Record<string, string> {
+    this.lastReadState = "unreadable";
+    this.lastReadFailureReason = args.reason;
+    if (!args.forWrite) return {};
+    // A failed quarantine is the one case that still has to fail closed: if the
+    // ciphertext could not be moved, writing would destroy it.
+    this.quarantineUnreadableStore(args.reason, args.recoverableByPeer, args.error);
+    return {};
+  }
+
+  /**
+   * Moves the unreadable ciphertext to a timestamped sibling and records a
+   * marker beside it. Caller holds the lock.
+   */
+  private quarantineUnreadableStore(
+    reason: CredentialStoreReadFailureReason,
+    recoverable: boolean,
+    cause: unknown,
+  ): void {
+    const at = new Date();
+    const stamp = at.toISOString().replace(/[:.]/g, "-");
+    const file = `${path.basename(this.credentialsPath)}.quarantined-${stamp}`;
+    const target = path.join(path.dirname(this.credentialsPath), file);
+    try {
+      fs.renameSync(this.credentialsPath, target);
+      ensureMode600(target);
+    } catch (error: unknown) {
+      if (isEnoent(error)) return; // A peer already moved or removed it.
+      throw new Error(
+        "ADE could not set aside the unreadable credential store, so it was left untouched.",
+        { cause: cause ?? error },
+      );
+    }
+    const record: CredentialStoreQuarantineRecord = {
+      version: 1,
+      at: at.toISOString(),
+      file,
+      reason,
+      recoverable,
+    };
+    try {
+      writeFileAtomic(
+        quarantineMarkerPath(this.credentialsPath),
+        `${JSON.stringify(record, null, 2)}\n`,
+      );
+    } catch {
+      // The marker only drives recovery and reporting; losing it must not fail
+      // the write that the quarantine just unblocked.
+    }
+    this.pruneExpiredQuarantineFiles();
+  }
+
+  /**
+   * Merges a previously quarantined store back in once some process on this
+   * machine can decrypt it.
+   *
+   * This is the automatic half of the fix for machines already in the broken
+   * state: the brain quarantines an `os`-sealed store it cannot read and boots
+   * clean, then the desktop app — which CAN read it — puts the account session
+   * back without anyone signing in again.
+   *
+   * Only keys the live store lacks are restored. The live values were written
+   * after the quarantine, so they win; a token the user has since replaced must
+   * not be resurrected. Returns the merged values, or null when nothing changed.
+   */
+  private recoverQuarantinedStore(
+    values: Record<string, string>,
+    machineKey: Buffer,
+    material: Buffer | null,
+  ): Record<string, string> | null {
+    const record = this.readQuarantineRecordThrottled();
+    if (!record) return null;
+    const markerPath = quarantineMarkerPath(this.credentialsPath);
+    const quarantinedPath = path.join(path.dirname(this.credentialsPath), record.file);
+    const expired = Date.now() - Date.parse(record.at) > QUARANTINE_RETENTION_MS;
+    if (!record.recoverable || expired) {
+      // Nothing here will ever be recovered: stop advertising a pending repair,
+      // but keep the ciphertext itself for diagnostics.
+      if (expired) this.clearQuarantineMarker(markerPath);
+      return null;
+    }
+    let attempt: CredentialDecodeAttempt;
+    try {
+      attempt = decodeCredentialStore(readJsonObject(quarantinedPath), machineKey, material);
+    } catch {
+      return null;
+    }
+    if (!attempt.ok) {
+      // This process HAS the OS material the quarantine was waiting for and
+      // still cannot open the file — so no peer will. Say so, or every surface
+      // keeps telling the user to open an app that has already tried.
+      if (material) this.demoteQuarantineToUnrecoverable(record, markerPath);
+      return null;
+    }
+    const merged = { ...values };
+    let changed = false;
+    for (const [key, value] of Object.entries(attempt.values)) {
+      if (key in merged) continue;
+      merged[key] = value;
+      changed = true;
+    }
+    try {
+      if (changed) this.writeAll(merged);
+      // The quarantined copy is live credential ciphertext that this process can
+      // decrypt. Once its contents are back in the store, keeping it is only
+      // extra secret material at rest.
+      unlinkIfExists(quarantinedPath);
+      this.clearQuarantineMarker(markerPath);
+    } catch {
+      return changed ? merged : null;
+    }
+    return changed ? merged : null;
+  }
+
+  private demoteQuarantineToUnrecoverable(
+    record: CredentialStoreQuarantineRecord,
+    markerPath: string,
+  ): void {
+    try {
+      writeFileAtomic(
+        markerPath,
+        `${JSON.stringify({ ...record, recoverable: false }, null, 2)}\n`,
+      );
+    } catch {
+      // Reporting-only state.
+    }
+  }
+
+  private readQuarantineRecordThrottled(): CredentialStoreQuarantineRecord | null {
+    const now = Date.now();
+    if (
+      this.lastQuarantineProbeAt > 0
+      && now - this.lastQuarantineProbeAt < QUARANTINE_PROBE_INTERVAL_MS
+    ) {
+      return null;
+    }
+    this.lastQuarantineProbeAt = now;
+    return readCredentialStoreQuarantine(this.credentialsPath);
+  }
+
+  private clearQuarantineMarker(markerPath: string): void {
+    try {
+      unlinkIfExists(markerPath);
+    } catch {
+      // Reporting-only state; a stale marker is not worth failing a read for.
+    }
+    this.lastQuarantineProbeAt = 0;
+  }
+
+  /**
+   * Drops quarantined ciphertext nobody came back for. Diagnostics are worth a
+   * month, not forever — these files are undecryptable-by-anyone in the corrupt
+   * case and decryptable-by-a-peer in the recoverable one, and neither should
+   * accumulate one copy per failed startup.
+   */
+  private pruneExpiredQuarantineFiles(): void {
+    const dir = path.dirname(this.credentialsPath);
+    const prefix = `${path.basename(this.credentialsPath)}.quarantined-`;
+    let entries: string[];
+    try {
+      entries = fs.readdirSync(dir);
+    } catch {
+      return;
+    }
+    const active = readCredentialStoreQuarantine(this.credentialsPath)?.file ?? null;
+    for (const entry of entries) {
+      if (!entry.startsWith(prefix) || entry === active) continue;
       try {
-        // Seal with the key the attempt already derived, not a fresh material
-        // read: after a self-heal the freshly-read material is what decrypted
-        // this store, and re-asking the OS could disagree with it.
-        this.writeAllWithKey(attempt.values, attempt.key);
+        const stat = fs.statSync(path.join(dir, entry));
+        if (Date.now() - stat.mtimeMs <= QUARANTINE_RETENTION_MS) continue;
+        fs.unlinkSync(path.join(dir, entry));
       } catch {
-        // Preserve read compatibility if migration cannot rewrite right now.
+        // Best effort housekeeping.
       }
     }
-    return attempt.values;
   }
 
   /**
@@ -959,7 +1490,7 @@ export class EncryptedFileCredentialStore implements SyncCredentialStore {
     if (!raw || Object.keys(raw).length === 0) {
       this.lastReadState = "unreadable";
       this.lastReadFailureReason = "store_format";
-      throw new Error("Unsupported ADE credential store format.");
+      return {};
     }
     const machineKey = await readOrCreateMachineKeyAsync(this.machineKeyPath);
     const material = await this.readKeyMaterialAsync();
@@ -978,58 +1509,57 @@ export class EncryptedFileCredentialStore implements SyncCredentialStore {
       if (retried) attempt = retried;
     }
     if (!attempt.ok) {
+      // Never throws, and never quarantines: a read has nothing to protect by
+      // failing, and the asynchronous path holds no lock to quarantine under.
+      // The reason is what the caller needs, and it gets it.
       this.lastReadState = "unreadable";
       this.lastReadFailureReason = attempt.reason;
-      if (attempt.osBound) throw attempt.error;
       return {};
     }
     this.lastReadState = "available";
     this.lastReadFailureReason = null;
-    // The asynchronous path binds legacy ciphertext too. It is the brain's read
-    // path, and on a machine whose only reader is the brain the store would
-    // otherwise stay machine-key-sealed forever.
-    if (attempt.rewriteWithCurrentKey) this.bindLegacyCiphertextUnderLock(attempt.key);
+    if (attempt.sealedBinding !== "machine") this.rebindToMachineKeyUnderLock(material);
     return attempt.values;
   }
 
+  /**
+   * The only seal this store performs. Always the machine key, always declared:
+   * this file is co-owned by the desktop app, the brain and the CLI, and the
+   * machine key is the one key all three can derive. See `CredentialStoreBinding`.
+   */
   private writeAll(values: Record<string, string>): void {
     const machineKey = readOrCreateMachineKey(this.machineKeyPath);
-    const key = deriveOsBoundCredentialKey(machineKey, this.readKeyMaterial());
-    this.writeAllWithKey(values, key);
-  }
-
-  private writeAllWithKey(values: Record<string, string>, key: Buffer): void {
-    writeFileAtomic(this.credentialsPath, `${JSON.stringify(serializeStore(values, key), null, 2)}\n`);
+    writeFileAtomic(
+      this.credentialsPath,
+      `${JSON.stringify(serializeStore(values, machineKey, "machine"), null, 2)}\n`,
+    );
   }
 
   /**
-   * Re-seals machine-key ciphertext with the OS-bound key, under this store's
-   * lock, for a caller that does NOT already hold it.
+   * Re-seals an `os`-bound store to the machine key under this store's lock, for
+   * an asynchronous caller that does NOT already hold it.
    *
-   * The re-read inside the lock is the point: a peer may have bound the file
-   * while this reader waited, and re-deriving from the stale `raw` would undo
-   * whatever the peer wrote. `key` is passed in rather than re-derived so the
-   * asynchronous caller never touches the synchronous key-material reader.
+   * The re-read inside the lock is the point: a peer may have converged the file
+   * while this reader waited, and rewriting from the stale `raw` would undo it.
    *
-   * Best effort: a failure here only leaves the ciphertext legacy, which still
-   * reads, so it must never fail the read that triggered it.
+   * `material` is handed in rather than re-read so the asynchronous caller never
+   * touches the synchronous key-material reader — on Windows that is a blocking
+   * PowerShell spawn, and the async path exists precisely to avoid it.
+   *
+   * Best effort: failing here only leaves the ciphertext bound as it was, which
+   * this process can still read, so it must never fail the read that triggered it.
    */
-  private bindLegacyCiphertextUnderLock(key: Buffer): void {
+  private rebindToMachineKeyUnderLock(material: Buffer | null): void {
     try {
       this.withLock(() => {
-        const raw = readJsonObject(this.credentialsPath);
         const machineKey = readOrCreateMachineKey(this.machineKeyPath);
-        try {
-          deserializeStore(raw, key, { emptyOnDecryptFailure: false });
-          return;
-        } catch {
-          // Still legacy: fall through and bind it.
-        }
-        const values = deserializeStore(raw, machineKey, { emptyOnDecryptFailure: false });
-        this.writeAllWithKey(values, key);
+        const raw = readJsonObject(this.credentialsPath);
+        const attempt = decodeCredentialStore(raw, machineKey, material);
+        if (!attempt.ok || attempt.sealedBinding === "machine") return;
+        this.writeAll(attempt.values);
       });
     } catch {
-      // Preserve read compatibility if the binding cannot happen right now.
+      // Preserve read compatibility if the rebind cannot happen right now.
     }
   }
 

--- a/apps/ade-cli/src/services/credentials/credentialStore.ts
+++ b/apps/ade-cli/src/services/credentials/credentialStore.ts
@@ -3,6 +3,32 @@ import fs from "node:fs";
 import path from "node:path";
 import { resolveMachineAdeLayout } from "../projects/machineLayout";
 import {
+  CREDENTIAL_FILE_LOCK_TIMEOUT_MS,
+  CredentialFileStatWatcher,
+  defaultLockPath,
+  ensureDirMode700,
+  ensureMode600,
+  isEnoent,
+  isEexist,
+  isSamePath,
+  readJsonObject,
+  readJsonObjectAsync,
+  unlinkIfExists,
+  withCredentialFileLock,
+  withOptionalCredentialFileLock,
+  writeFileAtomic,
+} from "./credentialFileIo";
+import {
+  clearQuarantineMarker,
+  deleteQuarantinedStoreFile,
+  quarantineCredentialFile,
+  quarantineHasExpired,
+  readCredentialStoreQuarantine,
+  readQuarantinedStoreFile,
+  writeQuarantineRecord,
+  type CredentialStoreQuarantineRecord,
+} from "./credentialStoreQuarantine";
+import {
   invalidateDefaultOsBoundKeyMaterialCache,
   platformSupportsOsBoundKeyMaterial,
   readDefaultOsBoundKeyMaterial,
@@ -65,23 +91,15 @@ export type CredentialStoreReadFailureReason =
   /** The file exists but is not a recognised credential envelope. */
   | "store_format";
 
-/**
- * A credential file that could not be read and was moved aside so the process
- * that hit it could keep running.
- *
- * `recoverable` means a peer process may still hold the key (an `os`-sealed
- * store quarantined by the brain, which the desktop app can open). Those are
- * merged back automatically by the first store instance that can decrypt them —
- * see `recoverQuarantinedStore`. Anything else is kept purely for diagnostics.
- */
-export type CredentialStoreQuarantineRecord = {
-  version: 1;
-  at: string;
-  /** Basename of the quarantined ciphertext, in the same directory. */
-  file: string;
-  reason: CredentialStoreReadFailureReason;
-  recoverable: boolean;
+// Re-exported so consumers that only care about credential health — `ade
+// doctor`, the desktop account bridge — have one import to reach for.
+export {
+  readCredentialStoreQuarantine,
+  type CredentialStoreQuarantineRecord,
 };
+
+/** Bounds how often a store re-stats the quarantine marker on a clean read. */
+const QUARANTINE_PROBE_INTERVAL_MS = 5_000;
 
 export type SyncCredentialStore = CredentialStore & {
   getSync(key: string): string | null;
@@ -186,36 +204,14 @@ function fileBackedCredentialWriteError(key: string): Error {
   );
 }
 /**
- * How long a writer waits for the credential-file lock before giving up.
- *
- * Exported because cross-process protocols layered on this store have to
- * out-wait it. In particular the account service polls for a peer's rotated
- * refresh token after a definitive `invalid_grant`: if that poll window were
- * shorter than this timeout, a peer that legitimately won the exchange but is
- * still queued behind the lock would have its session declared dead by the
- * loser.
+ * Re-exported from the file-IO layer that actually enforces it, so a caller
+ * pacing itself against the lock cannot drift from the real timeout.
  */
-export const CREDENTIAL_STORE_LOCK_TIMEOUT_MS = 15_000;
-const LOCK_TIMEOUT_MS = CREDENTIAL_STORE_LOCK_TIMEOUT_MS;
-const LOCK_STALE_MS = 10_000;
-const LOCK_RETRY_MS = 25;
+export const CREDENTIAL_STORE_LOCK_TIMEOUT_MS = CREDENTIAL_FILE_LOCK_TIMEOUT_MS;
 const CREDENTIAL_CHANGE_POLL_INTERVAL_MS = 250;
 /** Bounds OS key-material re-reads when a store keeps failing to decrypt. */
 const KEY_MATERIAL_SELF_HEAL_INTERVAL_MS = 30_000;
-/**
- * How long a recoverable quarantine keeps being retried before ADE stops
- * expecting a peer to turn up with the key. Generous on purpose: the peer here
- * is usually "the user opens the desktop app", which can be a fortnight away on
- * a machine that only runs the brain.
- */
-const QUARANTINE_RETENTION_MS = 30 * 24 * 60 * 60 * 1_000;
-/** Bounds how often a store re-stats the quarantine marker on a clean read. */
-const QUARANTINE_PROBE_INTERVAL_MS = 5_000;
 
-type CredentialLockMetadata = {
-  pid?: number;
-  createdAt?: string;
-};
 
 function normalizeKey(key: string): string {
   const normalized = key.trim();
@@ -224,300 +220,6 @@ function normalizeKey(key: string): string {
   return normalized;
 }
 
-function ensureMode600(filePath: string): void {
-  if (process.platform === "win32") return;
-  try {
-    fs.chmodSync(filePath, 0o600);
-  } catch {
-    // Best effort; some filesystems do not support chmod.
-  }
-}
-
-function ensureDirMode700(dirPath: string): void {
-  fs.mkdirSync(dirPath, { recursive: true, mode: 0o700 });
-  if (process.platform === "win32") return;
-  try {
-    fs.chmodSync(dirPath, 0o700);
-  } catch {
-    // Best effort; some filesystems do not support chmod.
-  }
-}
-
-function writeFileAtomic(filePath: string, contents: string | Buffer): void {
-  ensureDirMode700(path.dirname(filePath));
-  const tmpPath = `${filePath}.${process.pid}.${Date.now()}.tmp`;
-  fs.writeFileSync(tmpPath, contents, { mode: 0o600 });
-  ensureMode600(tmpPath);
-  fs.renameSync(tmpPath, filePath);
-  ensureMode600(filePath);
-}
-
-function isEnoent(error: unknown): boolean {
-  return typeof error === "object"
-    && error !== null
-    && "code" in error
-    && (error as { code?: unknown }).code === "ENOENT";
-}
-
-function isEexist(error: unknown): boolean {
-  return typeof error === "object"
-    && error !== null
-    && "code" in error
-    && (error as { code?: unknown }).code === "EEXIST";
-}
-
-/**
- * Windows does not report lock contention as EEXIST the way POSIX does.
- *
- * Deleting a file on Windows only unlinks the name once every open handle to it
- * closes, so between one holder's unlink and the last handle drop the lock name
- * still occupies the directory in a "delete pending" state. A concurrent
- * `open(lockPath, "wx")` against that name fails with a delete-pending or
- * sharing violation, which Node surfaces as EPERM, EACCES or EBUSY instead of
- * EEXIST. Those are the same "someone else holds it, try again" condition, so
- * they have to keep the acquisition loop running; treating them as fatal makes
- * every concurrent credential write a coin flip on Windows.
- */
-function isLockContention(error: unknown): boolean {
-  if (isEexist(error)) return true;
-  if (process.platform !== "win32") return false;
-  if (typeof error !== "object" || error === null || !("code" in error)) return false;
-  const code = (error as { code?: unknown }).code;
-  return code === "EPERM" || code === "EACCES" || code === "EBUSY";
-}
-
-function sleepSync(ms: number): void {
-  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms);
-}
-
-function defaultLockPath(credentialsPath: string): string {
-  return `${credentialsPath}.lock`;
-}
-
-function isSamePath(left: string, right: string): boolean {
-  return path.resolve(left) === path.resolve(right);
-}
-
-type CredentialFileStatSnapshot = {
-  ino: number;
-  mtimeMs: number;
-  size: number;
-} | null;
-
-function readCredentialFileStatSnapshot(filePath: string): CredentialFileStatSnapshot | undefined {
-  try {
-    const stat = fs.statSync(filePath);
-    return { ino: stat.ino, mtimeMs: stat.mtimeMs, size: stat.size };
-  } catch (error: unknown) {
-    if (isEnoent(error)) return null;
-    return undefined;
-  }
-}
-
-function isSameCredentialFileStat(
-  left: CredentialFileStatSnapshot,
-  right: CredentialFileStatSnapshot,
-): boolean {
-  if (left === null || right === null) return left === right;
-  return left.ino === right.ino
-    && left.mtimeMs === right.mtimeMs
-    && left.size === right.size;
-}
-
-class CredentialFileStatWatcher {
-  private previous: CredentialFileStatSnapshot | undefined;
-  private timer: NodeJS.Timeout | null = null;
-
-  constructor(
-    private readonly filePath: string,
-    private readonly listener: () => void,
-    private readonly intervalMs: number | null,
-  ) {}
-
-  start(): void {
-    this.previous = readCredentialFileStatSnapshot(this.filePath);
-    if (this.intervalMs === null) return;
-    this.timer = setInterval(() => this.checkNow(), this.intervalMs);
-    this.timer.unref();
-  }
-
-  checkNow(): void {
-    const current = readCredentialFileStatSnapshot(this.filePath);
-    if (current === undefined) return;
-    if (this.previous === undefined) {
-      this.previous = current;
-      return;
-    }
-    if (isSameCredentialFileStat(current, this.previous)) return;
-    this.previous = current;
-    try {
-      this.listener();
-    } catch {
-      // Credential observers are best-effort; one subscriber must not stop
-      // the watcher or prevent sibling subscribers from seeing the change.
-    }
-  }
-
-  dispose(): void {
-    if (this.timer) clearInterval(this.timer);
-    this.timer = null;
-  }
-}
-
-function parseLockMetadata(raw: string): CredentialLockMetadata {
-  try {
-    const parsed = JSON.parse(raw) as unknown;
-    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return {};
-    const record = parsed as Record<string, unknown>;
-    return {
-      pid: Number.isSafeInteger(record.pid) && Number(record.pid) > 0 ? Number(record.pid) : undefined,
-      createdAt: typeof record.createdAt === "string" ? record.createdAt : undefined,
-    };
-  } catch {
-    return {};
-  }
-}
-
-function isProcessRunning(pid: number): boolean {
-  try {
-    process.kill(pid, 0);
-    return true;
-  } catch (error: unknown) {
-    return !(
-      typeof error === "object"
-      && error !== null
-      && "code" in error
-      && (error as { code?: unknown }).code === "ESRCH"
-    );
-  }
-}
-
-function isSameLockStat(left: fs.Stats, right: fs.Stats): boolean {
-  return left.dev === right.dev
-    && left.ino === right.ino
-    && left.size === right.size
-    && left.mtimeMs === right.mtimeMs;
-}
-
-function removeStaleLock(lockPath: string): void {
-  let originalStat: fs.Stats;
-  let originalRaw: string;
-  try {
-    originalStat = fs.statSync(lockPath);
-    if (Date.now() - originalStat.mtimeMs <= LOCK_STALE_MS) return;
-    originalRaw = fs.readFileSync(lockPath, "utf8");
-  } catch {
-    return;
-  }
-
-  const metadata = parseLockMetadata(originalRaw);
-  if (metadata.pid && isProcessRunning(metadata.pid)) return;
-
-  try {
-    const currentStat = fs.statSync(lockPath);
-    if (!isSameLockStat(currentStat, originalStat)) return;
-    if (fs.readFileSync(lockPath, "utf8") !== originalRaw) return;
-    fs.unlinkSync(lockPath);
-  } catch {
-    // Another process won the lock race or removed the stale file first.
-  }
-}
-
-function withCredentialFileLock<T>(lockPath: string, fn: () => T): T {
-  ensureDirMode700(path.dirname(lockPath));
-  const deadline = Date.now() + LOCK_TIMEOUT_MS;
-  let fd: number | null = null;
-
-  while (fd === null) {
-    try {
-      const candidateFd = fs.openSync(lockPath, "wx", 0o600);
-      try {
-        fs.writeFileSync(
-          candidateFd,
-          JSON.stringify({ pid: process.pid, createdAt: new Date().toISOString() }),
-        );
-        fd = candidateFd;
-      } catch (error: unknown) {
-        try {
-          fs.closeSync(candidateFd);
-        } catch {
-          // ignore
-        }
-        try {
-          fs.unlinkSync(lockPath);
-        } catch {
-          // ignore
-        }
-        throw error;
-      }
-      ensureMode600(lockPath);
-    } catch (error: unknown) {
-      if (!isLockContention(error)) throw error;
-      removeStaleLock(lockPath);
-      if (Date.now() >= deadline) {
-        throw new Error("Timed out waiting for ADE credential store lock.", { cause: error });
-      }
-      sleepSync(LOCK_RETRY_MS);
-    }
-  }
-
-  try {
-    return fn();
-  } finally {
-    try {
-      fs.closeSync(fd);
-    } catch {
-      // ignore
-    }
-    try {
-      fs.unlinkSync(lockPath);
-    } catch {
-      // ignore
-    }
-  }
-}
-
-function unlinkIfExists(filePath: string): void {
-  try {
-    fs.unlinkSync(filePath);
-  } catch (error: unknown) {
-    if (!isEnoent(error)) throw error;
-  }
-}
-
-function withOptionalCredentialFileLock<T>(lockPath: string, skippedLockPath: string, fn: () => T): T {
-  if (isSamePath(lockPath, skippedLockPath)) return fn();
-  return withCredentialFileLock(lockPath, fn);
-}
-
-function readJsonObject(filePath: string): Record<string, unknown> | null {
-  try {
-    const raw = fs.readFileSync(filePath, "utf8");
-    const parsed = JSON.parse(raw) as unknown;
-    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return null;
-    return parsed as Record<string, unknown>;
-  } catch (error: unknown) {
-    if (isEnoent(error)) return {};
-    throw error;
-  }
-}
-
-async function readJsonObjectAsync(filePath: string): Promise<{
-  value: Record<string, unknown> | null;
-  exists: boolean;
-}> {
-  try {
-    const raw = await fs.promises.readFile(filePath, "utf8");
-    const parsed = JSON.parse(raw) as unknown;
-    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
-      return { value: null, exists: true };
-    }
-    return { value: parsed as Record<string, unknown>, exists: true };
-  } catch (error: unknown) {
-    if (isEnoent(error)) return { value: {}, exists: false };
-    throw error;
-  }
-}
 
 function normalizeStoredCredentialValues(value: unknown): Record<string, string> {
   if (!value || typeof value !== "object" || Array.isArray(value)) return {};
@@ -838,43 +540,6 @@ function retryDecodeWithRefreshedKeyMaterial(args: {
   return retried.ok ? retried : null;
 }
 
-function quarantineMarkerPath(credentialsPath: string): string {
-  return `${credentialsPath}.quarantine.json`;
-}
-
-function isQuarantineRecord(value: unknown): value is CredentialStoreQuarantineRecord {
-  if (!value || typeof value !== "object" || Array.isArray(value)) return false;
-  const record = value as Partial<CredentialStoreQuarantineRecord>;
-  return record.version === 1
-    && typeof record.at === "string"
-    && Number.isFinite(Date.parse(record.at))
-    && typeof record.file === "string"
-    // A marker names a sibling file, never a path: it is read by processes that
-    // may be less trusted than whatever wrote it, and following `../` out of the
-    // secrets directory is not a thing this format needs to support.
-    && record.file.length > 0
-    && !record.file.includes("/")
-    && !record.file.includes("\\")
-    && record.file !== "."
-    && record.file !== ".."
-    && (record.reason === "decrypt_failure"
-      || record.reason === "no_os_key_material"
-      || record.reason === "store_format")
-    && typeof record.recoverable === "boolean";
-}
-
-export function readCredentialStoreQuarantine(
-  credentialsPath: string,
-): CredentialStoreQuarantineRecord | null {
-  try {
-    const parsed = JSON.parse(
-      fs.readFileSync(quarantineMarkerPath(credentialsPath), "utf8"),
-    ) as unknown;
-    return isQuarantineRecord(parsed) ? parsed : null;
-  } catch {
-    return null;
-  }
-}
 
 /**
  * Health of a credential file, read without touching it.
@@ -1290,51 +955,22 @@ export class EncryptedFileCredentialStore implements SyncCredentialStore {
     this.lastReadFailureReason = args.reason;
     if (!args.forWrite) return {};
     // A failed quarantine is the one case that still has to fail closed: if the
-    // ciphertext could not be moved, writing would destroy it.
-    this.quarantineUnreadableStore(args.reason, args.recoverableByPeer, args.error);
+    // ciphertext could not be copied aside, writing over it would destroy it.
+    const record = quarantineCredentialFile({
+      credentialsPath: this.credentialsPath,
+      reason: args.reason,
+      recoverable: args.recoverableByPeer,
+    });
+    if (record) {
+      // Reset the live file here rather than leaving it to the caller's write.
+      // Not every write path reaches one — `deleteSync` returns early when the
+      // key is absent, and `updateSync` when the updater declines — and each of
+      // those would otherwise quarantine the same unreadable file again on the
+      // next call, one copy per attempt.
+      this.writeAll({});
+      this.lastQuarantineProbeAt = 0;
+    }
     return {};
-  }
-
-  /**
-   * Moves the unreadable ciphertext to a timestamped sibling and records a
-   * marker beside it. Caller holds the lock.
-   */
-  private quarantineUnreadableStore(
-    reason: CredentialStoreReadFailureReason,
-    recoverable: boolean,
-    cause: unknown,
-  ): void {
-    const at = new Date();
-    const stamp = at.toISOString().replace(/[:.]/g, "-");
-    const file = `${path.basename(this.credentialsPath)}.quarantined-${stamp}`;
-    const target = path.join(path.dirname(this.credentialsPath), file);
-    try {
-      fs.renameSync(this.credentialsPath, target);
-      ensureMode600(target);
-    } catch (error: unknown) {
-      if (isEnoent(error)) return; // A peer already moved or removed it.
-      throw new Error(
-        "ADE could not set aside the unreadable credential store, so it was left untouched.",
-        { cause: cause ?? error },
-      );
-    }
-    const record: CredentialStoreQuarantineRecord = {
-      version: 1,
-      at: at.toISOString(),
-      file,
-      reason,
-      recoverable,
-    };
-    try {
-      writeFileAtomic(
-        quarantineMarkerPath(this.credentialsPath),
-        `${JSON.stringify(record, null, 2)}\n`,
-      );
-    } catch {
-      // The marker only drives recovery and reporting; losing it must not fail
-      // the write that the quarantine just unblocked.
-    }
-    this.pruneExpiredQuarantineFiles();
   }
 
   /**
@@ -1357,18 +993,19 @@ export class EncryptedFileCredentialStore implements SyncCredentialStore {
   ): Record<string, string> | null {
     const record = this.readQuarantineRecordThrottled();
     if (!record) return null;
-    const markerPath = quarantineMarkerPath(this.credentialsPath);
-    const quarantinedPath = path.join(path.dirname(this.credentialsPath), record.file);
-    const expired = Date.now() - Date.parse(record.at) > QUARANTINE_RETENTION_MS;
-    if (!record.recoverable || expired) {
+    if (!record.recoverable || quarantineHasExpired(record)) {
       // Nothing here will ever be recovered: stop advertising a pending repair,
       // but keep the ciphertext itself for diagnostics.
-      if (expired) this.clearQuarantineMarker(markerPath);
+      if (quarantineHasExpired(record)) this.forgetQuarantine();
       return null;
     }
     let attempt: CredentialDecodeAttempt;
     try {
-      attempt = decodeCredentialStore(readJsonObject(quarantinedPath), machineKey, material);
+      attempt = decodeCredentialStore(
+        readQuarantinedStoreFile(this.credentialsPath, record),
+        machineKey,
+        material,
+      );
     } catch {
       return null;
     }
@@ -1376,7 +1013,9 @@ export class EncryptedFileCredentialStore implements SyncCredentialStore {
       // This process HAS the OS material the quarantine was waiting for and
       // still cannot open the file — so no peer will. Say so, or every surface
       // keeps telling the user to open an app that has already tried.
-      if (material) this.demoteQuarantineToUnrecoverable(record, markerPath);
+      if (material) {
+        writeQuarantineRecord(this.credentialsPath, { ...record, recoverable: false });
+      }
       return null;
     }
     const merged = { ...values };
@@ -1391,26 +1030,12 @@ export class EncryptedFileCredentialStore implements SyncCredentialStore {
       // The quarantined copy is live credential ciphertext that this process can
       // decrypt. Once its contents are back in the store, keeping it is only
       // extra secret material at rest.
-      unlinkIfExists(quarantinedPath);
-      this.clearQuarantineMarker(markerPath);
+      deleteQuarantinedStoreFile(this.credentialsPath, record);
+      this.forgetQuarantine();
     } catch {
       return changed ? merged : null;
     }
     return changed ? merged : null;
-  }
-
-  private demoteQuarantineToUnrecoverable(
-    record: CredentialStoreQuarantineRecord,
-    markerPath: string,
-  ): void {
-    try {
-      writeFileAtomic(
-        markerPath,
-        `${JSON.stringify({ ...record, recoverable: false }, null, 2)}\n`,
-      );
-    } catch {
-      // Reporting-only state.
-    }
   }
 
   private readQuarantineRecordThrottled(): CredentialStoreQuarantineRecord | null {
@@ -1425,41 +1050,9 @@ export class EncryptedFileCredentialStore implements SyncCredentialStore {
     return readCredentialStoreQuarantine(this.credentialsPath);
   }
 
-  private clearQuarantineMarker(markerPath: string): void {
-    try {
-      unlinkIfExists(markerPath);
-    } catch {
-      // Reporting-only state; a stale marker is not worth failing a read for.
-    }
+  private forgetQuarantine(): void {
+    clearQuarantineMarker(this.credentialsPath);
     this.lastQuarantineProbeAt = 0;
-  }
-
-  /**
-   * Drops quarantined ciphertext nobody came back for. Diagnostics are worth a
-   * month, not forever — these files are undecryptable-by-anyone in the corrupt
-   * case and decryptable-by-a-peer in the recoverable one, and neither should
-   * accumulate one copy per failed startup.
-   */
-  private pruneExpiredQuarantineFiles(): void {
-    const dir = path.dirname(this.credentialsPath);
-    const prefix = `${path.basename(this.credentialsPath)}.quarantined-`;
-    let entries: string[];
-    try {
-      entries = fs.readdirSync(dir);
-    } catch {
-      return;
-    }
-    const active = readCredentialStoreQuarantine(this.credentialsPath)?.file ?? null;
-    for (const entry of entries) {
-      if (!entry.startsWith(prefix) || entry === active) continue;
-      try {
-        const stat = fs.statSync(path.join(dir, entry));
-        if (Date.now() - stat.mtimeMs <= QUARANTINE_RETENTION_MS) continue;
-        fs.unlinkSync(path.join(dir, entry));
-      } catch {
-        // Best effort housekeeping.
-      }
-    }
   }
 
   /**

--- a/apps/ade-cli/src/services/credentials/credentialStoreQuarantine.ts
+++ b/apps/ade-cli/src/services/credentials/credentialStoreQuarantine.ts
@@ -1,0 +1,209 @@
+import fs from "node:fs";
+import path from "node:path";
+import {
+  ensureMode600,
+  isEnoent,
+  readJsonObject,
+  unlinkIfExists,
+  writeFileAtomic,
+} from "./credentialFileIo";
+import type { CredentialStoreReadFailureReason } from "./credentialStore";
+
+/**
+ * Setting an unreadable credential file aside so the process that hit it can
+ * keep running.
+ *
+ * The alternative — refusing to write — is what crash-looped the ADE brain
+ * under launchd: its first startup act mints the sync bootstrap token, and a
+ * write that throws on an unreadable store is a process exit and an immediate
+ * relaunch, forever. Quarantine keeps the "never write an empty store over real
+ * credentials" invariant by preserving the bytes instead of refusing to run.
+ *
+ * Type-only import of the failure reason back from `credentialStore`: the cycle
+ * is erased at compile time, and the reason genuinely belongs to the read that
+ * produced it rather than to this module.
+ */
+
+/**
+ * A credential file that could not be read and was moved aside so the process
+ * that hit it could keep running.
+ *
+ * `recoverable` means a peer process may still hold the key (an `os`-sealed
+ * store quarantined by the brain, which the desktop app can open). Those are
+ * merged back automatically by the first store instance that can decrypt them —
+ * see `recoverQuarantinedStore`. Anything else is kept purely for diagnostics.
+ */
+export type CredentialStoreQuarantineRecord = {
+  version: 1;
+  at: string;
+  /** Basename of the quarantined ciphertext, in the same directory. */
+  file: string;
+  reason: CredentialStoreReadFailureReason;
+  recoverable: boolean;
+};
+
+/**
+ * How long a recoverable quarantine keeps being retried before ADE stops
+ * expecting a peer to turn up with the key. Generous on purpose: the peer here
+ * is usually "the user opens the desktop app", which can be a fortnight away on
+ * a machine that only runs the brain.
+ */
+export const QUARANTINE_RETENTION_MS = 30 * 24 * 60 * 60 * 1_000;
+
+function quarantineMarkerPath(credentialsPath: string): string {
+  return `${credentialsPath}.quarantine.json`;
+}
+
+function isQuarantineRecord(value: unknown): value is CredentialStoreQuarantineRecord {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return false;
+  const record = value as Partial<CredentialStoreQuarantineRecord>;
+  return record.version === 1
+    && typeof record.at === "string"
+    && Number.isFinite(Date.parse(record.at))
+    && typeof record.file === "string"
+    // A marker names a sibling file, never a path: it is read by processes that
+    // may be less trusted than whatever wrote it, and following `../` out of the
+    // secrets directory is not a thing this format needs to support.
+    && record.file.length > 0
+    && !record.file.includes("/")
+    && !record.file.includes("\\")
+    && record.file !== "."
+    && record.file !== ".."
+    && (record.reason === "decrypt_failure"
+      || record.reason === "no_os_key_material"
+      || record.reason === "store_format")
+    && typeof record.recoverable === "boolean";
+}
+
+export function readCredentialStoreQuarantine(
+  credentialsPath: string,
+): CredentialStoreQuarantineRecord | null {
+  try {
+    const parsed = JSON.parse(
+      fs.readFileSync(quarantineMarkerPath(credentialsPath), "utf8"),
+    ) as unknown;
+    return isQuarantineRecord(parsed) ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Copies the unreadable ciphertext to a timestamped sibling and records a marker
+ * beside it. The caller holds the store's lock and is expected to replace the
+ * original with a fresh store immediately after.
+ *
+ * COPY, not rename, and that is a Windows correctness requirement: deleting or
+ * renaming a file there only succeeds once every handle to it closes, so a peer
+ * process mid-read turns the rename into EPERM/EACCES/EBUSY. Copying leaves the
+ * original in place for the caller's ordinary atomic write to replace — the same
+ * operation every credential write already performs, so quarantine adds no new
+ * Windows failure mode. Returns null when there was nothing to set aside.
+ */
+export function quarantineCredentialFile(args: {
+  credentialsPath: string;
+  reason: CredentialStoreReadFailureReason;
+  recoverable: boolean;
+  now?: Date;
+}): CredentialStoreQuarantineRecord | null {
+  const at = args.now ?? new Date();
+  const stamp = at.toISOString().replace(/[:.]/g, "-");
+  const file = `${path.basename(args.credentialsPath)}.quarantined-${stamp}`;
+  const target = path.join(path.dirname(args.credentialsPath), file);
+  try {
+    fs.copyFileSync(args.credentialsPath, target);
+    ensureMode600(target);
+  } catch (error: unknown) {
+    if (isEnoent(error)) return null; // A peer already replaced or removed it.
+    throw new Error(
+      "ADE could not set aside the unreadable credential store, so it was left untouched.",
+      { cause: error },
+    );
+  }
+  const record: CredentialStoreQuarantineRecord = {
+    version: 1,
+    at: at.toISOString(),
+    file,
+    reason: args.reason,
+    recoverable: args.recoverable,
+  };
+  writeQuarantineRecord(args.credentialsPath, record);
+  pruneExpiredQuarantineFiles(args.credentialsPath);
+  return record;
+}
+
+/**
+ * Records — or updates — the marker. Best effort: it only drives recovery and
+ * reporting, so losing it must never fail the write the quarantine unblocked.
+ */
+export function writeQuarantineRecord(
+  credentialsPath: string,
+  record: CredentialStoreQuarantineRecord,
+): void {
+  try {
+    writeFileAtomic(
+      quarantineMarkerPath(credentialsPath),
+      `${JSON.stringify(record, null, 2)}\n`,
+    );
+  } catch {
+    // Reporting-only state.
+  }
+}
+
+export function clearQuarantineMarker(credentialsPath: string): void {
+  try {
+    unlinkIfExists(quarantineMarkerPath(credentialsPath));
+  } catch {
+    // A stale marker is not worth failing a read for.
+  }
+}
+
+/** Reads a quarantined copy without the store's key-derivation or rewrites. */
+export function readQuarantinedStoreFile(
+  credentialsPath: string,
+  record: CredentialStoreQuarantineRecord,
+): Record<string, unknown> | null {
+  return readJsonObject(path.join(path.dirname(credentialsPath), record.file));
+}
+
+export function deleteQuarantinedStoreFile(
+  credentialsPath: string,
+  record: CredentialStoreQuarantineRecord,
+): void {
+  unlinkIfExists(path.join(path.dirname(credentialsPath), record.file));
+}
+
+/**
+ * Drops quarantined ciphertext nobody came back for. Diagnostics are worth a
+ * month, not forever — these files are undecryptable-by-anyone in the corrupt
+ * case and decryptable-by-a-peer in the recoverable one, and neither should
+ * accumulate one copy per failed startup.
+ */
+export function pruneExpiredQuarantineFiles(credentialsPath: string): void {
+  const dir = path.dirname(credentialsPath);
+  const prefix = `${path.basename(credentialsPath)}.quarantined-`;
+  let entries: string[];
+  try {
+    entries = fs.readdirSync(dir);
+  } catch {
+    return;
+  }
+  const active = readCredentialStoreQuarantine(credentialsPath)?.file ?? null;
+  for (const entry of entries) {
+    if (!entry.startsWith(prefix) || entry === active) continue;
+    try {
+      const stat = fs.statSync(path.join(dir, entry));
+      if (Date.now() - stat.mtimeMs <= QUARANTINE_RETENTION_MS) continue;
+      fs.unlinkSync(path.join(dir, entry));
+    } catch {
+      // Best effort housekeeping.
+    }
+  }
+}
+
+export function quarantineHasExpired(
+  record: CredentialStoreQuarantineRecord,
+  now: number = Date.now(),
+): boolean {
+  return now - Date.parse(record.at) > QUARANTINE_RETENTION_MS;
+}

--- a/apps/ade-cli/src/services/credentials/osBoundKeyMaterial.ts
+++ b/apps/ade-cli/src/services/credentials/osBoundKeyMaterial.ts
@@ -99,12 +99,10 @@ export type OsBoundKeyMaterialBinding =
 /**
  * The single decision every entry point below dispatches on.
  *
- * Read, read-async, invalidate and "is material expected?" MUST agree: an
- * invalidation that dropped the macOS resolver's cache on Windows would leave
- * the credential store's self-heal retrying against the same stale DPAPI
- * material, and an `expectsOsBoundKeyMaterial()` that still said "darwin only"
- * would misreport a Windows key failure as an ordinary decrypt failure.
- * Deriving all four from one pure function is what keeps them in step.
+ * Read, read-async and invalidate MUST agree: an invalidation that dropped the
+ * macOS resolver's cache on Windows would leave the credential store's
+ * self-heal retrying against the same stale DPAPI material. Deriving every
+ * entry point from one pure function is what keeps them in step.
  *
  * The env-gate applies on BOTH platforms: a test process, or an explicit
  * opt-out, must never reach `security` or `powershell.exe`.
@@ -120,10 +118,21 @@ export function resolveOsBoundKeyMaterialBinding(
   return "none";
 }
 
-/** Is OS-held material expected to back this process's credential key? */
-export function expectsOsBoundKeyMaterial(): boolean {
-  const binding = resolveOsBoundKeyMaterialBinding();
-  return binding === "windows_dpapi" || binding === "macos_keychain";
+/**
+ * Could SOME process on this platform hold OS material for a credential store —
+ * regardless of whether THIS one can?
+ *
+ * Deliberately platform-only, with no env gate. The credential store uses it to
+ * decide whether ciphertext it cannot open might still be openable by a peer,
+ * and the answer must not depend on this process's own opt-out: a desktop app
+ * launched with `ADE_CREDENTIAL_STORE_DISABLE_OS_BINDING=1` is exactly the
+ * process that would otherwise write off a store the un-opted-out brain — or a
+ * later launch of itself — can still read.
+ */
+export function platformSupportsOsBoundKeyMaterial(
+  platform: NodeJS.Platform = process.platform,
+): boolean {
+  return platform === "darwin" || platform === "win32";
 }
 
 function decodeMacKeychainSecret(raw: string): Buffer {
@@ -377,10 +386,12 @@ export function invalidateDefaultOsBoundKeyMaterialCache(keyBindingDir: string):
 /**
  * Creating resolution for the platform's OS binding.
  *
- * DPAPI failures propagate rather than degrading to `null`. `null` means "no OS
- * binding", which derives the bare machine key — so swallowing a transient
- * PowerShell timeout would read a DPAPI-bound store as empty and, on the write
- * path, silently re-seal it unbound.
+ * DPAPI failures propagate rather than degrading to `null` here, so the caller
+ * can tell "this platform has no OS binding" from "asking the OS failed". The
+ * credential store catches them and classifies the read as `no_os_key_material`
+ * — which is recoverable — rather than treating a transient PowerShell timeout
+ * as corruption. It can no longer re-seal anything unbound: the shared store is
+ * always sealed with the machine key.
  */
 export function readDefaultOsBoundKeyMaterial(keyBindingDir: string): Buffer | null {
   switch (resolveOsBoundKeyMaterialBinding()) {

--- a/apps/ade-cli/src/services/credentials/osBoundKeyMaterial.ts
+++ b/apps/ade-cli/src/services/credentials/osBoundKeyMaterial.ts
@@ -2,6 +2,7 @@ import crypto from "node:crypto";
 import { execFile, spawnSync } from "node:child_process";
 import {
   invalidateWindowsDpapiMaterial,
+  readExistingWindowsDpapiMaterial,
   readOrCreateWindowsDpapiMaterial,
   readOrCreateWindowsDpapiMaterialAsync,
 } from "./windowsDpapiMaterial";
@@ -221,6 +222,17 @@ export function resolveMacKeychainMaterialOutcome(
   return { material: null, reason: "unavailable" };
 }
 
+/** Find-only: reports what the keychain already holds and never adds an item. */
+function readMacKeychainMaterialSync(): OsBoundKeyMaterialResolution {
+  if (process.platform !== "darwin") return { material: null, reason: "unavailable" };
+  const existing = defaultMacKeychainCommands().find();
+  if (existing.kind === "found") return { material: decodeMacKeychainSecret(existing.value) };
+  return {
+    material: null,
+    reason: existing.kind === "not_found" ? "not_found" : "unavailable",
+  };
+}
+
 function readOrCreateMacKeychainMaterial(): OsBoundKeyMaterialResolution {
   if (process.platform !== "darwin") return { material: null, reason: "unavailable" };
   return resolveMacKeychainMaterialOutcome(defaultMacKeychainCommands());
@@ -274,6 +286,11 @@ export type OsBoundKeyMaterialResolver = {
   read(): Buffer | null;
   /** Read-only resolution: never creates the item. */
   readAsync(): Promise<Buffer | null>;
+  /**
+   * Synchronous read-only resolution, for diagnostics that must not create the
+   * item or wait on an asynchronous read.
+   */
+  readExisting(): Buffer | null;
   /** Drops the cache so the next resolution re-asks the OS. */
   invalidate(): void;
 };
@@ -292,6 +309,8 @@ export type OsBoundKeyMaterialResolver = {
 export function createMacKeychainMaterialResolver(args: {
   read: () => OsBoundKeyMaterialResolution;
   readAsync: () => Promise<OsBoundKeyMaterialResolution>;
+  /** Defaults to a find-only `security` call that never adds the item. */
+  readExisting?: () => OsBoundKeyMaterialResolution;
   now?: () => number;
   negativeCacheMs?: number;
 }): OsBoundKeyMaterialResolver {
@@ -331,6 +350,14 @@ export function createMacKeychainMaterialResolver(args: {
       const readEpoch = epoch;
       return record(readEpoch, args.read());
     },
+    readExisting(): Buffer | null {
+      if (cached) return cached;
+      if (withinBackoff()) return null;
+      const readExisting = args.readExisting;
+      if (!readExisting) return null;
+      const readEpoch = epoch;
+      return record(readEpoch, readExisting());
+    },
     async readAsync(): Promise<Buffer | null> {
       if (cached) return cached;
       if (withinBackoff()) return null;
@@ -357,6 +384,7 @@ export function createMacKeychainMaterialResolver(args: {
 const defaultMacKeychainMaterialResolver = createMacKeychainMaterialResolver({
   read: readOrCreateMacKeychainMaterial,
   readAsync: readMacKeychainMaterialAsync,
+  readExisting: readMacKeychainMaterialSync,
 });
 
 /**
@@ -418,6 +446,29 @@ export async function readDefaultOsBoundKeyMaterialAsync(
       return await readOrCreateWindowsDpapiMaterialAsync(keyBindingDir);
     case "macos_keychain":
       return await defaultMacKeychainMaterialResolver.readAsync();
+    default:
+      return null;
+  }
+}
+
+/**
+ * Read-only resolution for diagnostics: existing material or null, never a
+ * create.
+ *
+ * `readDefaultOsBoundKeyMaterial` is a CREATING resolver on both platforms — it
+ * mints and stores a macOS keychain item, or mints, DPAPI-protects and writes a
+ * Windows key file. A health check that used it would create the very state it
+ * was asked to report on, and would block for the platform's create budget
+ * (up to 30 s of PowerShell cold start on Windows) to do it.
+ */
+export function readExistingOsBoundKeyMaterial(keyBindingDir: string): Buffer | null {
+  switch (resolveOsBoundKeyMaterialBinding()) {
+    case "env_passphrase":
+      return readCredentialPassphraseFromEnv();
+    case "windows_dpapi":
+      return readExistingWindowsDpapiMaterial(keyBindingDir);
+    case "macos_keychain":
+      return defaultMacKeychainMaterialResolver.readExisting();
     default:
       return null;
   }

--- a/apps/ade-cli/src/services/credentials/windowsDpapiMaterial.ts
+++ b/apps/ade-cli/src/services/credentials/windowsDpapiMaterial.ts
@@ -305,6 +305,32 @@ export function readOrCreateWindowsDpapiMaterial(keyBindingDir: string): Buffer 
   return material;
 }
 
+/**
+ * Read-only counterpart for diagnostics: returns existing material or null, and
+ * never creates the protected key file.
+ *
+ * `readOrCreateWindowsDpapiMaterial` mints a key, runs a synchronous PowerShell
+ * protect, and writes `.credential-key.dpapi` when the file is absent. That is
+ * correct for a store that is about to seal something and wrong for anything
+ * that only reports state — a diagnostic must not change what it describes, and
+ * must not block a caller for the 30 s PowerShell budget to do it.
+ */
+export function readExistingWindowsDpapiMaterial(keyBindingDir: string): Buffer | null {
+  const keyPath = protectedKeyPath(keyBindingDir);
+  const cached = cachedKeyMaterial.get(keyPath);
+  if (cached) return cached;
+  const readEpoch = dpapiEpoch;
+  let material: Buffer;
+  try {
+    material = unprotectKey(keyPath);
+  } catch (error) {
+    if (isNodeErrorCode(error, "ENOENT")) return null;
+    throw error;
+  }
+  if (readEpoch === dpapiEpoch) cachedKeyMaterial.set(keyPath, material);
+  return material;
+}
+
 /** Async counterpart used by brain-facing credential reads. */
 export async function readOrCreateWindowsDpapiMaterialAsync(
   keyBindingDir: string,

--- a/apps/desktop/src/main/services/account/accountBridge.test.ts
+++ b/apps/desktop/src/main/services/account/accountBridge.test.ts
@@ -1,4 +1,5 @@
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { EncryptedFileCredentialStore } from "../../../../../ade-cli/src/services/credentials/credentialStore";
 import {
   createAccountBridge,
   createBrainAccountActionCaller,
@@ -392,5 +393,66 @@ describe("describeMachinePairingRepairFailure", () => {
       .toMatch(/Sign in to ADE again/);
     expect(describeMachinePairingRepairFailure(new Error("boom")).message)
       .toBe("ADE couldn't reconnect this computer to your account. Try again in a moment.");
+  });
+});
+
+describe("accountBridge.repairCredentialStore", () => {
+  const bridgeFor = (report: {
+    state: "available" | "missing" | "unreadable";
+    reason: string | null;
+    recoveredKeys: number;
+    quarantine: { recoverable: boolean } | null;
+  }) => {
+    const repairSync = vi.fn(() => report);
+    vi.spyOn(
+      EncryptedFileCredentialStore.prototype,
+      "repairSync",
+    ).mockImplementation(repairSync as never);
+    return createAccountBridge({ getProjectRoot: () => "/tmp/project" });
+  };
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("reports a restored credential as repaired", () => {
+    expect(bridgeFor({
+      state: "available",
+      reason: null,
+      recoveredKeys: 1,
+      quarantine: null,
+    }).repairCredentialStore()).toEqual({
+      outcome: "repaired",
+      readable: true,
+      recoveredKeys: 1,
+    });
+  });
+
+  it("requires a sign-in only when the LIVE store cannot be read", () => {
+    // An unrecoverable quarantine marker is a fact about a file set aside
+    // earlier, and it is deliberately never cleared while the ciphertext is kept
+    // for diagnostics. Treating it as "sign in again" made every later Repair
+    // demand a sign-in on a machine that is signed in and perfectly fine.
+    expect(bridgeFor({
+      state: "available",
+      reason: null,
+      recoveredKeys: 0,
+      quarantine: { recoverable: false },
+    }).repairCredentialStore()).toEqual({
+      outcome: "no_problem_found",
+      readable: true,
+      recoveredKeys: 0,
+    });
+
+    expect(bridgeFor({
+      state: "unreadable",
+      reason: "decrypt_failure",
+      recoveredKeys: 0,
+      quarantine: null,
+    }).repairCredentialStore()).toEqual({
+      outcome: "sign_in_required",
+      readable: false,
+      recoveredKeys: 0,
+    });
   });
 });

--- a/apps/desktop/src/main/services/account/accountBridge.ts
+++ b/apps/desktop/src/main/services/account/accountBridge.ts
@@ -730,17 +730,16 @@ export function createAccountBridge(options: AccountBridgeOptions): AccountBridg
         quarantineRecoverable: report.quarantine?.recoverable ?? null,
       });
       const readable = report.state !== "unreadable";
-      // "Fixed it" is only honest when something was actually wrong AND is now
-      // right: a recovered credential, or a store that had been set aside and no
-      // longer is. Everything else is either "nothing was broken here" or "this
-      // Mac cannot open it — sign in again".
+      // Only an unreadable LIVE store means the user has to sign in again. An
+      // unrecoverable quarantine marker is a fact about a file that was set
+      // aside earlier, and it is never cleared while the ciphertext is kept for
+      // diagnostics — so treating it as "sign in again" would make every future
+      // Repair demand a sign-in on a machine that is signed in and fine.
       const outcome: AdeAccountSessionRepairResult["outcome"] = !readable
         ? "sign_in_required"
         : report.recoveredKeys > 0
           ? "repaired"
-          : report.quarantine?.recoverable === false
-            ? "sign_in_required"
-            : "no_problem_found";
+          : "no_problem_found";
       return { outcome, readable, recoveredKeys: report.recoveredKeys };
     },
 

--- a/apps/desktop/src/main/services/account/accountBridge.ts
+++ b/apps/desktop/src/main/services/account/accountBridge.ts
@@ -15,6 +15,7 @@ import {
   resolveOfficialAccountDirectoryBaseUrl,
 } from "../../../../../ade-cli/src/services/account/sharedAccountAuthService";
 import { AccountMachineDirectoryService } from "../../../../../ade-cli/src/services/account/accountMachineDirectoryService";
+import { EncryptedFileCredentialStore } from "../../../../../ade-cli/src/services/credentials/credentialStore";
 import { accountMachineDisplayName } from "../../../shared/accountDirectory";
 import { resolveMachineAdeLayout } from "../../../../../ade-cli/src/services/projects/machineLayout";
 import { createFileLogger, type Logger } from "../logging/logger";
@@ -35,6 +36,7 @@ import type {
   AdeAccountMachinesResult,
   AdeAccountPairMachineProgress,
   AdeAccountLoginPoll,
+  AdeAccountSessionRepairResult,
   AdeAccountSessionReadState,
   AdeAccountSessionState,
   AdeAccountStatus,
@@ -402,6 +404,13 @@ export type AccountBridge = {
   ): () => void;
   removeMachine(machineKey: string): Promise<AdeAccountMachineRemovalResult>;
   repairMachinePairing(): Promise<AdeAccountMachinePairingRepairResult>;
+  /**
+   * Repairs the credential FILE, not the account: converge its key binding and
+   * merge back anything a peer process had to set aside. Synchronous work on a
+   * locked file, so it is deliberately not routed through the brain — the brain
+   * is usually the process that could not read it.
+   */
+  repairCredentialStore(): Omit<AdeAccountSessionRepairResult, "brainRestarted">;
 };
 
 export type AccountBridgePairMachineOptions = {
@@ -709,6 +718,29 @@ export function createAccountBridge(options: AccountBridgeOptions): AccountBridg
      * leaves both latches set, because heartbeats always publish
      * `pairing: false` and sign-in reuses the same stable device id.
      */
+    repairCredentialStore: (): Omit<AdeAccountSessionRepairResult, "brainRestarted"> => {
+      const report = new EncryptedFileCredentialStore({ secretsDir }).repairSync();
+      options.logger?.info("account.credential_store_repair", {
+        state: report.state,
+        reason: report.reason,
+        recoveredKeys: report.recoveredKeys,
+        quarantineRecoverable: report.quarantine?.recoverable ?? null,
+      });
+      const readable = report.state !== "unreadable";
+      // "Fixed it" is only honest when something was actually wrong AND is now
+      // right: a recovered credential, or a store that had been set aside and no
+      // longer is. Everything else is either "nothing was broken here" or "this
+      // Mac cannot open it — sign in again".
+      const outcome: AdeAccountSessionRepairResult["outcome"] = !readable
+        ? "sign_in_required"
+        : report.recoveredKeys > 0
+          ? "repaired"
+          : report.quarantine?.recoverable === false
+            ? "sign_in_required"
+            : "no_problem_found";
+      return { outcome, readable, recoveredKeys: report.recoveredKeys };
+    },
+
     repairMachinePairing: async (): Promise<AdeAccountMachinePairingRepairResult> => {
       if (!options.callBrainAccountAction) {
         throw new Error(

--- a/apps/desktop/src/main/services/account/accountBridge.ts
+++ b/apps/desktop/src/main/services/account/accountBridge.ts
@@ -720,7 +720,10 @@ export function createAccountBridge(options: AccountBridgeOptions): AccountBridg
      */
     repairCredentialStore: (): Omit<AdeAccountSessionRepairResult, "brainRestarted"> => {
       const report = new EncryptedFileCredentialStore({ secretsDir }).repairSync();
-      options.logger?.info("account.credential_store_repair", {
+      // Machine sink, same as the other machine-level credential mutations in
+      // this file: on a remote-bound project the project logger ships records to
+      // the OTHER machine, and a credential repair is a fact about this one.
+      getMachineLogger()?.info("account.credential_store_repair", {
         state: report.state,
         reason: report.reason,
         recoveredKeys: report.recoveredKeys,

--- a/apps/desktop/src/main/services/analytics/productAnalyticsPolicy.ts
+++ b/apps/desktop/src/main/services/analytics/productAnalyticsPolicy.ts
@@ -194,6 +194,12 @@ const SAFE_STRING_VALUES: Partial<Record<string, ReadonlySet<string>>> = {
     // deliberately absent: the app half is already reported by
     // `ade_update_install_did_not_land`, so only the brain half is new signal.
     "service", "restart", "health",
+    // Repair ran and the credential store is readable, but nothing on this
+    // computer can open what was set aside — the user has to sign in again.
+    // Distinct from `failed`, which means the repair itself did not run: the
+    // product question is whether Repair recovers a session or only confirms it
+    // is gone, and collapsing the two into `completed` answers neither.
+    "sign_in_required",
     // Which usage scope an installation actually looked at. Reuses `outcome`
     // rather than adding a parallel `scope` key, the same way the update
     // transaction reuses it for its failed step. These are the three values of

--- a/apps/desktop/src/main/services/analytics/productAnalyticsService.test.ts
+++ b/apps/desktop/src/main/services/analytics/productAnalyticsService.test.ts
@@ -189,6 +189,21 @@ describe("productAnalyticsService", () => {
       dedupeKey: "brain_repair:failed",
       minimumIntervalMs: 60 * 60 * 1_000,
     })).toEqual({ accepted: false, reason: "duplicate" });
+    // The credential-store repair's third outcome. It has to survive the
+    // sanitizer as itself: silently normalizing "we could not open your
+    // session" into `completed` is the one answer this event must not give.
+    expect(harness.service.capture({
+      event: "ade_feature_used",
+      surface: "desktop",
+      properties: { feature: "connections", action: "brain_repair", outcome: "sign_in_required" },
+      dedupeKey: "brain_repair:sign_in_required",
+      minimumIntervalMs: 60 * 60 * 1_000,
+    })).toEqual({ accepted: true, reason: "accepted" });
+    expect(harness.messages.at(-1)?.properties).toMatchObject({
+      feature: "connections",
+      action: "brain_repair",
+      outcome: "sign_in_required",
+    });
     fs.rmSync(harness.root, { recursive: true, force: true });
   });
 

--- a/apps/desktop/src/main/services/ipc/ipcTimeouts.test.ts
+++ b/apps/desktop/src/main/services/ipc/ipcTimeouts.test.ts
@@ -127,6 +127,10 @@ describe("ipcInvokeTimeoutMs", () => {
     // if either grows, this expectation is the thing that should be revisited.
     const WORST_CASE_MS = 60_000 + 60_000 + 20_000 + 20_000;
     expect(ipcInvokeTimeoutMs(IPC.appRestartBackgroundService)).toBeGreaterThanOrEqual(WORST_CASE_MS);
+    // Repairing the stored sign-in finishes with that same restart, so it needs
+    // the same budget — on the default the renderer reports "Repair failed" for
+    // a repair that is still running.
+    expect(ipcInvokeTimeoutMs(IPC.accountRepairSession)).toBeGreaterThanOrEqual(WORST_CASE_MS);
   });
 
   it("gives retryable remote runtime actions enough time to reconnect", () => {

--- a/apps/desktop/src/main/services/ipc/ipcTimeouts.ts
+++ b/apps/desktop/src/main/services/ipc/ipcTimeouts.ts
@@ -132,6 +132,11 @@ export function ipcInvokeTimeoutMs(channel: string, args: readonly unknown[] = [
     // not give up before the main process knows the outcome, or the Repair
     // button reports a failure for a restart that actually succeeded.
     case IPC.appRestartBackgroundService:
+    // Repairing the stored sign-in ends in that same brain restart, so it
+    // inherits the same budget. On the 30s default the renderer would report a
+    // failure for a repair that is still running — the exact mis-report the
+    // restart case above exists to prevent.
+    case IPC.accountRepairSession:
       return 4 * 60_000;
     // The Usage page's Refresh runs the isolated ledger worker end to end. On
     // the 30s default the renderer rejected with a raw IPC timeout — and blanked

--- a/apps/desktop/src/main/services/ipc/registerIpc.ts
+++ b/apps/desktop/src/main/services/ipc/registerIpc.ts
@@ -262,6 +262,7 @@ import type {
   AdeAccountMachinesResult,
   AdeAccountMachinePairResult,
   AdeAccountMachinePairingRepairResult,
+  AdeAccountSessionRepairResult,
   CreateLaneFromPrBranchArgs,
   CreateLaneFromPrBranchPreflightResult,
   CreateLaneFromPrBranchResult,
@@ -9609,6 +9610,42 @@ export function registerIpc({
       arg: { machineKey?: string },
     ): Promise<AdeAccountMachineRemovalResult> => {
       return await accountBridge.removeMachine(arg?.machineKey ?? "");
+    },
+  );
+
+  // What the "Can't read your sign-in" Repair control runs. Order matters: the
+  // credential file is repaired FIRST, then the brain restarts, so the
+  // replacement process reads an already-converged store. A restart alone —
+  // which is all this surface used to do — could not fix any credential-store
+  // condition, which is the only condition that surface appears for.
+  ipcMain.handle(
+    IPC.accountRepairSession,
+    async (): Promise<AdeAccountSessionRepairResult> => {
+      const repair = accountBridge.repairCredentialStore();
+      let brainRestarted: boolean | null = null;
+      if (projectRecoveryService) {
+        try {
+          await projectRecoveryService.restartBrain();
+          brainRestarted = true;
+        } catch {
+          // The store repair is the load-bearing half and it already happened.
+          // Report the restart honestly instead of discarding the repair.
+          brainRestarted = false;
+        }
+      }
+      productAnalyticsService?.capture({
+        event: "ade_feature_used",
+        surface: "desktop",
+        properties: {
+          feature: "connections",
+          action: "session_repair",
+          outcome: repair.outcome,
+        },
+        projectId: null,
+        dedupeKey: `session_repair:${repair.outcome}`,
+        minimumIntervalMs: 60 * 60 * 1_000,
+      });
+      return { ...repair, brainRestarted };
     },
   );
 

--- a/apps/desktop/src/main/services/ipc/registerIpc.ts
+++ b/apps/desktop/src/main/services/ipc/registerIpc.ts
@@ -9621,7 +9621,29 @@ export function registerIpc({
   ipcMain.handle(
     IPC.accountRepairSession,
     async (): Promise<AdeAccountSessionRepairResult> => {
-      const repair = accountBridge.repairCredentialStore();
+      // Same product fact as the restart-only handler above, so it keeps the
+      // existing `brain_repair` action and dedupe key rather than forking the
+      // funnel — this control replaced that one, it did not join it. The
+      // outcome is the only thing that got finer: whether the click recovered a
+      // session or only confirmed one is unrecoverable is the question the old
+      // completed/failed pair could not answer.
+      const captureRepairOutcome = (outcome: "completed" | "sign_in_required" | "failed") => {
+        productAnalyticsService?.capture({
+          event: "ade_feature_used",
+          surface: "desktop",
+          properties: { feature: "connections", action: "brain_repair", outcome },
+          projectId: null,
+          dedupeKey: `brain_repair:${outcome}`,
+          minimumIntervalMs: 60 * 60 * 1_000,
+        });
+      };
+      let repair: Omit<AdeAccountSessionRepairResult, "brainRestarted">;
+      try {
+        repair = accountBridge.repairCredentialStore();
+      } catch (error) {
+        captureRepairOutcome("failed");
+        throw error;
+      }
       let brainRestarted: boolean | null = null;
       if (projectRecoveryService) {
         try {
@@ -9633,18 +9655,9 @@ export function registerIpc({
           brainRestarted = false;
         }
       }
-      productAnalyticsService?.capture({
-        event: "ade_feature_used",
-        surface: "desktop",
-        properties: {
-          feature: "connections",
-          action: "session_repair",
-          outcome: repair.outcome,
-        },
-        projectId: null,
-        dedupeKey: `session_repair:${repair.outcome}`,
-        minimumIntervalMs: 60 * 60 * 1_000,
-      });
+      captureRepairOutcome(
+        repair.outcome === "sign_in_required" ? "sign_in_required" : "completed",
+      );
       return { ...repair, brainRestarted };
     },
   );

--- a/apps/desktop/src/preload/global.d.ts
+++ b/apps/desktop/src/preload/global.d.ts
@@ -343,6 +343,7 @@ import type {
   AdeAccountMachine,
   AdeAccountMachineRemovalResult,
   AdeAccountMachinePairingRepairResult,
+  AdeAccountSessionRepairResult,
   AdeAccountMachinesResult,
   AdeAccountMachinePairResult,
   AdeAccountPairMachineProgress,
@@ -2434,6 +2435,12 @@ declare global {
         removeMachine: (machineKey: string) => Promise<AdeAccountMachineRemovalResult>;
         /** Re-pairs THIS machine after an account-side removal. */
         repairMachinePairing: () => Promise<AdeAccountMachinePairingRepairResult>;
+        /**
+         * Repairs the stored sign-in on THIS Mac: converge the credential
+         * file's key binding, restore anything set aside, then restart the
+         * background service. Optional because older preloads lack it.
+         */
+        repairSession?: () => Promise<AdeAccountSessionRepairResult>;
       };
       prs: {
         createFromLane: (args: CreatePrFromLaneArgs) => Promise<PrSummary>;

--- a/apps/desktop/src/preload/preload.ts
+++ b/apps/desktop/src/preload/preload.ts
@@ -273,6 +273,7 @@ import type {
   AdeAccountMachine,
   AdeAccountMachineRemovalResult,
   AdeAccountMachinePairingRepairResult,
+  AdeAccountSessionRepairResult,
   AdeAccountMachinesResult,
   AdeAccountMachinePairResult,
   AdeAccountPairMachineProgress,
@@ -8797,6 +8798,8 @@ contextBridge.exposeInMainWorld("ade", {
       ipcRenderer.invoke(IPC.accountRemoveMachine, { machineKey }),
     repairMachinePairing: (): Promise<AdeAccountMachinePairingRepairResult> =>
       ipcRenderer.invoke(IPC.accountRepairMachinePairing),
+    repairSession: (): Promise<AdeAccountSessionRepairResult> =>
+      ipcRenderer.invoke(IPC.accountRepairSession),
   },
   prs: {
     createFromLane: async (args: CreatePrFromLaneArgs): Promise<PrSummary> =>

--- a/apps/desktop/src/renderer/components/account/AccountPage.test.tsx
+++ b/apps/desktop/src/renderer/components/account/AccountPage.test.tsx
@@ -124,7 +124,7 @@ describe("AccountPage signed-out card", () => {
 
     expect(
       screen.getByText(
-        "Can't read your sign-in right now — your session is still there. Fix access instead of signing in again.",
+        "Can't read your sign-in right now — your session is still there. Try Repair before signing in again.",
       ),
     ).toBeTruthy();
     expect(screen.queryByRole("button", { name: "Sign in or create account" })).toBeNull();

--- a/apps/desktop/src/renderer/components/settings/BrainRepairButton.tsx
+++ b/apps/desktop/src/renderer/components/settings/BrainRepairButton.tsx
@@ -33,6 +33,16 @@ export function BrainRepairButton({
         >
           Repair failed — quit and reopen ADE.
         </span>
+      ) : repair.notice ? (
+        <span
+          style={{
+            color: repair.notice.tone === "ok" ? COLORS.textSecondary : COLORS.warning,
+            fontFamily: SANS_FONT,
+            fontSize: 11,
+          }}
+        >
+          {repair.notice.text}
+        </span>
       ) : null}
     </>
   );

--- a/apps/desktop/src/renderer/hooks/useBrainRepair.test.tsx
+++ b/apps/desktop/src/renderer/hooks/useBrainRepair.test.tsx
@@ -1,0 +1,121 @@
+/* @vitest-environment jsdom */
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { act, cleanup, renderHook, waitFor } from "@testing-library/react";
+import type { AdeAccountSessionRepairResult } from "../../shared/types/account";
+import { useBrainRepair } from "./useBrainRepair";
+
+afterEach(() => {
+  cleanup();
+  delete (window as { ade?: unknown }).ade;
+});
+
+function stubBridge(bridge: {
+  repairSession?: () => Promise<AdeAccountSessionRepairResult>;
+  restartBackgroundService?: () => Promise<void>;
+}): void {
+  (window as { ade?: unknown }).ade = {
+    account: bridge.repairSession ? { repairSession: bridge.repairSession } : {},
+    app: bridge.restartBackgroundService
+      ? { restartBackgroundService: bridge.restartBackgroundService }
+      : {},
+  };
+}
+
+async function runRepair(result: { current: ReturnType<typeof useBrainRepair> }) {
+  await act(async () => {
+    result.current.run();
+  });
+  await waitFor(() => expect(result.current.pending).toBe(false));
+}
+
+describe("useBrainRepair", () => {
+  it("repairs the stored sign-in rather than only restarting the service", async () => {
+    // The control is offered for exactly one condition — the stored session
+    // could not be read — and restarting the service cannot fix that: the
+    // replacement process reads the same unreadable file.
+    const repairSession = vi.fn(async () => ({
+      outcome: "repaired" as const,
+      readable: true,
+      recoveredKeys: 1,
+      brainRestarted: true,
+    }));
+    const restartBackgroundService = vi.fn(async () => {});
+    stubBridge({ repairSession, restartBackgroundService });
+
+    const { result } = renderHook(() => useBrainRepair());
+    await runRepair(result);
+
+    expect(repairSession).toHaveBeenCalledTimes(1);
+    expect(restartBackgroundService).not.toHaveBeenCalled();
+    expect(result.current.notice).toEqual({ tone: "ok", text: "Fixed — your sign-in is back." });
+  });
+
+  it("warns when the credential repair succeeds but the background service does not restart", async () => {
+    // The two halves are reported separately for a reason. Calling this "fixed"
+    // while the service is still down describes half the outcome.
+    stubBridge({
+      repairSession: async () => ({
+        outcome: "repaired",
+        readable: true,
+        recoveredKeys: 1,
+        brainRestarted: false,
+      }),
+    });
+
+    const { result } = renderHook(() => useBrainRepair());
+    await runRepair(result);
+
+    expect(result.current.notice?.tone).toBe("warn");
+    expect(result.current.notice?.text).toContain("didn't restart");
+    expect(result.current.error).toBeNull();
+  });
+
+  it("says to sign in again only when nothing on this computer can open the store", async () => {
+    stubBridge({
+      repairSession: async () => ({
+        outcome: "sign_in_required",
+        readable: false,
+        recoveredKeys: 0,
+        brainRestarted: true,
+      }),
+    });
+
+    const { result } = renderHook(() => useBrainRepair());
+    await runRepair(result);
+
+    expect(result.current.notice).toEqual({
+      tone: "warn",
+      text: "Your sign-in can't be read on this computer. Sign in again.",
+    });
+  });
+
+  it("falls back to a bare restart on a preload without the repair route", async () => {
+    // `repairSession` is optional on the bridge; an older preload must keep the
+    // button working rather than losing it.
+    const restartBackgroundService = vi.fn(async () => {});
+    stubBridge({ restartBackgroundService });
+
+    const { result } = renderHook(() => useBrainRepair());
+    expect(result.current.available).toBe(true);
+    await runRepair(result);
+
+    expect(restartBackgroundService).toHaveBeenCalledTimes(1);
+    expect(result.current.notice).toBeNull();
+    expect(result.current.error).toBeNull();
+  });
+
+  it("reports a thrown repair through error, not through a success notice", async () => {
+    stubBridge({
+      repairSession: async () => {
+        throw new Error("repair exploded");
+      },
+    });
+
+    const { result } = renderHook(() => useBrainRepair());
+    await runRepair(result);
+
+    expect(result.current.error).toContain("repair exploded");
+    expect(result.current.notice).toBeNull();
+  });
+});

--- a/apps/desktop/src/renderer/hooks/useBrainRepair.ts
+++ b/apps/desktop/src/renderer/hooks/useBrainRepair.ts
@@ -47,6 +47,17 @@ export function useBrainRepair(onSettled?: () => void): BrainRepair {
           text: "Your sign-in can't be read on this computer. Sign in again.",
         };
       }
+      // The store repair and the restart are separate halves and the handler
+      // reports them separately. Calling a repair "fixed" while the background
+      // service is still down describes half the outcome.
+      if (result.brainRestarted === false) {
+        return {
+          tone: "warn",
+          text: result.outcome === "repaired"
+            ? "Your sign-in is back, but the ADE background service didn't restart. Try again."
+            : "The ADE background service didn't restart. Try again.",
+        };
+      }
       if (result.outcome === "repaired") {
         return { tone: "ok", text: "Fixed — your sign-in is back." };
       }

--- a/apps/desktop/src/renderer/hooks/useBrainRepair.ts
+++ b/apps/desktop/src/renderer/hooks/useBrainRepair.ts
@@ -18,7 +18,7 @@ export type BrainRepair = {
 };
 
 /**
- * Repairs this Mac's stored sign-in, then restarts the brain — the background
+ * Repairs this computer's stored sign-in, then restarts the brain — the background
  * `com.ade.runtime` service — and calls `onSettled` once it resolves, so the
  * caller can re-read whatever health source it renders.
  *
@@ -44,7 +44,7 @@ export function useBrainRepair(onSettled?: () => void): BrainRepair {
       if (result.outcome === "sign_in_required") {
         return {
           tone: "warn",
-          text: "Your sign-in can't be read on this Mac. Sign in again.",
+          text: "Your sign-in can't be read on this computer. Sign in again.",
         };
       }
       if (result.outcome === "repaired") {

--- a/apps/desktop/src/renderer/hooks/useBrainRepair.ts
+++ b/apps/desktop/src/renderer/hooks/useBrainRepair.ts
@@ -2,60 +2,90 @@ import { useCallback, useState } from "react";
 import { extractError } from "../lib/format";
 import { useAsyncAction } from "./useAsyncAction";
 
+/** What a finished repair should tell the user, or null when there is nothing to say. */
+export type BrainRepairNotice = { tone: "ok" | "warn"; text: string } | null;
+
 export type BrainRepair = {
-  /** Restarts the brain; ignores clicks while a restart is in flight. */
+  /** Repairs the stored sign-in and restarts the brain; ignores repeat clicks. */
   run: () => void;
   pending: boolean;
-  /** False when this surface cannot restart a brain (hosted web, browser mock). */
+  /** False when this surface cannot repair (hosted web, browser mock). */
   available: boolean;
   /** Technical failure detail from the last attempt, or null. */
   error: string | null;
+  /** Outcome of the last successful attempt, in the user's words. */
+  notice: BrainRepairNotice;
 };
 
 /**
- * Restarts this Mac's ADE brain — the background `com.ade.runtime` service —
- * and calls `onSettled` once the restart resolves, so the caller can re-read
- * whatever health source it renders.
+ * Repairs this Mac's stored sign-in, then restarts the brain — the background
+ * `com.ade.runtime` service — and calls `onSettled` once it resolves, so the
+ * caller can re-read whatever health source it renders.
  *
- * This is the remediation for a brain that cannot decrypt the stored account
- * session: the replacement process re-reads the keychain from scratch. The main
- * process waits for the replacement to answer a ping before resolving — only it
- * can observe brain readiness — so there is nothing to wait for here. A rejected
- * restart is reported through `error`; the caller's own banner stays put either
- * way, since `onSettled` runs on both paths.
+ * The order is the point. This control is offered for one condition: the stored
+ * account session could not be read. Restarting the service was never a fix for
+ * that — the replacement process reads the same unreadable file — so the main
+ * process repairs the credential file first (converge its key binding, restore
+ * anything a peer process had to set aside) and restarts after.
+ *
+ * `repairSession` is optional on the bridge because an older preload does not
+ * have it; that case falls back to the bare restart rather than losing the
+ * button. A rejected attempt is reported through `error`, and `onSettled` runs
+ * on both paths so the caller's own banner refreshes either way.
  */
 export function useBrainRepair(onSettled?: () => void): BrainRepair {
   const [error, setError] = useState<string | null>(null);
+  const [notice, setNotice] = useState<BrainRepairNotice>(null);
 
-  const action = useCallback(async () => {
-    const invoke = window.ade?.app?.restartBackgroundService;
-    if (!invoke) throw new Error("Restarting the ADE background service is not available here.");
-    await invoke();
+  const action = useCallback(async (): Promise<BrainRepairNotice> => {
+    const repairSession = window.ade?.account?.repairSession;
+    if (repairSession) {
+      const result = await repairSession();
+      if (result.outcome === "sign_in_required") {
+        return {
+          tone: "warn",
+          text: "Your sign-in can't be read on this Mac. Sign in again.",
+        };
+      }
+      if (result.outcome === "repaired") {
+        return { tone: "ok", text: "Fixed — your sign-in is back." };
+      }
+      return null;
+    }
+    const restart = window.ade?.app?.restartBackgroundService;
+    if (!restart) throw new Error("Repairing the ADE background service is not available here.");
+    await restart();
+    return null;
   }, []);
 
   const { run, pending } = useAsyncAction({
     action,
-    onSuccess: () => {
+    onSuccess: (result) => {
       setError(null);
+      setNotice(result);
       onSettled?.();
     },
     onError: (reason) => {
       setError(extractError(reason));
+      setNotice(null);
       onSettled?.();
     },
   });
 
-  // Clear the previous failure as the retry starts, so the inline error never
-  // sits next to a spinner that has not failed yet.
+  // Clear the previous outcome as the retry starts, so no stale line sits next
+  // to a spinner that has not finished yet.
   const runRepair = useCallback(() => {
     setError(null);
+    setNotice(null);
     run();
   }, [run]);
 
   return {
     run: runRepair,
     pending,
-    available: typeof window.ade?.app?.restartBackgroundService === "function",
+    available: typeof window.ade?.account?.repairSession === "function"
+      || typeof window.ade?.app?.restartBackgroundService === "function",
     error,
+    notice,
   };
 }

--- a/apps/desktop/src/renderer/lib/account.test.ts
+++ b/apps/desktop/src/renderer/lib/account.test.ts
@@ -205,7 +205,7 @@ describe("account session state", () => {
     expect(accountSessionNotice("active")).toBeNull();
     expect(accountSessionNotice("expired")).toBe("Your ADE sign-in expired — sign in again.");
     expect(accountSessionNotice("unreadable")).toBe(
-      "Can't read your sign-in right now — your session is still there. Fix access instead of signing in again.",
+      "Can't read your sign-in right now — your session is still there. Try Repair before signing in again.",
     );
   });
 });

--- a/apps/desktop/src/renderer/lib/account.ts
+++ b/apps/desktop/src/renderer/lib/account.ts
@@ -128,7 +128,7 @@ const ACCOUNT_SESSION_LABELS: Record<
   },
   unreadable: {
     notice:
-      "Can't read your sign-in right now — your session is still there. Fix access instead of signing in again.",
+      "Can't read your sign-in right now — your session is still there. Try Repair before signing in again.",
     title: "Can't read your sign-in",
     shortLabel: "Sign-in unavailable",
     connectionsSubtitle: "Your session is still there — open your account to fix it",

--- a/apps/desktop/src/shared/ipc.ts
+++ b/apps/desktop/src/shared/ipc.ts
@@ -648,6 +648,7 @@ export const IPC = {
   accountGetLocalMachineIdentity: "ade.account.getLocalMachineIdentity",
   accountRemoveMachine: "ade.account.removeMachine",
   accountRepairMachinePairing: "ade.account.repairMachinePairing",
+  accountRepairSession: "ade.account.repairSession",
   prsCreateFromLane: "ade.prs.createFromLane",
   prsLinkToLane: "ade.prs.linkToLane",
   prsPreflightCreateLaneFromPrBranch: "ade.prs.preflightCreateLaneFromPrBranch",

--- a/apps/desktop/src/shared/types/account.ts
+++ b/apps/desktop/src/shared/types/account.ts
@@ -195,6 +195,27 @@ export type AdeAccountMachinePairingRepairResult = {
   reasonCode?: string | null;
 };
 
+/**
+ * What the "Can't read your sign-in" Repair control actually did.
+ *
+ * The control used to restart the background service and nothing else, which
+ * could not fix any credential-store condition — the one class of failure the
+ * surface offering it exists for. Now it runs the store's own repair first
+ * (converge the file's key binding, merge back anything a peer process set
+ * aside) and restarts the brain after, so `outcome` can say which of the three
+ * real endings happened rather than "we restarted something".
+ */
+export type AdeAccountSessionRepairResult = {
+  /** `repaired` — readable again. `sign_in_required` — nothing on this Mac can open it. */
+  outcome: "repaired" | "sign_in_required" | "no_problem_found";
+  /** Did the credential file end up readable? */
+  readable: boolean;
+  /** Credentials put back from a file a peer process had set aside. */
+  recoveredKeys: number;
+  /** Did the brain restart succeed? Null when this window cannot restart it. */
+  brainRestarted: boolean | null;
+};
+
 /** Token-free result of adopting an account-directory machine for paired use. */
 export type AdeAccountMachinePairResult = {
   targetId: string;

--- a/apps/desktop/src/shared/types/account.ts
+++ b/apps/desktop/src/shared/types/account.ts
@@ -206,7 +206,7 @@ export type AdeAccountMachinePairingRepairResult = {
  * real endings happened rather than "we restarted something".
  */
 export type AdeAccountSessionRepairResult = {
-  /** `repaired` — readable again. `sign_in_required` — nothing on this Mac can open it. */
+  /** `repaired` — readable again. `sign_in_required` — nothing on this computer can open it. */
   outcome: "repaired" | "sign_in_required" | "no_problem_found";
   /** Did the credential file end up readable? */
   readable: boolean;

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1109,8 +1109,8 @@ Related UI docs: [Terminals UI surfaces](./features/terminals-and-sessions/ui-su
 |--------|----------|-----------|
 | GitHub PAT | `.ade/secrets/github/*.bin` | `safeStorage.encryptString` (OS-backed) |
 | API provider keys | `.ade/secrets/api-keys.json` | Plaintext `0600` |
-| ADE project secrets | `.ade/secrets/project-secrets.v1.enc` | AES-GCM encrypted file store, OS-bound on supported hosts |
-| Machine credential store (shared) | `.ade/secrets/credentials.json.enc` + `.machine-key` | AES-GCM file store; key HKDF-derived from the machine key and a macOS-keychain secret. Read by the brain, the `ade` CLI, and desktop |
+| ADE project secrets | `.ade/secrets/project-secrets.v1.enc` | AES-GCM encrypted file store sealed with its own machine key; also co-owned by the brain |
+| Machine credential store (shared) | `.ade/secrets/credentials.json.enc` + `.machine-key` | AES-GCM file store sealed with the machine key. Read and written by the brain, the `ade` CLI, and desktop |
 | Machine credential store (Electron) | `.ade/secrets/credentials.safe.enc` | `safeStorage.encryptString`; readable only by Electron |
 | Claude OAuth creds | Claude's own store | Inherited |
 | Codex auth tokens | Codex's own store | Inherited |
@@ -1129,14 +1129,44 @@ migrated duplicates out of the file store, and deleting the legacy files only
 when nothing is retained. Writing either key through the safeStorage store
 throws rather than silently signing the brain out of a machine whose app is
 signed in, and a legacy store that cannot be decrypted aborts the migration
-instead of being replaced with an empty one. Keychain material is resolved
-race-safely (`osBoundKeyMaterial.ts`): the create is non-clobbering, an
-inconclusive `security` result fails closed rather than minting a replacement
-secret, and a decrypt failure against cached material re-reads the keychain once
-before the store is declared unreadable. A brain that still cannot read it
-publishes nothing to the account directory; that state is user-repairable from
-Connections and reported once per episode as `ade_account_session_unreadable`
-(see [logging](./logging.md)).
+instead of being replaced with an empty one. The shared file store is sealed with the bare machine key, never with
+OS-held material, and the envelope records that binding (`binding: "machine"`,
+still `version: 1` and outside the AAD so an older build keeps reading it). The
+reason is that the file is co-owned by processes with unequal access to the OS:
+the brain runs as a launchd agent (or a Windows scheduled task) with no UI, so a
+keychain item whose ACL belongs to the desktop app is unreadable to it and
+`security` fails closed. Sealing under either process's OS binding locked the
+other out — and because reads used to re-seal the file with the current
+process's key, opening the app was enough to strand the brain permanently.
+Readers still try both keys, ordered by the declared binding, and re-seal only
+*toward* `machine`, so a store an older build left OS-bound converges the first
+time a process that can open it reads it. OS binding survives as a read-only
+compatibility path with no writer; single-writer secrets that want OS protection
+belong in the Electron `safeStorage` store.
+
+Key material itself is resolved race-safely (`osBoundKeyMaterial.ts`): the
+create is non-clobbering, an inconclusive `security` result fails closed rather
+than minting a replacement secret, and a decrypt failure against cached material
+re-reads the keychain once before the store is declared unreadable.
+
+An unreadable store never fails a process. Reads report a state and a coarse
+reason (`decrypt_failure`, `no_os_key_material`, `store_format`); a write copies
+the ciphertext aside to a timestamped sibling with a
+`credentials.json.enc.quarantine.json` marker and starts a fresh store, so the
+"never write an empty store over real credentials" invariant is kept by
+preserving the bytes rather than by refusing to run — refusing is what
+crash-looped the brain, whose first startup act mints the sync bootstrap token.
+Quarantine copies rather than renames because Windows cannot rename a file while
+another process holds it open. A quarantine whose key a peer may still hold is
+marked recoverable and merged back — only for keys the live store lacks — by the
+first process that can decrypt it; when the process that holds the OS material
+tries and fails, the marker is demoted so surfaces stop promising a repair that
+cannot happen. `ade doctor` reports this straight from disk, because the case it
+exists for is a brain that cannot start. A brain that still cannot read the
+store publishes nothing to the account directory; that state is user-repairable
+from Connections — the control runs the store repair before restarting the
+brain — and reported once per episode as `ade_account_session_unreadable` (see
+[logging](./logging.md)).
 
 ADE project-secret dotenv imports are explicit transfers, not background
 sync: the desktop reads a user-selected local file (1 MB cap) and sends its

--- a/docs/development/windows-support.md
+++ b/docs/development/windows-support.md
@@ -183,6 +183,17 @@ the named pipe is healthy.
   account identifiers, and paths independently for every provider.
 - Provider credentials are machine-local. Never copy a credential store into an
   evidence bundle or across a cross-machine handoff.
+- The shared credential store (`credentials.json.enc`) is sealed with the bare
+  machine key on every platform, never with DPAPI- or keychain-derived material.
+  It is co-owned by the desktop app, the brain and the CLI, and any binding one
+  of them can derive but another cannot locks that other one out permanently.
+  Windows DPAPI (`CurrentUser`) is symmetric between the desktop app and the
+  scheduled-task brain because both run as the signed-in user — but the DPAPI
+  helper is a PowerShell spawn that can time out, and a timeout used to throw
+  out of a plain credential read. Verify that a DPAPI failure degrades to an
+  "unreadable, may be recoverable" report and never terminates the brain.
+- Single-writer secrets that want OS-level protection belong in the Electron
+  safeStorage store (`credentials.safe.enc`), which only the desktop app reads.
 
 ## Standalone brain or installation is damaged
 

--- a/docs/features/onboarding-and-settings/README.md
+++ b/docs/features/onboarding-and-settings/README.md
@@ -1235,7 +1235,18 @@ not-signed-in states distinctly; the branch logic lives once in
 `accountSessionState` / `accountSessionNotice`
 (`apps/desktop/src/renderer/lib/account.ts`), and the `unreadable` copy leads
 with the shared `BrainRepairButton` (or a plain retry where there is no brain to
-restart) with sign-in demoted to "Sign in anyway". The CLI's `account-auth` text
+restart) with sign-in demoted to "Sign in anyway".
+
+Repair has to actually repair. Restarting the background service — all this
+control used to do — cannot fix any credential-store condition, which is the
+only condition this surface appears for: the replacement process reads the same
+unreadable file. `account.repairSession` therefore repairs the shared credential
+store first (converge its key binding, merge back anything a peer process had to
+set aside) and restarts the brain after, then reports which of three things
+happened: the store is readable again, the store is readable but nothing on this
+computer can open what was set aside so a fresh sign-in is required, or the
+repair itself failed. The store mechanics are in
+[ARCHITECTURE](../../ARCHITECTURE.md) under the machine credential stores. The CLI's `account-auth` text
 formatter makes the same three distinctions rather than printing one
 "Not signed in — local use does not require an account." for all of them.
 

--- a/docs/logging.md
+++ b/docs/logging.md
@@ -211,12 +211,23 @@ stay in local logs.
 
 Clicking "Repair" on the Connections pane's unreadable-session banner records
 the existing `ade_feature_used` event at the IPC owner boundary (where the
-restart outcome is known) with `feature: "connections"`,
-`action: "brain_repair"`, and a coarse `outcome` (`completed` or `failed`). It
-carries no error text, paths, or machine identifiers — the thrown error stays in
-the renderer. A per-outcome one-hour deduplication key bounds a click-loop to at
-most 24 accepted events per installation per UTC day, inside the existing
-`ade_feature_used` and shared ceilings.
+outcome is known) with `feature: "connections"`, `action: "brain_repair"`, and a
+coarse `outcome`. The control now repairs the shared credential store — converge
+its key binding, restore anything a peer process set aside — before restarting
+the background service, so the outcome has three values rather than two:
+`completed` (the store is readable, whether or not anything had to be restored),
+`sign_in_required` (the repair ran, but nothing on this computer can open what
+was set aside), and `failed` (the repair itself threw). The distinction is the
+point — collapsing "recovered your session" and "your session is gone" into one
+value answers neither question. Both the credential-repair handler and the older
+restart-only handler emit the same action and dedupe key, because they are the
+same product fact reached through a new and an old preload. It carries no error
+text, paths, key material, or machine identifiers — the thrown error stays in the
+renderer. A per-outcome one-hour deduplication key bounds a click-loop to at most
+24 accepted events per outcome — 72 across all three — per installation per UTC
+day, inside the existing `ade_feature_used` 140-per-day / 30-per-minute limits
+and the shared 200-event ceiling; no ceiling was raised. The dashboard spec is
+deliberately untouched: no card asks this question yet.
 
 Clicking "Reconnect this computer" on the Account pane's removed-machine banner
 records the existing `ade_feature_used` event at the IPC owner boundary (the


### PR DESCRIPTION
A real user spent an evening with a completely dead ADE. The cause was a design
flaw in the shared credential store, and **opening the desktop app was the
breaking event — every time.**

## The trapdoor

`~/.ade/secrets/credentials.json.enc` is co-owned by three processes that do not
have equal access to OS-held key material. The brain runs as a launchd agent
(`com.ade.runtime`) with no UI, so reading a keychain item whose ACL belongs to
another app needs a consent prompt it can never answer: `security` fails closed,
`resolveMacKeychainMaterialOutcome` correctly reports `unavailable`, and the
brain derives the bare machine key. The desktop app reads that item fine.

The decode path made that asymmetry fatal:

```ts
const candidates = osBound ? [key, machineKey] : [machineKey];
```

A process **with** material tried the OS-bound key and fell back to the machine
key. A process **without** material had no fallback at all. And a read that
succeeded via the fallback *re-sealed the file with the current process's key*.

So: brain seals with the bare key → works. User opens ADE → the app reads it
through the fallback and "helpfully" upgrades it to OS-bound → the brain can
never read it again. Its first startup act mints the sync bootstrap token, that
write threw, the process exited, launchd restarted it, forever — ~15 processes
per millisecond in the kernel log. `ade doctor` could only say `brain.running:
false`, and the launchd backoff line said `after repeated failures: unknown`.
Reinstalling did nothing: the poisoned state is `~/.ade/secrets` plus a keychain
item, and both survive a reinstall.

## The design

**The shared store is sealed with the bare machine key. Always.** The envelope
now records that (`binding: "machine"`), still `version: 1` and outside the AAD
so an older build keeps reading files this one writes — a downgrade must not
repeat the incident. OS binding survives as a **read-only** compatibility path
with no writer.

That is a deliberate trade, documented in the code. An attacker who copies
`~/.ade/secrets` now gets the ciphertext and the key beside it — but that was
already true of `machine-identity-signing.json` and `sync-cloud-relay.json`, and
OS binding never stopped the realistic attacker, who runs as this user and can
just ask the keychain. Single-writer secrets that want real OS protection keep
the Electron `safeStorage` store.

- **Reading is symmetric.** Both keys are tried whenever both exist, ordered by
  the declared binding.
- **Re-sealing only ever moves toward `machine`.** The upgrade-on-read that
  created the trapdoor is gone; the downgrade is what heals broken machines.
- **An unreadable store never fails a process.** Reads report a state and a
  coarse reason. A *write* copies the ciphertext aside to a timestamped sibling
  with a quarantine marker and starts fresh — the "never write an empty store
  over real credentials" invariant is kept by preserving the bytes, not by
  refusing to run. Refusing is what crash-looped the brain.

## Self-heal on already-broken machines

No shell surgery, no re-auth:

1. The brain can't read the OS-bound store → quarantines it as **recoverable**
   and boots signed out instead of dying.
2. The desktop app opens, decrypts the quarantined copy, and merges it back —
   only for keys the live store lacks, so a token the user replaced in the
   meantime is never resurrected. Session intact.
3. If the process that *does* hold the material tries and fails (the destroyed
   keychain-item case), the marker is demoted so every surface stops promising a
   repair that cannot happen and says "sign in again" instead.

This also covers the volatile workaround state: with
`ADE_CREDENTIAL_STORE_DISABLE_OS_BINDING=1` set via `launchctl setenv`, the store
on disk is machine-sealed, so after the reboot that drops the env var the new
code simply reads it. The env var stops mattering.

## Saying why

- The launchd backoff line carries the recorded detail instead of the bare
  `unknown` bucket.
- The brain logs its credential-store state at startup, into
  `launchd.err.log` where someone debugging a dead brain is already looking.
- `ade doctor` gained a **Credentials** row read straight from disk — the case it
  exists for is a brain that cannot start, so it must not need one.
- `ade brain repair-credentials` runs the repair locally, for the same reason.

## Repair actually repairs

`useBrainRepair` restarted the background service and nothing else — which
cannot fix any credential-store condition, the only condition that surface
appears for. `account.repairSession` now repairs the store first (converge the
binding, restore what was set aside), restarts the brain after, and reports which
of three things happened rather than "we restarted something".

## Windows

Reviewed as a first-class runtime, and it found two real defects:

- Quarantine used `rename`. Windows cannot rename a file while any handle is
  open, so a peer mid-read yields `EPERM`/`EACCES`/`EBUSY` — this path throwing
  is the crash loop quarantine exists to prevent. It copies now.
- `readOrCreateWindowsDpapiMaterial` throws on every DPAPI failure, including a
  transient PowerShell cold-start timeout, and that exception travelled straight
  out of `getSync` — the same crash loop by a different trigger. It degrades to
  the recoverable classification now, which is safe precisely because no writer
  seals with OS material any more.

DPAPI itself is symmetric (the app and the scheduled-task brain both run as the
signed-in user), so the ACL asymmetry was macOS-only. No capability is lost.

## Adjacent paths audited

- **`projectSecretService`** (`project-secrets.v1.enc`) — same class, same store
  implementation, and the brain reads `CLERK_*` from it. **Fixed by the same
  change.**
- **`ElectronSafeStorageCredentialStore`** — its legacy migration already aborts
  on an unreadable store rather than destroying it; verified still correct
  against the new non-throwing read.
- **`machine-identity-signing.json`, `sync-cloud-relay.json`** — plaintext JSON,
  no key derivation, no OS binding. **Cleared:** no asymmetry is possible.
- **`pluginSecretStore.ts`** — does not exist in this repo.
- Every other `osBoundKeyMaterial` consumer — there are none outside
  `credentialStore.ts`.

## Also

Split `credentialStore.ts` (1888 lines) along its real seams into
`credentialFileIo.ts` and `credentialStoreQuarantine.ts`. The Repair analytics
event was reusing an action/outcome pair outside the closed allowlist and would
have been silently stripped — it now reuses `brain_repair` with one added
allowlisted outcome, `sign_in_required`, because collapsing "we recovered your
session" and "your session is gone" into `completed` answers neither question.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- ade:link v=1 type=pr repo=arul28/ADE branch=ade%2Fcredential-store-hardening-be08830f num=1079 -->
<p>
  <img src="https://ade-app.dev/logo.png" height="18" align="left" alt="ADE">
  &nbsp;&nbsp;<strong>Open in ADE</strong>
  &nbsp;·&nbsp; <a href="https://ade-app.dev/open?type=branch&amp;repo=arul28%2FADE&amp;branch=ade%2Fcredential-store-hardening-be08830f&amp;pr=1079">ade/credential-store-hardening-be08830f branch</a>
  &nbsp;·&nbsp; <a href="https://ade-app.dev/open?type=pr&amp;repo=arul28%2FADE&amp;number=1079">PR #1079</a>
</p>
<!-- /ade:link -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added local credential-store repair through the CLI and desktop app.
  - Added credential health reporting to diagnostics, including actionable guidance for missing, unreadable, or quarantined credentials.
  - Added recovery of saved credentials while protecting unreadable data through quarantine.
  - Repair results now explain whether credentials were restored and whether the background service restarted.
- **Bug Fixes**
  - Improved startup and crash-loop messages with useful failure details.
  - Updated sign-in guidance to recommend trying Repair before signing in again.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->