### PR TITLE
docs(release): v1.2.63 release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.2.63] - 2026-08-19
+
+### Getting help
+
+- Settings gained a Send button beside Diagnostics sharing; previously a report could only be sent from a surface that had already failed.
+- Diagnostic reports no longer require an open project: the machine-scoped main log, the most recent project's log, the background service's stdout as well as stderr, and the service definition are all collected.
+- The desktop main process now writes a machine-scoped log from process start (`~/.ade/runtime/desktop-main.jsonl`), so startup, deeplink, single-instance and CLI-install events are recorded even when no project is ever opened.
+- Linux reports now collect the service journal instead of asking for a macOS log path that never existed there.
+- A failed report save no longer claims the report is on disk.
+
+### The `ade` terminal command
+
+- The CLI install now runs once, is skipped when `ade` already resolves from any source, and never re-runs on every launch.
+
+### Fixes
+
+- Report collection no longer blocks the Electron main thread or the brain's event loop on subprocesses (Windows and Linux).
+- The Windows installed-product smoke test no longer fails a passing run on a benign cleanup `taskkill`, and its process-ownership checks re-verify identity rather than trusting a recycled PID.
+- The account-directory production deploy preflight now checks all four required secrets and both required vars, instead of one secret and one var.
+
 ## [1.2.62] - 2026-08-19
 
 ### Automatic diagnostic reports
@@ -1634,7 +1654,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Initial public release.
 
-[Unreleased]: https://github.com/arul28/ADE/compare/v1.2.62...HEAD
+[Unreleased]: https://github.com/arul28/ADE/compare/v1.2.63...HEAD
+[1.2.63]: https://github.com/arul28/ADE/compare/v1.2.62...v1.2.63
 [1.2.62]: https://github.com/arul28/ADE/compare/v1.2.61...v1.2.62
 [1.2.61]: https://github.com/arul28/ADE/compare/v1.2.60...v1.2.61
 [1.2.60]: https://github.com/arul28/ADE/compare/v1.2.59...v1.2.60

--- a/changelog/index.mdx
+++ b/changelog/index.mdx
@@ -5,6 +5,6 @@ description: "Latest ADE release notes and release history."
 
 ADE release notes live here in newest-first order. Start with the latest release, or browse the release list in the sidebar.
 
-<Card title="Latest release" icon="tag" href="/changelog/v1.2.62">
-  v1.2.62 - When ADE fails, it can now tell us itself: automatic redacted diagnostic reports, announced every time and switched off in one click.
+<Card title="Latest release" icon="tag" href="/changelog/v1.2.63">
+  v1.2.63 - Asking ADE for help works the first time: the `ade` command sets itself up, a report can be sent whenever you want, and reports carry what support actually needs.
 </Card>

--- a/changelog/v1.2.63.mdx
+++ b/changelog/v1.2.63.mdx
@@ -1,0 +1,23 @@
+---
+title: "v1.2.63"
+description: "Release notes for ADE v1.2.63 - August 19, 2026"
+---
+
+Asking ADE for help now works the first time: the `ade` command sets itself up, a report can be sent whenever you want one, and the report finally contains the things support actually needs.
+
+---
+
+## Getting help
+
+- **Send a report whenever you want.** Settings now has a Send button next to Diagnostics sharing. Until now a report could only be sent from a screen that had already failed — so if something merely felt wrong, there was nothing to click.
+- **Reports work with no project open.** A report used to leave out ADE's own log unless a project happened to be open, which is exactly the case where a report matters most.
+- **Reports carry what was missing.** The background service's full output and its startup configuration are now included. Several problems left their only trace in files no report ever read.
+- **A report that could not be saved no longer says it was.** The message told you to open a file that was never written.
+
+## The `ade` terminal command
+
+- **ADE sets up the `ade` command once, properly.** It used to be re-run on every launch and could overwrite a copy you installed yourself; now it runs once, and never touches an `ade` you already have.
+
+## Fixes
+
+- **ADE no longer freezes while a report is being prepared.** On Windows and Linux, gathering a report could lock the window for a few seconds — usually for an automatic report nobody asked for.

--- a/docs.json
+++ b/docs.json
@@ -181,6 +181,7 @@
             "expanded": true,
             "pages": [
               "changelog",
+              "changelog/v1.2.63",
               "changelog/v1.2.62",
               "changelog/v1.2.61",
               "changelog/v1.2.60",


### PR DESCRIPTION
Release notes for v1.2.63 — the post-release fixes from #1132.

All four release-doc surfaces updated: `changelog/v1.2.63.mdx`, `docs.json`, `changelog/index.mdx`, root `CHANGELOG.md`. `node scripts/validate-docs.mjs` passes (235 files).

Docs-only; no product code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)