### PR TITLE
docs(release): complete the v1.2.63 notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [1.2.63] - 2026-08-19
+## [1.2.63] - 2026-08-20
+
+### GitHub connection
+
+- The GitHub App user credential is renewed through one coordinator per credential store: a process-wide single-flight plus a cross-process lease and backoff ledger persisted inside the credential record. Parallel renewals could previously invalidate the rotating refresh token, after which every process retried the dead token without backoff until GitHub rate-limited the OAuth host (#1137).
+- `github.appUserToken.v1` is file-backed and shared by the desktop app, the machine brain, and the CLI; a routed desktop store with a one-time freshness-aware adoption replaces the split safeStorage copy.
+- The status model is honest: `credentialState` (missing / authorized / blocked / needs_reauth) is judged by the refresh token, never by the 8-hour access token; a paused renewal shows its retry time with no re-authorize CTA; ADE's own renewal reads as "renewing", not as a failed check; and the App panel gained a Disconnect control.
+- OAuth transport errors are typed: HTTP-200 error bodies (`bad_refresh_token`) are read, `retry-after` is honored, a credential is declared dead only on a 401 or a definitive OAuth error code, and the whole refresh exchange is bounded below the lease lifetime.
+- The brain watches the shared credential file and force-polls the relay after a re-authorization instead of waiting out its five-minute cooldown.
+- A refresh whose store write fails keeps the rotated token in process memory, retries the persist, and never re-POSTs the spent refresh token; the account-session rotation journal likewise survives failed exchanges.
+
+### Updates
+
+- "Check for updates" runs when an update is already staged (#1134), and a manual check no longer discards the update that was already downloaded (#1135).
+
+### Providers
+
+- ADE no longer overrides the user's own provider configuration (#1136).
 
 ### Getting help
 

--- a/changelog/index.mdx
+++ b/changelog/index.mdx
@@ -6,5 +6,5 @@ description: "Latest ADE release notes and release history."
 ADE release notes live here in newest-first order. Start with the latest release, or browse the release list in the sidebar.
 
 <Card title="Latest release" icon="tag" href="/changelog/v1.2.63">
-  v1.2.63 - Asking ADE for help works the first time: the `ade` command sets itself up, a report can be sent whenever you want, and reports carry what support actually needs.
+  v1.2.63 - The GitHub connection renews itself without breaking itself, and asking ADE for help works the first time: the `ade` command sets itself up and reports carry what support actually needs.
 </Card>

--- a/changelog/v1.2.63.mdx
+++ b/changelog/v1.2.63.mdx
@@ -1,11 +1,24 @@
 ---
 title: "v1.2.63"
-description: "Release notes for ADE v1.2.63 - August 19, 2026"
+description: "Release notes for ADE v1.2.63 - August 20, 2026"
 ---
 
-Asking ADE for help now works the first time: the `ade` command sets itself up, a report can be sent whenever you want one, and the report finally contains the things support actually needs.
+The GitHub connection now takes care of itself: renewals are coordinated, honest about their state, and can no longer talk themselves to death. Asking ADE for help also works the first time: the `ade` command sets itself up, a report can be sent whenever you want one, and the report finally contains the things support actually needs.
 
 ---
+
+## Your GitHub connection
+
+- **The connection renews itself without breaking itself.** Every part of ADE now renews the GitHub authorization through one coordinator. Before, parallel renewals could invalidate the credential, and ADE then retried the dead credential without pause until GitHub blocked the whole machine — which also blocked the re-authorize flow that would have fixed it.
+- **The status tells the truth.** A working connection whose short-lived token lapsed no longer says "Authorization expired". A renewal that GitHub has paused says when it resumes, and does not ask you to re-authorize — that cannot help and used to make things worse. Only a truly dead authorization asks for a login.
+- **ADE renewing is not an error.** While ADE renews the authorization, screens say so in one calm sentence instead of reporting a failed check.
+- **You can disconnect.** The GitHub panel now has a Disconnect control. Removing the authorization previously had no button at all.
+- **Recovery is fast.** After you re-authorize, background GitHub features pick up the new authorization within seconds instead of waiting out a cooldown.
+
+## Updates
+
+- **"Check for updates" works while an update is already staged.** It used to do nothing.
+- **A manual check no longer discards an update that was already downloaded.**
 
 ## Getting help
 
@@ -20,4 +33,5 @@ Asking ADE for help now works the first time: the `ade` command sets itself up, 
 
 ## Fixes
 
+- **Your provider configuration stays yours.** ADE no longer overrides model provider settings you configured yourself.
 - **ADE no longer freezes while a report is being prepared.** On Windows and Linux, gathering a report could lock the window for a few seconds — usually for an automatic report nobody asked for.


### PR DESCRIPTION
The staged v1.2.63 entry predates #1134/#1135 (update-check fixes), #1136 (provider config), and #1137 (the GitHub App credential overhaul). This amends the existing entry across changelog/v1.2.63.mdx, changelog/index.mdx, and CHANGELOG.md — no new version. docs.json already carries the page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changelog edits with no product or security code changes.
> 
> **Overview**
> Completes the already-staged **v1.2.63** notes (date moved to 2026-08-20) so they cover work that landed after the first draft.
> 
> Adds GitHub App credential overhaul copy (#1137): coordinated renewal, honest `credentialState`, typed OAuth errors, shared file-backed store, disconnect, and faster post-reauth recovery. Also documents update-check fixes (#1134/#1135) and that ADE no longer overrides user provider config (#1136).
> 
> Same story is mirrored in `CHANGELOG.md`, `changelog/v1.2.63.mdx`, and the latest-release card on `changelog/index.mdx`. No new version.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fe11c74e01dbde15dae752d3eed30d52f3cac248. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->