### PR TITLE
Stop unknown-device sync rejection storms and Windows EBUSY flakes

### DIFF
--- a/apps/ade-cli/src/services/sync/brainProjectActionsSyncHandler.ts
+++ b/apps/ade-cli/src/services/sync/brainProjectActionsSyncHandler.ts
@@ -53,6 +53,10 @@ import {
   type PairFailureSubject,
 } from "./syncPairFailureTracker";
 import {
+  applyPairedDeviceRejectionThrottle,
+  createPairedDeviceRejectionLimiter,
+} from "./pairedDeviceRejectionLimiter";
+import {
   createRelayAuthorizationLifecycle,
   SYNC_RELAY_AUTHORIZATION_CLOSE_CODE,
   type RelayAuthorizationLifecycle,
@@ -370,6 +374,7 @@ export function createBrainProjectActionsSyncHandler(
   const { pinStore, pairingStore, securityStore } =
     resolveBrainMachineSyncStores(args.secretsDir);
   const dpopNonceCache = createSyncDpopNonceCache();
+  const pairedDeviceRejectionLimiter = createPairedDeviceRejectionLimiter();
   // One in-flight account-hello commit per device, so two routes arriving
   // together cannot both write a pairing record for it.
   const accountHelloCommitLocks = new Map<string, Promise<unknown>>();
@@ -1363,10 +1368,19 @@ export function createBrainProjectActionsSyncHandler(
                 // caller whether a device id exists here turns the handshake
                 // into an existence oracle — and the user's next step is the
                 // same either way.
-                args.logger.warn("sync_ingress.paired_device_rejected", {
-                  deviceId: auth.deviceId,
-                  reason: knownRecord ? "secret_mismatch" : "unknown_device",
-                });
+                // Throttle is keyed only by device id — never by reason — so
+                // the delay and log cadence cannot leak existence either.
+                const throttle = pairedDeviceRejectionLimiter.record(auth.deviceId);
+                if (throttle.shouldLog) {
+                  args.logger.warn("sync_ingress.paired_device_rejected", {
+                    deviceId: auth.deviceId,
+                    reason: knownRecord ? "secret_mismatch" : "unknown_device",
+                    countInWindow: throttle.countInWindow,
+                    delayMs: throttle.delayMs,
+                  });
+                }
+                await applyPairedDeviceRejectionThrottle(throttle);
+                if (!isPeerCurrent(lifecycleGeneration)) return true;
                 return authFail(SYNC_REPAIR_REQUIRED_MESSAGE, "repair_required");
               }
               authenticatedPairingRecord = pairingStore.getPairingRecord(auth.deviceId);

--- a/apps/ade-cli/src/services/sync/pairedDeviceRejectionLimiter.test.ts
+++ b/apps/ade-cli/src/services/sync/pairedDeviceRejectionLimiter.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it } from "vitest";
+import {
+  applyPairedDeviceRejectionThrottle,
+  createPairedDeviceRejectionLimiter,
+  PAIRED_DEVICE_REJECTION_BASE_DELAY_MS,
+  PAIRED_DEVICE_REJECTION_DELAY_AFTER,
+  PAIRED_DEVICE_REJECTION_LOG_EVERY,
+  PAIRED_DEVICE_REJECTION_MAX_DELAY_MS,
+  PAIRED_DEVICE_REJECTION_WINDOW_MS,
+} from "./pairedDeviceRejectionLimiter";
+
+function createClock(startMs = 1_000_000) {
+  let nowMs = startMs;
+  return {
+    now: () => nowMs,
+    advance(ms: number) {
+      nowMs += ms;
+    },
+  };
+}
+
+describe("paired device rejection limiter", () => {
+  it("logs the first rejection and then every Nth, independent of rejection reason", () => {
+    const clock = createClock();
+    const limiter = createPairedDeviceRejectionLimiter({ now: clock.now });
+    const logged: number[] = [];
+
+    for (let i = 1; i <= PAIRED_DEVICE_REJECTION_LOG_EVERY * 2; i += 1) {
+      const action = limiter.record("phone-a");
+      if (action.shouldLog) logged.push(i);
+      expect(action.countInWindow).toBe(i);
+    }
+
+    expect(logged).toEqual([
+      1,
+      PAIRED_DEVICE_REJECTION_LOG_EVERY,
+      PAIRED_DEVICE_REJECTION_LOG_EVERY * 2,
+    ]);
+  });
+
+  it("does not start delaying until after the burst threshold, then caps", () => {
+    const clock = createClock();
+    const limiter = createPairedDeviceRejectionLimiter({ now: clock.now });
+
+    for (let i = 1; i <= PAIRED_DEVICE_REJECTION_DELAY_AFTER; i += 1) {
+      expect(limiter.record("phone-a").delayMs).toBe(0);
+    }
+
+    const firstDelayed = limiter.record("phone-a");
+    expect(firstDelayed.delayMs).toBe(PAIRED_DEVICE_REJECTION_BASE_DELAY_MS);
+
+    const secondDelayed = limiter.record("phone-a");
+    expect(secondDelayed.delayMs).toBe(PAIRED_DEVICE_REJECTION_BASE_DELAY_MS * 2);
+
+    for (let i = 0; i < 20; i += 1) {
+      limiter.record("phone-a");
+    }
+    expect(limiter.record("phone-a").delayMs).toBe(PAIRED_DEVICE_REJECTION_MAX_DELAY_MS);
+  });
+
+  it("isolates devices so one looping phone cannot delay another", () => {
+    const clock = createClock();
+    const limiter = createPairedDeviceRejectionLimiter({ now: clock.now });
+
+    for (let i = 0; i < 10; i += 1) {
+      limiter.record("phone-looping");
+    }
+
+    const other = limiter.record("phone-ok");
+    expect(other.countInWindow).toBe(1);
+    expect(other.shouldLog).toBe(true);
+    expect(other.delayMs).toBe(0);
+  });
+
+  it("forgets hits that fall outside the window", () => {
+    const clock = createClock();
+    const limiter = createPairedDeviceRejectionLimiter({ now: clock.now });
+
+    for (let i = 0; i < 10; i += 1) {
+      limiter.record("phone-a");
+    }
+    expect(limiter.record("phone-a").countInWindow).toBe(11);
+
+    clock.advance(PAIRED_DEVICE_REJECTION_WINDOW_MS + 1);
+    const other = limiter.record("phone-b");
+    expect(other.countInWindow).toBe(1);
+    const afterWindow = limiter.record("phone-a");
+    expect(afterWindow.countInWindow).toBe(1);
+    expect(afterWindow.shouldLog).toBe(true);
+    expect(afterWindow.delayMs).toBe(0);
+  });
+
+  it("does not key empty device ids into a shared bucket", () => {
+    const limiter = createPairedDeviceRejectionLimiter();
+    const first = limiter.record("   ");
+    const second = limiter.record("");
+    expect(first.delayMs).toBe(0);
+    expect(second.delayMs).toBe(0);
+    expect(first.shouldLog).toBe(true);
+    expect(second.shouldLog).toBe(true);
+  });
+
+  it("skips sleeping when delay is zero", async () => {
+    const started = Date.now();
+    await applyPairedDeviceRejectionThrottle({
+      countInWindow: 1,
+      shouldLog: true,
+      delayMs: 0,
+    });
+    expect(Date.now() - started).toBeLessThan(50);
+  });
+});

--- a/apps/ade-cli/src/services/sync/pairedDeviceRejectionLimiter.test.ts
+++ b/apps/ade-cli/src/services/sync/pairedDeviceRejectionLimiter.test.ts
@@ -109,4 +109,21 @@ describe("paired device rejection limiter", () => {
     });
     expect(Date.now() - started).toBeLessThan(50);
   });
+
+  it("keeps a large same-device burst as a bounded count, not a growing timestamp list", () => {
+    const clock = createClock();
+    const limiter = createPairedDeviceRejectionLimiter({ now: clock.now });
+    const burst = 10_000;
+
+    let last = limiter.record("phone-burst");
+    for (let i = 1; i < burst; i += 1) {
+      last = limiter.record("phone-burst");
+    }
+
+    expect(last.countInWindow).toBe(burst);
+    expect(last.delayMs).toBe(PAIRED_DEVICE_REJECTION_MAX_DELAY_MS);
+    const other = limiter.record("phone-ok");
+    expect(other.countInWindow).toBe(1);
+    expect(other.delayMs).toBe(0);
+  });
 });

--- a/apps/ade-cli/src/services/sync/pairedDeviceRejectionLimiter.test.ts
+++ b/apps/ade-cli/src/services/sync/pairedDeviceRejectionLimiter.test.ts
@@ -126,4 +126,23 @@ describe("paired device rejection limiter", () => {
     expect(other.countInWindow).toBe(1);
     expect(other.delayMs).toBe(0);
   });
+
+  it("keeps backoff across the 60s boundary for a sustained retry loop", () => {
+    const clock = createClock();
+    const limiter = createPairedDeviceRejectionLimiter({ now: clock.now });
+
+    for (let i = 0; i < 8; i += 1) {
+      limiter.record("phone-loop");
+      clock.advance(7_500);
+    }
+
+    const acrossBoundary = limiter.record("phone-loop");
+    expect(acrossBoundary.countInWindow).toBeGreaterThan(PAIRED_DEVICE_REJECTION_DELAY_AFTER);
+    expect(acrossBoundary.delayMs).toBeGreaterThan(0);
+
+    clock.advance(PAIRED_DEVICE_REJECTION_WINDOW_MS + 1);
+    const afterQuiet = limiter.record("phone-loop");
+    expect(afterQuiet.countInWindow).toBe(1);
+    expect(afterQuiet.delayMs).toBe(0);
+  });
 });

--- a/apps/ade-cli/src/services/sync/pairedDeviceRejectionLimiter.ts
+++ b/apps/ade-cli/src/services/sync/pairedDeviceRejectionLimiter.ts
@@ -47,13 +47,11 @@ export function createPairedDeviceRejectionLimiter(
   const delayAfter = options.delayAfter ?? PAIRED_DEVICE_REJECTION_DELAY_AFTER;
   const baseDelayMs = options.baseDelayMs ?? PAIRED_DEVICE_REJECTION_BASE_DELAY_MS;
   const maxDelayMs = options.maxDelayMs ?? PAIRED_DEVICE_REJECTION_MAX_DELAY_MS;
-  const hits = new Map<string, number[]>();
+  const hits = new Map<string, { windowStartMs: number; count: number }>();
 
   const pruneExpired = (nowMs: number): void => {
-    for (const [id, stamps] of hits) {
-      const next = stamps.filter((ts) => nowMs - ts <= windowMs);
-      if (next.length === 0) hits.delete(id);
-      else hits.set(id, next);
+    for (const [id, slot] of hits) {
+      if (nowMs - slot.windowStartMs > windowMs) hits.delete(id);
     }
   };
 
@@ -69,10 +67,13 @@ export function createPairedDeviceRejectionLimiter(
         const oldest = hits.keys().next().value;
         if (oldest) hits.delete(oldest);
       }
-      const series = hits.get(key) ?? [];
-      series.push(nowMs);
-      hits.set(key, series);
-      const countInWindow = series.length;
+      const existing = hits.get(key);
+      const slot =
+        existing && nowMs - existing.windowStartMs <= windowMs
+          ? { windowStartMs: existing.windowStartMs, count: existing.count + 1 }
+          : { windowStartMs: nowMs, count: 1 };
+      hits.set(key, slot);
+      const countInWindow = slot.count;
       const shouldLog = countInWindow === 1 || countInWindow % logEvery === 0;
       let delayMs = 0;
       if (countInWindow > delayAfter) {

--- a/apps/ade-cli/src/services/sync/pairedDeviceRejectionLimiter.ts
+++ b/apps/ade-cli/src/services/sync/pairedDeviceRejectionLimiter.ts
@@ -18,6 +18,8 @@ export const PAIRED_DEVICE_REJECTION_DELAY_AFTER = 3;
 export const PAIRED_DEVICE_REJECTION_BASE_DELAY_MS = 250;
 export const PAIRED_DEVICE_REJECTION_MAX_DELAY_MS = 8_000;
 const PAIRED_DEVICE_REJECTION_MAX_TRACKED = 512;
+/** Rolling buckets keep a sliding 60s count without a timestamp per hit. */
+const PAIRED_DEVICE_REJECTION_BUCKET_MS = 5_000;
 
 export type PairedDeviceRejectionAction = {
   countInWindow: number;
@@ -47,11 +49,21 @@ export function createPairedDeviceRejectionLimiter(
   const delayAfter = options.delayAfter ?? PAIRED_DEVICE_REJECTION_DELAY_AFTER;
   const baseDelayMs = options.baseDelayMs ?? PAIRED_DEVICE_REJECTION_BASE_DELAY_MS;
   const maxDelayMs = options.maxDelayMs ?? PAIRED_DEVICE_REJECTION_MAX_DELAY_MS;
-  const hits = new Map<string, { windowStartMs: number; count: number }>();
+  const hits = new Map<string, Map<number, number>>();
+
+  const pruneSlot = (slot: Map<number, number>, nowMs: number): number => {
+    const cutoff = nowMs - windowMs;
+    let count = 0;
+    for (const [bucketStartMs, bucketCount] of slot) {
+      if (bucketStartMs <= cutoff) slot.delete(bucketStartMs);
+      else count += bucketCount;
+    }
+    return count;
+  };
 
   const pruneExpired = (nowMs: number): void => {
     for (const [id, slot] of hits) {
-      if (nowMs - slot.windowStartMs > windowMs) hits.delete(id);
+      if (pruneSlot(slot, nowMs) === 0) hits.delete(id);
     }
   };
 
@@ -67,13 +79,17 @@ export function createPairedDeviceRejectionLimiter(
         const oldest = hits.keys().next().value;
         if (oldest) hits.delete(oldest);
       }
-      const existing = hits.get(key);
-      const slot =
-        existing && nowMs - existing.windowStartMs <= windowMs
-          ? { windowStartMs: existing.windowStartMs, count: existing.count + 1 }
-          : { windowStartMs: nowMs, count: 1 };
-      hits.set(key, slot);
-      const countInWindow = slot.count;
+      let slot = hits.get(key);
+      if (!slot) {
+        slot = new Map();
+        hits.set(key, slot);
+      }
+      const bucketStartMs =
+        Math.floor(nowMs / PAIRED_DEVICE_REJECTION_BUCKET_MS) *
+        PAIRED_DEVICE_REJECTION_BUCKET_MS;
+      slot.set(bucketStartMs, (slot.get(bucketStartMs) ?? 0) + 1);
+      const countInWindow = pruneSlot(slot, nowMs);
+      if (countInWindow === 0) hits.delete(key);
       const shouldLog = countInWindow === 1 || countInWindow % logEvery === 0;
       let delayMs = 0;
       if (countInWindow > delayAfter) {

--- a/apps/ade-cli/src/services/sync/pairedDeviceRejectionLimiter.ts
+++ b/apps/ade-cli/src/services/sync/pairedDeviceRejectionLimiter.ts
@@ -1,0 +1,94 @@
+/**
+ * Host-side throttle for repeated paired-hello rejections from the same
+ * device id.
+ *
+ * A phone that kept a pairing secret after the host forgot the record will
+ * retry forever (LAN + Tailscale + Relay racing). Each hello is a full reject
+ * + close + warn log; left alone that is thousands of lines a day.
+ *
+ * The wire body stays identical for `unknown_device` and `secret_mismatch`.
+ * This limiter never sees the reason: applying a different delay or log
+ * cadence per reason would let an unauthenticated caller tell whether the
+ * device id exists.
+ */
+
+export const PAIRED_DEVICE_REJECTION_WINDOW_MS = 60_000;
+export const PAIRED_DEVICE_REJECTION_LOG_EVERY = 8;
+export const PAIRED_DEVICE_REJECTION_DELAY_AFTER = 3;
+export const PAIRED_DEVICE_REJECTION_BASE_DELAY_MS = 250;
+export const PAIRED_DEVICE_REJECTION_MAX_DELAY_MS = 8_000;
+const PAIRED_DEVICE_REJECTION_MAX_TRACKED = 512;
+
+export type PairedDeviceRejectionAction = {
+  countInWindow: number;
+  shouldLog: boolean;
+  delayMs: number;
+};
+
+export type PairedDeviceRejectionLimiter = {
+  record(deviceId: string): PairedDeviceRejectionAction;
+};
+
+type PairedDeviceRejectionLimiterOptions = {
+  now?: () => number;
+  windowMs?: number;
+  logEvery?: number;
+  delayAfter?: number;
+  baseDelayMs?: number;
+  maxDelayMs?: number;
+};
+
+export function createPairedDeviceRejectionLimiter(
+  options: PairedDeviceRejectionLimiterOptions = {},
+): PairedDeviceRejectionLimiter {
+  const now = options.now ?? Date.now;
+  const windowMs = options.windowMs ?? PAIRED_DEVICE_REJECTION_WINDOW_MS;
+  const logEvery = options.logEvery ?? PAIRED_DEVICE_REJECTION_LOG_EVERY;
+  const delayAfter = options.delayAfter ?? PAIRED_DEVICE_REJECTION_DELAY_AFTER;
+  const baseDelayMs = options.baseDelayMs ?? PAIRED_DEVICE_REJECTION_BASE_DELAY_MS;
+  const maxDelayMs = options.maxDelayMs ?? PAIRED_DEVICE_REJECTION_MAX_DELAY_MS;
+  const hits = new Map<string, number[]>();
+
+  const pruneExpired = (nowMs: number): void => {
+    for (const [id, stamps] of hits) {
+      const next = stamps.filter((ts) => nowMs - ts <= windowMs);
+      if (next.length === 0) hits.delete(id);
+      else hits.set(id, next);
+    }
+  };
+
+  return {
+    record(deviceId: string): PairedDeviceRejectionAction {
+      const key = deviceId.trim();
+      if (!key) {
+        return { countInWindow: 1, shouldLog: true, delayMs: 0 };
+      }
+      const nowMs = now();
+      pruneExpired(nowMs);
+      if (hits.size >= PAIRED_DEVICE_REJECTION_MAX_TRACKED && !hits.has(key)) {
+        const oldest = hits.keys().next().value;
+        if (oldest) hits.delete(oldest);
+      }
+      const series = hits.get(key) ?? [];
+      series.push(nowMs);
+      hits.set(key, series);
+      const countInWindow = series.length;
+      const shouldLog = countInWindow === 1 || countInWindow % logEvery === 0;
+      let delayMs = 0;
+      if (countInWindow > delayAfter) {
+        const exp = Math.min(countInWindow - delayAfter - 1, 16);
+        delayMs = Math.min(maxDelayMs, baseDelayMs * (2 ** exp));
+      }
+      return { countInWindow, shouldLog, delayMs };
+    },
+  };
+}
+
+export async function applyPairedDeviceRejectionThrottle(
+  action: PairedDeviceRejectionAction,
+): Promise<void> {
+  if (action.delayMs <= 0) return;
+  await new Promise<void>((resolve) => {
+    setTimeout(resolve, action.delayMs);
+  });
+}

--- a/apps/ade-cli/src/services/sync/syncHostService.test.ts
+++ b/apps/ade-cli/src/services/sync/syncHostService.test.ts
@@ -4945,6 +4945,14 @@ describe("sync host account authentication", () => {
           code: "repair_required",
           message: (stale.payload as { message: string }).message,
         });
+        const unknownAgain = await harness.pairedHello("unknown-device-hello-2", {
+          deviceId: "device-this-machine-never-paired",
+          secret: "still-not-the-secret",
+        });
+        expect(unknownAgain.payload).toMatchObject({
+          code: "repair_required",
+          message: (stale.payload as { message: string }).message,
+        });
       } finally {
         await harness.cleanup();
       }

--- a/apps/ade-cli/src/services/sync/syncHostService.ts
+++ b/apps/ade-cli/src/services/sync/syncHostService.ts
@@ -154,6 +154,10 @@ import {
   type PairFailureSubject,
 } from "./syncPairFailureTracker";
 import {
+  applyPairedDeviceRejectionThrottle,
+  createPairedDeviceRejectionLimiter,
+} from "./pairedDeviceRejectionLimiter";
+import {
   createSyncDpopNonceCache,
   evaluatePairedHelloDpop,
   syncDpopFailureMessage,
@@ -2058,6 +2062,7 @@ export function createSyncHostService(args: SyncHostServiceArgs) {
     filePath: pairingSecretsPath,
     pinStore: args.pinStore,
   });
+  const pairedDeviceRejectionLimiter = createPairedDeviceRejectionLimiter();
   const machineIdentitySigningStore =
     args.machineIdentitySigningStore
     ?? createMachineIdentitySigningStore({ logger: args.logger });
@@ -7230,10 +7235,19 @@ export function createSyncHostService(args: SyncHostServiceArgs) {
             // is and logs it below, but telling an UNAUTHENTICATED caller
             // whether a device id exists here turns this into an existence
             // oracle, and the user's next step is the same either way.
-            args.logger.warn("sync_host.paired_device_rejected", {
-              deviceId: pairedAuth.deviceId,
-              reason: knownRecord ? "secret_mismatch" : "unknown_device",
-            });
+            // Throttle is keyed only by device id — never by reason — so the
+            // delay and log cadence cannot leak existence either.
+            const throttle = pairedDeviceRejectionLimiter.record(pairedAuth.deviceId);
+            if (throttle.shouldLog) {
+              args.logger.warn("sync_host.paired_device_rejected", {
+                deviceId: pairedAuth.deviceId,
+                reason: knownRecord ? "secret_mismatch" : "unknown_device",
+                countInWindow: throttle.countInWindow,
+                delayMs: throttle.delayMs,
+              });
+            }
+            await applyPairedDeviceRejectionThrottle(throttle);
+            if (!isPeerLifecycleCurrent(peer, lifecycleGeneration)) return true;
             return authFail(SYNC_REPAIR_REQUIRED_MESSAGE, "repair_required");
           }
           authenticatedPairingRecord = pairingStore.getPairingRecordForSecret(

--- a/apps/desktop/scripts/windows-uninstall-cleanup.test.mjs
+++ b/apps/desktop/scripts/windows-uninstall-cleanup.test.mjs
@@ -56,6 +56,38 @@ function shortWindowsPath(value) {
   return resolved;
 }
 
+// Node ignores maxRetries/retryDelay unless recursive is true. These teardowns
+// already rm a temp directory (ADE Beta.exe is a locked child), so retries
+// apply. 40 × 250ms matches windows-quirks.md §6 / removeCursorSdkRuntimePath.
+const WINDOWS_TEMP_CLEANUP_RM_OPTIONS = {
+  recursive: true,
+  force: true,
+  maxRetries: 40,
+  retryDelay: 250,
+};
+
+function removeTempRoot(tempRoot) {
+  fs.rmSync(tempRoot, WINDOWS_TEMP_CLEANUP_RM_OPTIONS);
+}
+
+test("Windows uninstall temp cleanup retries EBUSY via fs.rmSync options", (t) => {
+  const originalRmSync = fs.rmSync;
+  const seen = [];
+  t.after(() => {
+    fs.rmSync = originalRmSync;
+  });
+  fs.rmSync = (target, options) => {
+    seen.push({ target, options });
+  };
+  removeTempRoot("/tmp/ade-windows-uninstall-ebusy");
+  assert.equal(seen.length, 1);
+  assert.equal(seen[0].target, "/tmp/ade-windows-uninstall-ebusy");
+  assert.deepEqual(seen[0].options, WINDOWS_TEMP_CLEANUP_RM_OPTIONS);
+  assert.equal(seen[0].options.recursive, true);
+  assert.equal(seen[0].options.maxRetries, 40);
+  assert.equal(seen[0].options.retryDelay, 250);
+});
+
 test("Windows standalone installer path normalizer is executable PowerShell", {
   skip: process.platform !== "win32",
 }, () => {
@@ -83,7 +115,7 @@ test("Windows uninstall cleanup removes only CLI shims owned by this installatio
   skip: process.platform !== "win32",
 }, (t) => {
   const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "ade uninstall cleanup "));
-  t.after(() => fs.rmSync(tempRoot, { recursive: true, force: true }));
+  t.after(() => removeTempRoot(tempRoot));
   const installDir = path.join(tempRoot, "install & source");
   const packagedCliDir = path.join(installDir, "resources", "ade-cli", "bin");
   const cliBinDir = path.join(tempRoot, "user bin");
@@ -129,7 +161,7 @@ test("Windows stable uninstall reaches protocol cleanup without treating it as C
   skip: process.platform !== "win32",
 }, (t) => {
   const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "ade stable protocol cleanup "));
-  t.after(() => fs.rmSync(tempRoot, { recursive: true, force: true }));
+  t.after(() => removeTempRoot(tempRoot));
   const installDir = path.join(tempRoot, "ADE");
   const cliBinDir = path.join(tempRoot, "empty user bin");
   fs.mkdirSync(installDir, { recursive: true });
@@ -161,7 +193,7 @@ test("Windows uninstall still cleans a corrupted product whose executable is mis
   skip: process.platform !== "win32",
 }, (t) => {
   const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "ade missing executable cleanup "));
-  t.after(() => fs.rmSync(tempRoot, { recursive: true, force: true }));
+  t.after(() => removeTempRoot(tempRoot));
   const installDir = path.join(tempRoot, "ADE Beta");
   const cliBinDir = path.join(tempRoot, "empty user bin");
   const adeHome = path.join(tempRoot, ".ade-beta");
@@ -197,7 +229,7 @@ test("Windows bundled CLI wrapper resolves the Beta executable and identity", {
   skip: process.platform !== "win32",
 }, (t) => {
   const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "ade beta wrapper "));
-  t.after(() => fs.rmSync(tempRoot, { recursive: true, force: true }));
+  t.after(() => removeTempRoot(tempRoot));
   const resourcesDir = path.join(tempRoot, "resources");
   const cliRoot = path.join(resourcesDir, "ade-cli");
   const binDir = path.join(cliRoot, "bin");
@@ -250,7 +282,7 @@ test("Windows install setup compensates shim and startup state when service regi
   skip: process.platform !== "win32",
 }, (t) => {
   const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "ade setup rollback "));
-  t.after(() => fs.rmSync(tempRoot, { recursive: true, force: true }));
+  t.after(() => removeTempRoot(tempRoot));
   const installDir = path.join(tempRoot, "ADE Beta");
   const cliRoot = path.join(installDir, "resources", "ade-cli");
   const cliBin = path.join(cliRoot, "bin");
@@ -314,7 +346,7 @@ test("Windows failed repair restores the previous shim and startup service", {
   skip: process.platform !== "win32",
 }, (t) => {
   const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "ade repair rollback "));
-  t.after(() => fs.rmSync(tempRoot, { recursive: true, force: true }));
+  t.after(() => removeTempRoot(tempRoot));
   const installDir = path.join(tempRoot, "ADE Beta");
   const cliRoot = path.join(installDir, "resources", "ade-cli");
   const cliBin = path.join(cliRoot, "bin");
@@ -376,7 +408,7 @@ test("Windows uninstall cleanup uses the packaged executable and channel identit
   skip: process.platform !== "win32",
 }, (t) => {
   const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "ade beta uninstall "));
-  t.after(() => fs.rmSync(tempRoot, { recursive: true, force: true }));
+  t.after(() => removeTempRoot(tempRoot));
   const installDir = path.join(tempRoot, "ADE Beta");
   const cliRoot = path.join(installDir, "resources", "ade-cli");
   const cliBinDir = path.join(tempRoot, "empty user bin");
@@ -450,7 +482,7 @@ test("Windows uninstall cleanup reports the packaged executable exit code", {
   skip: process.platform !== "win32",
 }, (t) => {
   const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "ade failed uninstall "));
-  t.after(() => fs.rmSync(tempRoot, { recursive: true, force: true }));
+  t.after(() => removeTempRoot(tempRoot));
   const installDir = path.join(tempRoot, "ADE");
   const cliRoot = path.join(installDir, "resources", "ade-cli");
   const cliBinDir = path.join(tempRoot, "empty user bin");

--- a/apps/ios/ADE/Services/SyncService.swift
+++ b/apps/ios/ADE/Services/SyncService.swift
@@ -2490,6 +2490,51 @@ private func syncCodeIsPairingRejection(_ code: String?) -> Bool {
   code == "auth_failed" || code == "repair_required"
 }
 
+/// One hop's pairing-rejection outcome after a connection race. A single
+/// unattributed hop must not drop the pairing — a stale LAN address can reach
+/// a stranger. Invalidation requires the race to have *finished* (every
+/// scheduled candidate produced an outcome) and every outcome to be a pairing
+/// rejection from the same host. Timeouts and mixed failures keep the pairing.
+struct SyncRacePairingFailure: Equatable {
+  var code: String?
+  var respondingHostIdentity: String?
+  var isAmbiguous: Bool
+}
+
+func syncShouldInvalidateSavedPairingAfterRace(
+  hopOutcomes: [SyncRacePairingFailure?],
+  scheduledCandidateCount: Int
+) -> Bool {
+  guard scheduledCandidateCount > 0, hopOutcomes.count == scheduledCandidateCount else {
+    return false
+  }
+  let pairing = hopOutcomes.compactMap { $0 }
+  guard pairing.count == hopOutcomes.count else { return false }
+  guard pairing.allSatisfy({ syncCodeIsPairingRejection($0.code) }) else { return false }
+  if pairing.contains(where: { !$0.isAmbiguous }) {
+    return true
+  }
+  guard pairing.count >= 2 else { return false }
+  let responding = pairing.compactMap { failure -> String? in
+    let trimmed = failure.respondingHostIdentity?.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard let trimmed, !trimmed.isEmpty else { return nil }
+    return trimmed
+  }
+  guard responding.count == pairing.count else { return false }
+  return Set(responding).count == 1
+}
+
+private func syncRacePairingFailure(from error: Error) -> SyncRacePairingFailure? {
+  let nsError = error as NSError
+  let code = nsError.userInfo["ADEErrorCode"] as? String
+  guard syncCodeIsPairingRejection(code) else { return nil }
+  return SyncRacePairingFailure(
+    code: code,
+    respondingHostIdentity: nsError.userInfo[syncRespondingHostIdentityKey] as? String,
+    isAmbiguous: nsError.userInfo[syncAmbiguousRouteAuthFailureKey] as? Bool == true
+  )
+}
+
 /// Copy for the rejection codes worth rewording on the phone. Everything else
 /// shows the host's own message, which is already written for a person.
 func syncHelloErrorFriendlyMessage(code: String?, respondingHostName: String?) -> String? {
@@ -15397,6 +15442,18 @@ final class SyncService: ObservableObject {
 
       var ownership = SyncConnectionRaceOwnership(candidateIds: Set(candidates.map(\.id)))
       var lastFailure: Error?
+      var raceHopOutcomes: [SyncRacePairingFailure?] = []
+      var lastPairingFailure: Error?
+      func resolvedRaceFailure(fallback: Error) -> Error {
+        if let lastPairingFailure,
+           syncShouldInvalidateSavedPairingAfterRace(
+            hopOutcomes: raceHopOutcomes,
+            scheduledCandidateCount: candidates.count
+           ) {
+          return errorByClearingAmbiguousRouteAuthFailure(lastPairingFailure)
+        }
+        return lastFailure ?? fallback
+      }
       while let event = try await group.next() {
         switch event {
         case .authenticated(let candidate):
@@ -15414,6 +15471,9 @@ final class SyncService: ObservableObject {
           }
         case .failed(let candidateId, let error):
           lastFailure = error
+          if candidateId < 0 {
+            continue
+          }
           let endpoint = candidates.first(where: { $0.id == candidateId })?.endpoint
           if let endpoint {
             let marked = errorByMarkingAmbiguousRouteAuthFailure(
@@ -15422,6 +15482,11 @@ final class SyncService: ObservableObject {
               expectedHostIdentity: profile.hostIdentity
             )
             lastFailure = marked
+            let pairingFailure = syncRacePairingFailure(from: marked)
+            raceHopOutcomes.append(pairingFailure)
+            if pairingFailure != nil {
+              lastPairingFailure = marked
+            }
             if syncEndpointFailureIsMeaningful(marked),
                raceFailedEndpoints.generation == connectAttemptGeneration {
               raceFailedEndpoints.addresses.append(endpoint.address)
@@ -15438,10 +15503,12 @@ final class SyncService: ObservableObject {
               }
               throw marked
             }
+          } else {
+            raceHopOutcomes.append(nil)
           }
           if ownership.failed(candidateId: candidateId) == .exhausted {
             group.cancelAll()
-            throw lastFailure ?? noConnectableAddressError()
+            throw resolvedRaceFailure(fallback: noConnectableAddressError())
           }
           if let nextCandidate = scheduler.candidateFinished(candidateId) {
             group.addTask { @MainActor [weak self] in
@@ -15465,14 +15532,14 @@ final class SyncService: ObservableObject {
               lateCandidate.task.cancel(with: .goingAway, reason: nil)
             }
           }
-          throw lastFailure ?? NSError(
+          throw resolvedRaceFailure(fallback: NSError(
             domain: "ADE",
             code: 35,
             userInfo: [NSLocalizedDescriptionKey: "The secure connection attempt timed out."]
-          )
+          ))
         }
       }
-      throw lastFailure ?? noConnectableAddressError()
+      throw resolvedRaceFailure(fallback: noConnectableAddressError())
     }
   }
 
@@ -16041,6 +16108,13 @@ final class SyncService: ObservableObject {
     )
     var userInfo = nsError.userInfo
     userInfo[syncAmbiguousRouteAuthFailureKey] = true
+    return NSError(domain: nsError.domain, code: nsError.code, userInfo: userInfo)
+  }
+
+  private func errorByClearingAmbiguousRouteAuthFailure(_ error: Error) -> Error {
+    let nsError = error as NSError
+    var userInfo = nsError.userInfo
+    userInfo[syncAmbiguousRouteAuthFailureKey] = false
     return NSError(domain: nsError.domain, code: nsError.code, userInfo: userInfo)
   }
 

--- a/apps/ios/ADE/Services/SyncService.swift
+++ b/apps/ios/ADE/Services/SyncService.swift
@@ -2492,9 +2492,10 @@ private func syncCodeIsPairingRejection(_ code: String?) -> Bool {
 
 /// One hop's pairing-rejection outcome after a connection race. A single
 /// unattributed hop must not drop the pairing — a stale LAN address can reach
-/// a stranger. Invalidation requires the race to have *finished* (every
-/// scheduled candidate produced an outcome) and every outcome to be a pairing
-/// rejection from the same host. Timeouts and mixed failures keep the pairing.
+/// a stranger. Invalidation requires the race's *started* hops to have all
+/// finished and every outcome to be a pairing rejection from the same host.
+/// Queued candidates that never got a slot do not keep a dead pairing alive.
+/// Timeouts and mixed failures keep the pairing.
 struct SyncRacePairingFailure: Equatable {
   var code: String?
   var respondingHostIdentity: String?
@@ -2503,25 +2504,23 @@ struct SyncRacePairingFailure: Equatable {
 
 func syncShouldInvalidateSavedPairingAfterRace(
   hopOutcomes: [SyncRacePairingFailure?],
-  scheduledCandidateCount: Int
+  startedCandidateCount: Int
 ) -> Bool {
-  guard scheduledCandidateCount > 0, hopOutcomes.count == scheduledCandidateCount else {
+  guard startedCandidateCount > 0, hopOutcomes.count == startedCandidateCount else {
     return false
   }
   let pairing = hopOutcomes.compactMap { $0 }
   guard pairing.count == hopOutcomes.count else { return false }
   guard pairing.allSatisfy({ syncCodeIsPairingRejection($0.code) }) else { return false }
-  if pairing.contains(where: { !$0.isAmbiguous }) {
-    return true
-  }
-  guard pairing.count >= 2 else { return false }
   let responding = pairing.compactMap { failure -> String? in
     let trimmed = failure.respondingHostIdentity?.trimmingCharacters(in: .whitespacesAndNewlines)
     guard let trimmed, !trimmed.isEmpty else { return nil }
     return trimmed
   }
-  guard responding.count == pairing.count else { return false }
-  return Set(responding).count == 1
+  guard responding.count == pairing.count, Set(responding).count == 1 else {
+    return false
+  }
+  return pairing.contains(where: { !$0.isAmbiguous }) || pairing.count >= 2
 }
 
 private func syncRacePairingFailure(from error: Error) -> SyncRacePairingFailure? {
@@ -15419,7 +15418,9 @@ final class SyncService: ObservableObject {
     let budget = connectAttemptBudget
     return try await withThrowingTaskGroup(of: AuthenticatedConnectionRaceEvent.self) { group in
       var scheduler = SyncConnectionRaceWaveScheduler(candidates: candidates)
-      for candidate in scheduler.startInitialCandidates() {
+      let initialCandidates = scheduler.startInitialCandidates()
+      var startedCandidateCount = initialCandidates.count
+      for candidate in initialCandidates {
         group.addTask { @MainActor [weak self] in
           guard let self else { return .failed(candidateId: candidate.id, error: CancellationError()) }
           return await self.authenticatedConnectionRaceEvent(
@@ -15448,7 +15449,7 @@ final class SyncService: ObservableObject {
         if let lastPairingFailure,
            syncShouldInvalidateSavedPairingAfterRace(
             hopOutcomes: raceHopOutcomes,
-            scheduledCandidateCount: candidates.count
+            startedCandidateCount: startedCandidateCount
            ) {
           return errorByClearingAmbiguousRouteAuthFailure(lastPairingFailure)
         }
@@ -15511,6 +15512,7 @@ final class SyncService: ObservableObject {
             throw resolvedRaceFailure(fallback: noConnectableAddressError())
           }
           if let nextCandidate = scheduler.candidateFinished(candidateId) {
+            startedCandidateCount += 1
             group.addTask { @MainActor [weak self] in
               guard let self else {
                 return .failed(candidateId: nextCandidate.id, error: CancellationError())

--- a/apps/ios/ADETests/SyncAccountConnectRecoveryTests.swift
+++ b/apps/ios/ADETests/SyncAccountConnectRecoveryTests.swift
@@ -102,6 +102,148 @@ final class SyncAccountConnectRecoveryTests: XCTestCase {
     XCTAssertEqual(secret, "fresh-secret")
   }
 
+  // MARK: - race-exhausted pairing invalidation
+
+  func testSingleAmbiguousPairingRejectionDoesNotDropSavedPairing() {
+    XCTAssertFalse(syncShouldInvalidateSavedPairingAfterRace(
+      hopOutcomes: [
+        SyncRacePairingFailure(
+          code: "repair_required",
+          respondingHostIdentity: "host-stranger",
+          isAmbiguous: true
+        ),
+      ],
+      scheduledCandidateCount: 1
+    ))
+  }
+
+  func testTwoAmbiguousPairingRejectionsFromTheSameHostDropSavedPairing() {
+    XCTAssertTrue(syncShouldInvalidateSavedPairingAfterRace(
+      hopOutcomes: [
+        SyncRacePairingFailure(
+          code: "repair_required",
+          respondingHostIdentity: "host-live",
+          isAmbiguous: true
+        ),
+        SyncRacePairingFailure(
+          code: "repair_required",
+          respondingHostIdentity: "host-live",
+          isAmbiguous: true
+        ),
+      ],
+      scheduledCandidateCount: 2
+    ))
+  }
+
+  func testIncompleteRaceDoesNotDropSavedPairing() {
+    XCTAssertFalse(syncShouldInvalidateSavedPairingAfterRace(
+      hopOutcomes: [
+        SyncRacePairingFailure(
+          code: "repair_required",
+          respondingHostIdentity: "host-stranger",
+          isAmbiguous: true
+        ),
+        SyncRacePairingFailure(
+          code: "repair_required",
+          respondingHostIdentity: "host-stranger",
+          isAmbiguous: true
+        ),
+      ],
+      scheduledCandidateCount: 3
+    ))
+  }
+
+  func testTimeoutAmongHopsDoesNotDropSavedPairing() {
+    XCTAssertFalse(syncShouldInvalidateSavedPairingAfterRace(
+      hopOutcomes: [
+        SyncRacePairingFailure(
+          code: "repair_required",
+          respondingHostIdentity: "host-stranger",
+          isAmbiguous: true
+        ),
+        SyncRacePairingFailure(
+          code: "repair_required",
+          respondingHostIdentity: "host-stranger",
+          isAmbiguous: true
+        ),
+        nil,
+      ],
+      scheduledCandidateCount: 3
+    ))
+  }
+
+  func testTwoAmbiguousPairingRejectionsStillDropWhenSavedHostIdentityIsStale() {
+    XCTAssertTrue(syncShouldInvalidateSavedPairingAfterRace(
+      hopOutcomes: [
+        SyncRacePairingFailure(
+          code: "repair_required",
+          respondingHostIdentity: "host-live",
+          isAmbiguous: true
+        ),
+        SyncRacePairingFailure(
+          code: "repair_required",
+          respondingHostIdentity: "host-live",
+          isAmbiguous: true
+        ),
+        SyncRacePairingFailure(
+          code: "repair_required",
+          respondingHostIdentity: "host-live",
+          isAmbiguous: true
+        ),
+      ],
+      scheduledCandidateCount: 3
+    ))
+  }
+
+  func testMixedRespondingHostsDoNotDropSavedPairing() {
+    XCTAssertFalse(syncShouldInvalidateSavedPairingAfterRace(
+      hopOutcomes: [
+        SyncRacePairingFailure(
+          code: "repair_required",
+          respondingHostIdentity: "host-a",
+          isAmbiguous: true
+        ),
+        SyncRacePairingFailure(
+          code: "repair_required",
+          respondingHostIdentity: "host-b",
+          isAmbiguous: true
+        ),
+      ],
+      scheduledCandidateCount: 2
+    ))
+  }
+
+  func testAttributedPairingRejectionDropsSavedPairingOnItsOwn() {
+    XCTAssertTrue(syncShouldInvalidateSavedPairingAfterRace(
+      hopOutcomes: [
+        SyncRacePairingFailure(
+          code: "repair_required",
+          respondingHostIdentity: "host-saved",
+          isAmbiguous: false
+        ),
+      ],
+      scheduledCandidateCount: 1
+    ))
+  }
+
+  func testNonPairingFailuresDoNotDropSavedPairing() {
+    XCTAssertFalse(syncShouldInvalidateSavedPairingAfterRace(
+      hopOutcomes: [
+        SyncRacePairingFailure(
+          code: "repair_required",
+          respondingHostIdentity: "host-live",
+          isAmbiguous: true
+        ),
+        SyncRacePairingFailure(
+          code: "host_update_required",
+          respondingHostIdentity: "host-live",
+          isAmbiguous: true
+        ),
+      ],
+      scheduledCandidateCount: 2
+    ))
+  }
+
   // MARK: - syncConnectReachedTarget
 
   func testReachedTargetWhenAttachedToTheRequestedMachine() {

--- a/apps/ios/ADETests/SyncAccountConnectRecoveryTests.swift
+++ b/apps/ios/ADETests/SyncAccountConnectRecoveryTests.swift
@@ -113,7 +113,7 @@ final class SyncAccountConnectRecoveryTests: XCTestCase {
           isAmbiguous: true
         ),
       ],
-      scheduledCandidateCount: 1
+      startedCandidateCount: 1
     ))
   }
 
@@ -131,7 +131,7 @@ final class SyncAccountConnectRecoveryTests: XCTestCase {
           isAmbiguous: true
         ),
       ],
-      scheduledCandidateCount: 2
+      startedCandidateCount: 2
     ))
   }
 
@@ -149,7 +149,7 @@ final class SyncAccountConnectRecoveryTests: XCTestCase {
           isAmbiguous: true
         ),
       ],
-      scheduledCandidateCount: 3
+      startedCandidateCount: 3
     ))
   }
 
@@ -168,7 +168,7 @@ final class SyncAccountConnectRecoveryTests: XCTestCase {
         ),
         nil,
       ],
-      scheduledCandidateCount: 3
+      startedCandidateCount: 3
     ))
   }
 
@@ -191,7 +191,7 @@ final class SyncAccountConnectRecoveryTests: XCTestCase {
           isAmbiguous: true
         ),
       ],
-      scheduledCandidateCount: 3
+      startedCandidateCount: 3
     ))
   }
 
@@ -209,7 +209,7 @@ final class SyncAccountConnectRecoveryTests: XCTestCase {
           isAmbiguous: true
         ),
       ],
-      scheduledCandidateCount: 2
+      startedCandidateCount: 2
     ))
   }
 
@@ -222,7 +222,48 @@ final class SyncAccountConnectRecoveryTests: XCTestCase {
           isAmbiguous: false
         ),
       ],
-      scheduledCandidateCount: 1
+      startedCandidateCount: 1
+    ))
+  }
+
+  func testAttributedAndAmbiguousPairingRejectionsFromDifferentHostsDoNotDropSavedPairing() {
+    XCTAssertFalse(syncShouldInvalidateSavedPairingAfterRace(
+      hopOutcomes: [
+        SyncRacePairingFailure(
+          code: "repair_required",
+          respondingHostIdentity: "host-saved",
+          isAmbiguous: false
+        ),
+        SyncRacePairingFailure(
+          code: "repair_required",
+          respondingHostIdentity: "host-stranger",
+          isAmbiguous: true
+        ),
+      ],
+      startedCandidateCount: 2
+    ))
+  }
+
+  func testStartedHopsConsensusDropsSavedPairingWhenLaterCandidatesNeverRan() {
+    XCTAssertTrue(syncShouldInvalidateSavedPairingAfterRace(
+      hopOutcomes: [
+        SyncRacePairingFailure(
+          code: "repair_required",
+          respondingHostIdentity: "host-live",
+          isAmbiguous: true
+        ),
+        SyncRacePairingFailure(
+          code: "repair_required",
+          respondingHostIdentity: "host-live",
+          isAmbiguous: true
+        ),
+        SyncRacePairingFailure(
+          code: "repair_required",
+          respondingHostIdentity: "host-live",
+          isAmbiguous: true
+        ),
+      ],
+      startedCandidateCount: 3
     ))
   }
 
@@ -240,7 +281,7 @@ final class SyncAccountConnectRecoveryTests: XCTestCase {
           isAmbiguous: true
         ),
       ],
-      scheduledCandidateCount: 2
+      startedCandidateCount: 2
     ))
   }
 

--- a/docs/features/sync-and-multi-device/README.md
+++ b/docs/features/sync-and-multi-device/README.md
@@ -1111,6 +1111,13 @@ Canonical files (`apps/ade-cli/src/services/sync/`):
   turn the handshake into an existence oracle for an unauthenticated caller.
   Connection arbitration and sealed adoption are options the brain leaves unset,
   which is the only genuine divergence between the two callers.
+- `pairedDeviceRejectionLimiter.ts` — per-`deviceId` throttle for repeated
+  paired-hello rejections. A phone that kept a pairing secret after the host
+  forgot the record will race LAN + Tailscale + Relay forever; without a cap
+  that is thousands of `paired_device_rejected` lines a day. The limiter
+  samples warn logs and delays later rejects. It never sees
+  `unknown_device` vs `secret_mismatch` — a different cadence per reason would
+  leak existence to an unauthenticated caller. Both ingresses share it.
 - `brainMachineSyncStores.ts` — the machine-level PIN / pairing / security
   stores for a brain hosting sync with no project scope
   (`sync-pin.json`, `sync-paired-devices.json`, `sync-security.json` under

--- a/docs/features/sync-and-multi-device/ios-companion.md
+++ b/docs/features/sync-and-multi-device/ios-companion.md
@@ -1072,11 +1072,12 @@ Sources: `apps/ios/ADE/Services/SyncService.swift` and
    and its identity matches the paired machine; unattributed or
    mismatched rejections are marked ambiguous, keep the pairing, and
    let the reconnect loop try other routes. After a connection race
-   *finishes* (every scheduled candidate produced an outcome) and every
-   hop was a pairing rejection from the same responding host, iOS also
-   drops the pairing — that is the saved machine rejecting this phone,
-   even when the profile never stored `hostIdentity` or it went stale.
-   A timeout or mixed failure among hops still keeps the pairing.
+   *finishes* (every candidate that actually started produced an outcome)
+   and every hop was a pairing rejection from the same responding host,
+   iOS also drops the pairing — that is the saved machine rejecting this
+   phone, even when the profile never stored `hostIdentity` or it went
+   stale. Queued addresses that never got a race slot do not keep a dead
+   pairing alive. A timeout or mixed failure among hops still keeps the pairing.
    "Pairing rejection" is
    `syncCodeIsPairingRejection` — `repair_required` (what current hosts send)
    or the generic `auth_failed` (what older hosts send for the same cause).

--- a/docs/features/sync-and-multi-device/ios-companion.md
+++ b/docs/features/sync-and-multi-device/ios-companion.md
@@ -1071,7 +1071,13 @@ Sources: `apps/ios/ADE/Services/SyncService.swift` and
    when the rejecting machine attributed itself (`hello_error.host`)
    and its identity matches the paired machine; unattributed or
    mismatched rejections are marked ambiguous, keep the pairing, and
-   let the reconnect loop try other routes. "Pairing rejection" is
+   let the reconnect loop try other routes. After a connection race
+   *finishes* (every scheduled candidate produced an outcome) and every
+   hop was a pairing rejection from the same responding host, iOS also
+   drops the pairing — that is the saved machine rejecting this phone,
+   even when the profile never stored `hostIdentity` or it went stale.
+   A timeout or mixed failure among hops still keeps the pairing.
+   "Pairing rejection" is
    `syncCodeIsPairingRejection` — `repair_required` (what current hosts send)
    or the generic `auth_failed` (what older hosts send for the same cause).
    Both mean the saved pairing is no longer usable, so every pairing decision


### PR DESCRIPTION
## Summary
- Host-side backoff for repeated paired-device rejections, keyed only by device id so the wire error stays identical for `unknown_device` and `secret_mismatch`.
- iOS reconnect races now drop a saved pairing only when every scheduled hop finished and every hop is a pairing rejection from the same responding host — otherwise the phone retries forever on ambiguous routes.
- Windows uninstall cleanup retries EBUSY via `fs.rmSync` `maxRetries`/`retryDelay` (only effective with `recursive: true`).

## Root cause (Issue A)
A live phone (`997f05a5-8b37-4905-8c61-2c50d9779499`) has been rejected as `unknown_device` for 24h+ (~8/min, bursts of 3–4 in 227ms). The host has no pairing record. The iOS client races LAN + Tailscale + Relay; `forgetHost()` only ran when `hello_error.host.deviceId` matched saved `hostIdentity`. Missing/stale identity made every hop ambiguous, so heartbeat reconnect never stopped.

Carved out: why the pairing vanished on disk (unpair, wipe, account revoke, never paired to this `~/.ade/secrets`) is not proven from the sandbox; backoff still ships either way.

## Test plan
- [x] `pairedDeviceRejectionLimiter` unit tests
- [x] host `repair_required` oracle still identical on a second unknown-device hello
- [x] iOS race consensus tests (complete vs incomplete vs mixed timeout vs mixed hosts)
- [x] Windows uninstall cleanup contract test for retry options (native EBUSY tests skip on macOS)


Made with [Cursor](https://cursor.com)

<!-- ade:link v=1 type=pr repo=arul28/ADE branch=ade%2Fsync-rejection-loop num=1120 -->
<p>
  <img src="https://ade-app.dev/logo.png" height="18" align="left" alt="ADE">
  &nbsp;&nbsp;<strong>Open in ADE</strong>
  &nbsp;·&nbsp; <a href="https://ade-app.dev/open?type=branch&amp;repo=arul28%2FADE&amp;branch=ade%2Fsync-rejection-loop&amp;pr=1120">ade/sync-rejection-loop branch</a>
  &nbsp;·&nbsp; <a href="https://ade-app.dev/open?type=pr&amp;repo=arul28%2FADE&amp;number=1120">PR #1120</a>
</p>
<!-- /ade:link -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Security**
  - Repeated failed paired-device authentication attempts are now progressively delayed, helping reduce abuse while preserving repair guidance.
  - Rejection warnings are logged periodically with relevant attempt details.

- **Bug Fixes**
  - Improved iOS connection-race handling prevents valid saved pairings from being invalidated prematurely.
  - Pairing recovery now responds more reliably when multiple connection candidates fail.
  - Windows uninstall cleanup is more resilient when temporary files are locked.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->