### PR TITLE
windows: honor ADE_BRAIN_HEARTBEAT_STALE_MS in the supervisor

### DIFF
--- a/apps/ade-cli/src/serviceManager/installWindows.test.ts
+++ b/apps/ade-cli/src/serviceManager/installWindows.test.ts
@@ -1604,6 +1604,45 @@ describe("windows supervisor wedge guard", () => {
     });
     expect(script).toContain("$heartbeatStaleMs = 30000");
   });
+
+  it("reads the same runtime staleness override the macOS watchdog reads", () => {
+    const script = renderWindowsServiceLauncher(command, {
+      pidPath: "C:\\ade\\launcher.pid.json",
+      heartbeatPath: "C:\\ade\\runtime\\heartbeat.json",
+    });
+    expect(script).toContain("$staleOverrideRaw = $env:ADE_BRAIN_HEARTBEAT_STALE_MS");
+    // Same rules as `resolveBrainHeartbeatStaleMs`: leading digits only, a
+    // positive value only, and never below the 30s floor.
+    expect(script).toContain("if ($staleOverrideRaw -match '^\\s*[+-]?\\d+') {");
+    expect(script).toContain(
+      "if ([long]::TryParse($Matches[0].Trim(), [ref]$staleOverrideMs) -and $staleOverrideMs -gt 0) {",
+    );
+    expect(script).toContain("$heartbeatStaleMs = [Math]::Max(30000, $staleOverrideMs)");
+    // The rendered default still has to be there for the override to fall back to.
+    expect(script).toContain(`$heartbeatStaleMs = ${BRAIN_HEARTBEAT_STALE_MS}`);
+  });
+
+  it("computes the suspend floor after the override so it rescales", () => {
+    const script = renderWindowsServiceLauncher(command, {
+      pidPath: "C:\\ade\\launcher.pid.json",
+      heartbeatPath: "C:\\ade\\runtime\\heartbeat.json",
+    });
+    const overrideAt = script.indexOf("$heartbeatStaleMs = [Math]::Max(30000, $staleOverrideMs)");
+    const floorAt = script.indexOf(
+      "$watcherSuspendFloorMs = [Math]::Max($heartbeatStaleMs, $heartbeatPollMs * 3)",
+    );
+    expect(overrideAt).toBeGreaterThan(-1);
+    expect(floorAt).toBeGreaterThan(overrideAt);
+  });
+
+  it("does not override the poll interval, which macOS has no override for", () => {
+    const script = renderWindowsServiceLauncher(command, {
+      pidPath: "C:\\ade\\launcher.pid.json",
+      heartbeatPath: "C:\\ade\\runtime\\heartbeat.json",
+    });
+    expect(script).not.toContain("ADE_BRAIN_HEARTBEAT_POLL_MS");
+    expect(script).toContain(`$heartbeatPollMs = ${BRAIN_HEARTBEAT_INTERVAL_MS}`);
+  });
 });
 
 /**

--- a/apps/ade-cli/src/serviceManager/windowsSupervisor.ts
+++ b/apps/ade-cli/src/serviceManager/windowsSupervisor.ts
@@ -209,6 +209,29 @@ export function renderWindowsServiceLauncher(
     }`,
     `$heartbeatStaleMs = ${Math.max(30_000, Math.floor(options.heartbeatStaleMs ?? BRAIN_HEARTBEAT_STALE_MS))}`,
     `$heartbeatPollMs = ${Math.max(1_000, Math.floor(options.heartbeatPollMs ?? BRAIN_HEARTBEAT_INTERVAL_MS))}`,
+    // The same runtime override the macOS watchdog reads
+    // (`resolveBrainHeartbeatStaleMs` in
+    // `src/services/runtime/brainWatchdogCheck.ts`), with the same rules: a
+    // positive integer wins, anything else keeps the rendered default, and the
+    // result never drops below 30s -- under the beat interval the watchdog
+    // would fire on every ordinary gap. The regex mirrors `Number.parseInt`,
+    // which reads the leading digits and ignores the rest.
+    //
+    // The pickup differs from macOS, and only here: the macOS checker is a
+    // fresh process every 60s, so it sees a changed machine variable at the
+    // next check. This supervisor reads the variable once at start, so a
+    // changed value applies after the brain service restarts.
+    //
+    // No poll-interval override: macOS has none, and parity means staleness
+    // only.
+    "$staleOverrideRaw = $env:ADE_BRAIN_HEARTBEAT_STALE_MS",
+    "if ($staleOverrideRaw -match '^\\s*[+-]?\\d+') {",
+    "  $staleOverrideMs = [long]0",
+    "  if ([long]::TryParse($Matches[0].Trim(), [ref]$staleOverrideMs) -and $staleOverrideMs -gt 0) {",
+    "    $heartbeatStaleMs = [Math]::Max(30000, $staleOverrideMs)",
+    "  }",
+    "}",
+    // Computed AFTER the override so the sleep floor rescales with it.
     // How late this supervisor's own poll may be before the machine counts as
     // having been suspended. Mirrors `brainWatcherSuspendFloorMs`, the rule the
     // macOS watchdog applies, so both platforms judge sleep the same way.

--- a/docs/development/windows-support.md
+++ b/docs/development/windows-support.md
@@ -106,6 +106,15 @@ own interval)` — not the same number: 90 s on Windows (15 s poll) and 180 s on
 macOS (60 s StartInterval), with `brainWatcherSuspendFloorMs` computing it
 there and the rendered PowerShell computing it inline.
 
+`ADE_BRAIN_HEARTBEAT_STALE_MS` overrides the 90 s staleness threshold on both
+platforms, with the same rules: a positive integer wins, anything else keeps the
+default, and the result never drops below 30 s. The suspend floor is computed
+after the override, so it rescales with it. Only the pickup differs. The macOS
+checker is a fresh process every 60 s, so it reads the variable at the next
+check. The Windows supervisor reads the variable once when it starts, so a
+changed machine variable applies after the brain service restarts. Neither
+platform has an override for the poll interval.
+
 The PID JSON is advisory ownership evidence. It is not a readiness file, and an
 ONLOGON Scheduled Task is not a current supervisor or readiness mechanism.
 The Run entry re-establishes the supervisor at the next user logon; the launcher

--- a/docs/features/remote-runtime/README.md
+++ b/docs/features/remote-runtime/README.md
@@ -1388,6 +1388,13 @@ Three layers now cover that, and they are deliberately different in kind:
   Both platforms apply the same three rules. macOS gets them from
   `evaluateBrainHeartbeat`; the Windows supervisor implements them inline in
   PowerShell against the same heartbeat file and the same suspend floor.
+  `ADE_BRAIN_HEARTBEAT_STALE_MS` overrides the 90 s staleness threshold on both
+  platforms, under the same rules — a positive integer wins, anything else keeps
+  the default, and the result never drops below 30 s — and the suspend floor is
+  computed after the override, so it rescales. Only the pickup differs: the
+  macOS check is a fresh process every 60 s and reads the variable at the next
+  check, while the Windows supervisor reads it once at start, so a changed
+  machine variable applies after the brain service restarts.
   - *macOS*: a separate launch agent, `com.ade.watchdog` (`.beta`/`.alpha` per
     channel), `StartInterval` 60 s, running `ade runtime watchdog-check` from
     the same binary the brain was installed from. It is installed and removed


### PR DESCRIPTION
## What

Follow-up from #1140's Windows watchdog work. The macOS external watchdog reads `ADE_BRAIN_HEARTBEAT_STALE_MS` at runtime; the Windows supervisor baked the threshold into the rendered PowerShell at install time, so the override silently did nothing there — a tester acting on it would draw wrong conclusions from an unchanged 90 s threshold.

## How

The rendered script reads the variable at start with exactly `resolveBrainHeartbeatStaleMs`'s rules (positive integer wins, 30 s floor, garbage keeps the default; an Int64-overflow value keeps the default, deliberately more conservative than macOS). `$watcherSuspendFloorMs` computes after the override so sleep detection rescales with it. Pickup semantics are documented: supervisor reads once at start (applies after a service restart); the macOS checker is a fresh process every 60 s. No poll-interval override — macOS has none, and parity means staleness only.

## Verification

- 3 new rendered-script assertions (override + bounds render, floor ordering, no poll override); the new lines sit inside the script the windows-foundation PowerShell parse tests execute on a real Windows runner.
- serviceManager + brainWatchdogCheck suites: 163 passed. ade-cli tsc clean.
- Docs updated: windows-support.md, remote-runtime README.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches Windows wedge-watchdog timing: a bad override could delay or (if parsing were wrong) accelerate killing a hung brain. Parsing is conservative (30s floor, garbage keeps default) and tests cover render order.
> 
> **Overview**
> The Windows PowerShell supervisor now reads `ADE_BRAIN_HEARTBEAT_STALE_MS` at start, matching macOS `resolveBrainHeartbeatStaleMs` (positive integer, 30s floor, invalid values keep the rendered default). Previously the threshold was baked in at install, so the env override did nothing.
> 
> `$watcherSuspendFloorMs` is computed after the override so sleep detection rescales. Pickup still differs: Windows applies a changed value only after a service restart; macOS re-reads every 60s. No poll-interval override.
> 
> Tests assert override parsing, floor ordering, and that poll interval stays fixed. Docs in `windows-support.md` and the remote-runtime README describe the shared rules and pickup difference.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 241838720cf3beacb15b1bacd5c206cc26f2ec4b. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->