### PR TITLE
fix(updates): let "Check for updates" run when an update is already staged

### DIFF
--- a/apps/desktop/src/main/services/ipc/registerIpc.ts
+++ b/apps/desktop/src/main/services/ipc/registerIpc.ts
@@ -11483,7 +11483,9 @@ export function registerIpc({
   });
 
   ipcMain.handle(IPC.updateCheckForUpdates, () => {
-    getCtx().autoUpdateService?.checkForUpdates();
+    // Only reachable from the Settings button, so it always counts as
+    // user-initiated: it must run even when an update is already staged.
+    getCtx().autoUpdateService?.checkForUpdates({ userInitiated: true });
   });
 
   ipcMain.handle(IPC.updateGetState, () => {

--- a/apps/desktop/src/main/services/updates/autoUpdateService.test.ts
+++ b/apps/desktop/src/main/services/updates/autoUpdateService.test.ts
@@ -420,6 +420,51 @@ describe("createAutoUpdateService", () => {
     service.dispose();
   });
 
+  it("still checks when an update is already staged, but only when the user asked", async () => {
+    // The Settings button was a silent no-op in exactly this state: an update
+    // downloaded and waiting for a restart. The automatic timers must keep
+    // standing down so they cannot disturb the staged download.
+    const updater = new FakeAutoUpdater();
+    const service = createAutoUpdateService({
+      logger: makeLogger(),
+      currentVersion: "1.2.60",
+      globalStatePath: makeStatePath(),
+      startupDelayMs: 60_000,
+      periodicCheckMs: 60_000,
+      now: () => "2026-08-19T21:00:00.000Z",
+      updater,
+    });
+
+    updater.emit("update-available", { version: "1.2.61" });
+    updater.emit("update-downloaded", { version: "1.2.61" });
+    expect(service.getSnapshot()).toMatchObject({ status: "ready", version: "1.2.61" });
+
+    updater.checkForUpdates.mockClear();
+    service.checkForUpdates();
+    // Flush the microtask queue rather than waitFor: a `not.toHaveBeenCalled`
+    // inside waitFor passes on its first tick and would assert nothing.
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(updater.checkForUpdates).not.toHaveBeenCalled();
+
+    updater.checkForUpdates.mockImplementation(async () => ({
+      updateInfo: { version: "1.2.63" },
+    }));
+    service.checkForUpdates({ userInitiated: true });
+
+    await vi.waitFor(() => {
+      expect(updater.checkForUpdates).toHaveBeenCalledTimes(1);
+      // The newest version is reported, and the staged 1.2.61 is left alone.
+      expect(service.getSnapshot()).toMatchObject({
+        status: "ready",
+        version: "1.2.61",
+        latestKnownVersion: "1.2.63",
+      });
+    });
+
+    service.dispose();
+  });
+
   it("tracks download progress and persists the target version before quit-and-install", async () => {
     const globalStatePath = makeStatePath();
     const updater = new FakeAutoUpdater();

--- a/apps/desktop/src/main/services/updates/autoUpdateService.ts
+++ b/apps/desktop/src/main/services/updates/autoUpdateService.ts
@@ -1050,8 +1050,19 @@ export function createAutoUpdateService({
     await checkPromise;
   }
 
-  function checkForUpdates(): void {
-    void runUpdateCheck();
+  /**
+   * `userInitiated` is what separates the Settings button from the startup and
+   * periodic timers. The automatic checks stay out of the way of an update that
+   * is already downloaded and waiting for a restart, but a person pressing
+   * "Check for updates" is asking a question, and answering it with an early
+   * return is indistinguishable from the button being broken — the version on
+   * screen just stays at whatever the last real check found.
+   *
+   * The `ready` branch of the check still returns before downloading, so this
+   * refreshes the newest known version without disturbing the staged download.
+   */
+  function checkForUpdates(options: { userInitiated?: boolean } = {}): void {
+    void runUpdateCheck({ allowReady: options.userInitiated === true });
   }
 
   async function refreshReadyUpdateBeforeInstall(): Promise<boolean> {


### PR DESCRIPTION
## The bug

Reported from a real install: on 1.2.60 with 1.2.61 downloaded and pending restart, Settings showed `Downloaded 1.2.61 · Latest 1.2.61` and pressing **Check for updates** did nothing — days after 1.2.62 shipped.

`runUpdateCheck` (`autoUpdateService.ts:967`) returns early when `snapshot.status === "ready"`:

```ts
|| (!args.allowReady && snapshot.status === "ready")
```

That guard is correct for the startup and periodic timers — they must not disturb an update that is downloaded and waiting. But the Settings button went through the same `checkForUpdates()` entry point with no `allowReady`, so **it never made a network request**. No error, no state change, and the displayed "Latest" frozen at whatever the last real check found. Indistinguishable from a broken button.

The only caller that passed `allowReady: true` was `refreshReadyUpdateBeforeInstall`, which re-checks just before installing — which is why restarting to update did eventually pick up newer versions.

## The fix

`checkForUpdates` takes `{ userInitiated }`; the IPC handler (the button's only caller) passes it, and the timers keep standing down.

**This does not restart or clobber a download.** The `ready` branch of the check (`:999`) returns before the download block, so a user-initiated check refreshes `latestKnownVersion` and leaves the staged update intact. The card then honestly reads `Downloaded 1.2.61 · Latest 1.2.63`.

## Tests

New regression test in `autoUpdateService.test.ts`: from a staged-`ready` state, an automatic check makes no request, a user-initiated one does, and the result reports the newer version while `status`/`version` stay on the staged update. 56 tests pass; `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Manual update checks from Settings now refresh available-version information even when an update is already staged.
  * Staged updates remain ready and are not unnecessarily replaced or downloaded again.
  * Automatic update checks continue to avoid interrupting staged updates.

* **Tests**
  * Added regression coverage for manual and automatic checks involving staged updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->