### PR TITLE
worker: deploy account-directory without R2 binding until the subscription is enabled

### DIFF
--- a/apps/account-directory/wrangler.jsonc
+++ b/apps/account-directory/wrangler.jsonc
@@ -45,12 +45,26 @@
   // is NOT created by deploying — run `wrangler r2 bucket create` first (see
   // README, "Diagnostic report uploads"). Missing binding is handled: the route
   // answers 503 and the in-app button reports that sending is unavailable.
-  "r2_buckets": [
-    {
-      "binding": "DIAGNOSTICS",
-      "bucket_name": "ade-diagnostics"
-    }
-  ],
+  //
+  // TEMPORARILY UNBOUND (v1.2.61 release). R2 is not enabled on this Cloudflare
+  // account: bucket creation fails with "Please enable R2 through the Cloudflare
+  // Dashboard [code: 10042]", and a Worker bound to a bucket that cannot exist
+  // fails to start — which would take down machine registration and pairing for
+  // every user, not just diagnostics. Leaving DIAGNOSTICS unbound is the
+  // designed degradation: `DiagnosticsEnv` types it `DIAGNOSTICS?: R2Bucket`,
+  // the upload route answers 503, and the in-app "Send to ADE" button reports
+  // that sending is unavailable. Every other route is unaffected.
+  //
+  // TO RE-ENABLE, once the R2 subscription is added to the account:
+  //   1. revert this commit (restores both `r2_buckets` blocks verbatim)
+  //   2. npx wrangler r2 bucket create ade-diagnostics
+  //      npx wrangler r2 bucket create ade-diagnostics-production
+  //   3. add the 90-day expiry lifecycle rule to BOTH buckets — nothing in the
+  //      Worker ever deletes a report (see README, step 4)
+  //   4. npm run deploy:production
+  //   5. verify the fail-closed probes: garbage Bearer -> 401, >512 KiB -> 413
+  //
+  // "r2_buckets": [{ "binding": "DIAGNOSTICS", "bucket_name": "ade-diagnostics" }],
   "env": {
     "production": {
       "name": "ade-account-directory-production",
@@ -68,13 +82,12 @@
           "database_id": "38ebe0bb-ac4d-4b39-b73e-bab2f0092971",
           "migrations_dir": "migrations"
         }
-      ],
-      "r2_buckets": [
-        {
-          "binding": "DIAGNOSTICS",
-          "bucket_name": "ade-diagnostics-production"
-        }
       ]
+      // DIAGNOSTICS is unbound here for the same reason as the top-level
+      // environment — see the note above `env` for why, and for the exact
+      // re-enable steps. The production bucket was `ade-diagnostics-production`.
+      //
+      // "r2_buckets": [{ "binding": "DIAGNOSTICS", "bucket_name": "ade-diagnostics-production" }]
     }
   }
 }


### PR DESCRIPTION
## Why

Phase 5.5 of the v1.2.61 release could not deploy the account-directory Worker. Creating the diagnostics buckets fails:

```
Please enable R2 through the Cloudflare Dashboard. [code: 10042]
```

This is **account-level product enablement, not a token scope**. The same API token lists Workers scripts, reads Worker settings, queries D1, and deployed Pages successfully. Independently, the account's own S3 endpoint (`<acct>.r2.cloudflarestorage.com`) rejects the TLS handshake with `SSLV3_ALERT_HANDSHAKE_FAILURE` — the R2 endpoint is not provisioned at all. Enabling it requires adding the R2 subscription in the dashboard, which is a billing decision for the account owner.

A Worker bound to a bucket that cannot exist **fails to start**. Deploying `wrangler.jsonc` as-is would take down machine registration, pairing, and heartbeat for every user in order to ship a route nobody can reach yet.

## What

Comment out both `r2_buckets` blocks (top-level and `env.production`), leaving the exact bindings and the re-enable steps inline.

This is the degradation the code was already written for:

- `DiagnosticsEnv = Env & { DIAGNOSTICS?: R2Bucket }` — the binding is optional
- `POST /diagnostics/upload` answers `503 {"error":"diagnostics upload unavailable"}` when unbound
- the in-app "Send to ADE" button reports that sending is unavailable

Every other route deploys unchanged. That matters here: production is currently running #1115-era code against the 0008 schema, so **two-phase pairing-grant reservation, supersede-by-hardware-anchor dedup, and refusal logging are not live**. This unblocks them.

## Verification

- `npm test` — 145 passed / 7 files. Nothing asserts `r2_buckets`; `verifyDeploymentConfig.test.ts` reads the committed `wrangler.jsonc` and still accepts it.
- `npm run verify:deploy-config -- production` and `-- default` — both complete (`DIRECTORY_AUTH_SECRET` + `PUSH_RELAY_URL` configured).
- `npm run build:production` dry-run — 121.17 KiB / 28.30 KiB gzip; resolved bindings are `DB`, `ONLINE_WINDOW_MS`, `WEB_CLIENT_ORIGIN`, `PUSH_RELAY_URL`, with no R2 entry.

## Re-enable path

Once the R2 subscription is added: revert this commit, create `ade-diagnostics` + `ade-diagnostics-production`, add the 90-day expiry lifecycle rule to both (nothing in the Worker ever deletes a report), redeploy, then run the fail-closed probes (garbage Bearer → 401, >512 KiB → 413).

🤖 Generated with [Claude Code](https://claude.com/claude-code)