### PR TITLE
docs(release): v1.2.62 release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.2.62] - 2026-08-19
+
+### Automatic diagnostic reports
+
+- Failures now send the redacted diagnostic report on their own: project recovery, renderer crash, failed update, pairing give-up, and stuck machine publish.
+- Every automatic send announces itself with a message offering View (read the exact report) and Turn off (stop future sends).
+- On by default, with a Diagnostics sharing section in Settings and a truthful row in `ade doctor`; turning it off takes effect immediately across the app and the CLI.
+- Budgets bound the volume: one report per failure kind per day and a small daily cap per machine, plus a fleet-wide server ceiling that refuses quietly rather than surfacing an error.
+- Reports carry the same redaction as the manual report, and a refused or failed send is never shown to the user as a failure.
+
 ## [1.2.61] - 2026-08-19
 
 ### Account and machines
@@ -1624,7 +1634,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Initial public release.
 
-[Unreleased]: https://github.com/arul28/ADE/compare/v1.2.61...HEAD
+[Unreleased]: https://github.com/arul28/ADE/compare/v1.2.62...HEAD
+[1.2.62]: https://github.com/arul28/ADE/compare/v1.2.61...v1.2.62
 [1.2.61]: https://github.com/arul28/ADE/compare/v1.2.60...v1.2.61
 [1.2.60]: https://github.com/arul28/ADE/compare/v1.2.59...v1.2.60
 [1.2.59]: https://github.com/arul28/ADE/compare/v1.2.58...v1.2.59

--- a/changelog/index.mdx
+++ b/changelog/index.mdx
@@ -5,6 +5,6 @@ description: "Latest ADE release notes and release history."
 
 ADE release notes live here in newest-first order. Start with the latest release, or browse the release list in the sidebar.
 
-<Card title="Latest release" icon="tag" href="/changelog/v1.2.61">
-  v1.2.61 - Reinstall and sign in fully heals your account, GitHub connection status tells the truth, errors are written in plain words, and one click sends a diagnostic report to ADE.
+<Card title="Latest release" icon="tag" href="/changelog/v1.2.62">
+  v1.2.62 - When ADE fails, it can now tell us itself: automatic redacted diagnostic reports, announced every time and switched off in one click.
 </Card>

--- a/changelog/v1.2.62.mdx
+++ b/changelog/v1.2.62.mdx
@@ -1,0 +1,16 @@
+---
+title: "v1.2.62"
+description: "Release notes for ADE v1.2.62 - August 19, 2026"
+---
+
+When ADE fails, it can now tell us itself. Automatic diagnostic reports are on by default, cost nothing to you, and can be turned off in one click from the message that announces them.
+
+---
+
+## Automatic diagnostic reports
+
+- **Failures report themselves.** When a project cannot be opened, the app crashes, an update fails, pairing gives up, or a machine gets stuck publishing, ADE sends the same redacted report you could already send by hand — without you having to notice, remember, or ask.
+- **You are told every time, and can stop it in one click.** A short message says a report was sent, with **View** to read exactly what left your machine and **Turn off** to stop future ones.
+- **On by default, off in one click.** Settings has a Diagnostics sharing section, and `ade doctor` shows whether sharing is on. Turning it off applies immediately, everywhere.
+- **Nothing is sent twice.** Each kind of failure sends at most one report a day, with a small daily cap per machine, so a crash loop cannot flood anything.
+- **The same redaction as the manual report.** Paths, tokens, and personal detail are stripped before anything is sent.

--- a/docs.json
+++ b/docs.json
@@ -181,6 +181,7 @@
             "expanded": true,
             "pages": [
               "changelog",
+              "changelog/v1.2.62",
               "changelog/v1.2.61",
               "changelog/v1.2.60",
               "changelog/v1.2.59",


### PR DESCRIPTION
Release notes for v1.2.62 — automatic diagnostic reports (#1129).

All four release-doc surfaces updated: `changelog/v1.2.62.mdx`, `docs.json`, `changelog/index.mdx`, root `CHANGELOG.md`. `node scripts/validate-docs.mjs` passes (234 files).

Docs-only; no product code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)