### PR TITLE
docs(release): v1.2.61 release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,54 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.2.61] - 2026-08-19
+
+### Account and machines
+
+- Machine identity is anchored to the hardware it runs on, so reinstalling and signing back in reconnects the existing machine instead of stranding a duplicate; existing duplicates are merged.
+- Pairing refusals now recover automatically in the background while signed in, and respect a machine you removed on purpose.
+- Machine identity is written durably with a backup, and a corrupt identity file is repaired instead of lost.
+
+### GitHub connection
+
+- An unreadable saved GitHub sign-in reports itself as unreadable and routes to Repair, instead of looking identical to a fresh install.
+- GitHub outages are distinguished from broken credentials.
+- Foreground PR polling no longer consumes the hourly GitHub API quota: failures arm an exponential stand-down, a request reserve is held for user actions, and recovery is automatic.
+- Failed check, comment, and review reads are reported as failures instead of rendering as "no checks ran".
+
+### Errors and diagnostics
+
+- Storage and startup failures carry coded, plain-language errors instead of raw system errnos.
+- Projects stored in iCloud or Dropbox are detected before they fail.
+- One-click "Send to ADE" for the redacted diagnostic report, on the desktop app, `ade report-issue --send`, and `ade code` — working even when the brain is down.
+
+### Machine sleep
+
+- Hosts announce suspend and resume, with a heartbeat-gap fallback, so "Asleep" is stated rather than inferred; machine rows carry battery, charging, and wall-power state.
+- A turn interrupted by sleep pauses and resumes in place instead of failing; session deeplinks carry their owning machine and offer to wake it.
+- Opt-in keep-awake setting with three levels, default off.
+
+### Work and chat
+
+- Cursor SDK chats recover from an in-stream token expiry by resuming the same agent in a fresh worker.
+- Claude chats recover after a session-limit reject without forking, with a quota card and a local-lane fork.
+- Cursor forks replay the full fitted transcript instead of a short conversation tail.
+- Cursor chats support mid-turn steering (interrupt and continue, or send after turn).
+- Chat runtimes no longer outlive the background work that pinned them; background-work elapsed is measured from when the work started, and Settle stays available on background-promoted rows.
+- Handoff, the tools pane, Git/diff/terminal, iOS simulator, app control, and browser panels act on the chat's machine rather than the tab's binding.
+- The @ mention popover dismisses when its query stops matching.
+
+### Connections and sync
+
+- Unknown-device sync rejection storms are throttled, and a pairing is dropped once every connection hop agrees it is gone.
+- Lane PR badges are scoped to the current branch.
+- Windows uninstall teardown retries locked files.
+
+### iOS
+
+- Mobile Work session cards polished.
+- The iOS app is built and tested on every PR.
+
 ## [1.2.60] - 2026-08-17
 
 ### Startup and recovery
@@ -1576,7 +1624,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Initial public release.
 
-[Unreleased]: https://github.com/arul28/ADE/compare/v1.2.55...HEAD
+[Unreleased]: https://github.com/arul28/ADE/compare/v1.2.61...HEAD
+[1.2.61]: https://github.com/arul28/ADE/compare/v1.2.60...v1.2.61
 [1.2.60]: https://github.com/arul28/ADE/compare/v1.2.59...v1.2.60
 [1.2.59]: https://github.com/arul28/ADE/compare/v1.2.58...v1.2.59
 [1.2.58]: https://github.com/arul28/ADE/compare/v1.2.57...v1.2.58

--- a/changelog/index.mdx
+++ b/changelog/index.mdx
@@ -5,6 +5,6 @@ description: "Latest ADE release notes and release history."
 
 ADE release notes live here in newest-first order. Start with the latest release, or browse the release list in the sidebar.
 
-<Card title="Latest release" icon="tag" href="/changelog/v1.2.60">
-  v1.2.60 - A slow-starting background service is no longer reported as broken, plus a direct project-to-Work flow, selected-output chat context, and cross-machine Files.
+<Card title="Latest release" icon="tag" href="/changelog/v1.2.61">
+  v1.2.61 - Reinstall and sign in fully heals your account, GitHub connection status tells the truth, errors are written in plain words, and one click sends a diagnostic report to ADE.
 </Card>

--- a/changelog/v1.2.61.mdx
+++ b/changelog/v1.2.61.mdx
@@ -1,0 +1,53 @@
+---
+title: "v1.2.61"
+description: "Release notes for ADE v1.2.61 - August 19, 2026"
+---
+
+Reinstalling and signing back in now fully repairs your account. Connection status says what is actually wrong instead of guessing, errors are written in plain words, and one click sends a diagnostic report to ADE.
+
+---
+
+## Account and machines
+
+- **Reinstall and sign in heals your account.** A machine is now recognized by the hardware it runs on, so signing in after a reinstall reconnects the machine you already had instead of leaving a stranded duplicate behind. Machines that were already duplicated are merged.
+- **Pairing recovers on its own.** When a machine is refused, ADE retries quietly in the background while you are signed in, and steps back when you removed that machine on purpose.
+- **A machine no longer loses its identity to a bad write.** Machine identity is saved durably with a backup, and a damaged file is repaired instead of turning the machine into a stranger.
+
+## GitHub connection
+
+- **A saved sign-in ADE cannot read no longer reads as "not connected".** That looked identical to a fresh install, so the fix was never obvious. ADE now says the sign-in cannot be read and points you at Repair.
+- **GitHub outages are told apart from broken credentials.** An outage no longer asks you to reconnect an account that is perfectly fine.
+- **PR checks stop burning your GitHub quota.** One open PR pane could spend an entire hour's worth of GitHub requests during an outage, blocking work elsewhere. ADE now slows down while GitHub is failing, keeps a reserve for the things you click, and recovers as soon as GitHub answers again.
+- **A failed check read no longer looks like a clean PR.** Checks and comments that could not be read now say so instead of showing "no checks ran".
+
+## Clearer errors and diagnostics
+
+- **Plain-language errors instead of raw system codes.** Storage and startup failures now describe what happened, with the technical detail kept in the report for support.
+- **Projects kept in iCloud or Dropbox are recognized.** ADE detects a project stored in a cloud-synced folder and tells you to move it out, instead of failing in a way that looks random.
+- **One-click "Send to ADE".** The redacted diagnostic report can be sent straight from the desktop app, from `ade report-issue --send`, and from `ade code` — and it works even when the background service is down.
+
+## Machine sleep
+
+- **ADE tells the truth about a sleeping machine.** A closed lid used to leave your phone reporting "Connected" to an unconscious Mac. Machines now announce sleep and wake, show battery and power state, and a turn interrupted by sleep pauses and picks up where it left off rather than failing.
+- **A chat on a sleeping Mac offers to wake it.** Links to a session carry the machine that owns it, so you land in the right place.
+- **Optional keep-awake.** A new setting can keep a Mac awake while agents are working. It is off by default, and each level states plainly what it does and does not survive.
+
+## Work and chat
+
+- **Cursor chats recover from an expired session.** A sign-in that quietly expired mid-conversation used to break every later message. ADE now reconnects the same chat and resends, instead of asking you to log out and back in.
+- **Claude chats recover after a usage-limit stop.** The chat keeps its identity, shows a card explaining the limit, and offers to continue locally — no forking required.
+- **Forking a Cursor chat carries the whole conversation.** Forks used to start from only the last few exchanges.
+- **Steer a Cursor chat mid-turn.** You can interrupt and continue, or queue your message for after the turn, the same way Claude chats already worked.
+- **Chats release their machine when the work is done.** A background task that never reported finishing could hold a chat's processes and memory open for the life of the app. Those now shut down, background-work time is reported honestly, and the Settle action stays available to stop the work.
+- **Actions follow the chat's machine.** Handoff, the tools pane, Git, Files, terminals, and the simulator, browser, and app panels now act on the machine the chat is actually running on, not the machine the tab happens to be pointed at.
+- **The @ mention menu closes when nothing matches.** Typing "@cursor is the runtime" no longer parks a suggestion list over the composer.
+
+## Connections and sync
+
+- **A forgotten pairing stops looping.** A phone whose pairing had been removed could retry forever. The device now learns the pairing is gone and stops, and repeated refusals are throttled.
+- **Lane PR badges match the branch you are on.**
+
+## iOS
+
+- **Mobile Work session cards are cleaner.**
+- **The iOS app is built and tested on every pull request.** It was the only part of ADE with no automated checks, which let three compile breaks land in a row.

--- a/docs.json
+++ b/docs.json
@@ -181,6 +181,7 @@
             "expanded": true,
             "pages": [
               "changelog",
+              "changelog/v1.2.61",
               "changelog/v1.2.60",
               "changelog/v1.2.59",
               "changelog/v1.2.58",


### PR DESCRIPTION
Release notes for desktop v1.2.61 (last tag v1.2.60).

Updates all four release-doc surfaces:
- `changelog/v1.2.61.mdx` (new)
- `docs.json` sidebar
- `changelog/index.mdx` latest-release card
- root `CHANGELOG.md` (entry + compare links)

`node scripts/validate-docs.mjs` passes (233 files).

Headlines: account & machine reliability overhaul (hardware-anchored identity so reinstall + sign in fully heals, duplicate-machine dedup, automatic pairing recovery), truthful GitHub connection status (unreadable store -> Repair, outages vs broken credentials, PR polling quota fix), plain-language errors including iCloud/Dropbox project detection, one-click "Send to ADE" diagnostics on desktop / `ade report-issue --send` / `ade code`, plus the #1109-#1124 user-visible fixes.

Docs-only; no product code changes. The v1.2.61 tag will point at this commit on main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)