### PR TITLE
ios(work): stabilize chat rendering and mobile UX

### DIFF
--- a/apps/ios/ADE.xcodeproj/project.pbxproj
+++ b/apps/ios/ADE.xcodeproj/project.pbxproj
@@ -130,6 +130,7 @@
 		FB000000000000000000C1C1 /* WorkSessionCanonicalState.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA000000000000000000C1C1 /* WorkSessionCanonicalState.swift */; };
 		E10000000000000000000039 /* WorkChatSessionView+Timeline.swift in Sources */ = {isa = PBXBuildFile; fileRef = D10000000000000000000039 /* WorkChatSessionView+Timeline.swift */; };
 		E1000000000000000000003A /* WorkReasoningCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1000000000000000000003A /* WorkReasoningCard.swift */; };
+		E10000000000000000000F0A /* WorkCardExpansion.swift in Sources */ = {isa = PBXBuildFile; fileRef = D10000000000000000000F0A /* WorkCardExpansion.swift */; };
 		E1000000000000000000003B /* WorkActivityIndicator.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1000000000000000000003B /* WorkActivityIndicator.swift */; };
 		E1000000000000000000003C /* WorkSessionGrouping.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1000000000000000000003C /* WorkSessionGrouping.swift */; };
 		E10000000000000000000F01 /* WorkLaneOrder.swift in Sources */ = {isa = PBXBuildFile; fileRef = D10000000000000000000F01 /* WorkLaneOrder.swift */; };
@@ -187,6 +188,7 @@
 		D31000000000000000000019 /* WorkPromptStashTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3000000000000000000000A /* WorkPromptStashTests.swift */; };
 		FB000000000000000000C2C2 /* WorkSessionCanonicalStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA000000000000000000C2C2 /* WorkSessionCanonicalStateTests.swift */; };
 		FB000000000000000000C2C3 /* WorkAssistantRenderingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA000000000000000000C2C3 /* WorkAssistantRenderingTests.swift */; };
+		FB000000000000000000C2D0 /* WorkCardExpansionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA000000000000000000C2D0 /* WorkCardExpansionTests.swift */; };
 		FB000000000000000000C2C4 /* WorkLiveRosterHydrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA000000000000000000C2C4 /* WorkLiveRosterHydrationTests.swift */; };
 		889573D8A5ED468D3BD12894 /* PRsTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EE4D463D21266B62B422D11 /* PRsTabView.swift */; };
 		B10000000000000000000003 /* LaneBatchManageSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000000000000000000003 /* LaneBatchManageSheet.swift */; };
@@ -428,6 +430,7 @@
 		FA000000000000000000C1C1 /* WorkSessionCanonicalState.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = WorkSessionCanonicalState.swift; path = ADE/Views/Work/WorkSessionCanonicalState.swift; sourceTree = "<group>"; };
 		D10000000000000000000039 /* WorkChatSessionView+Timeline.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "WorkChatSessionView+Timeline.swift"; path = "ADE/Views/Work/WorkChatSessionView+Timeline.swift"; sourceTree = "<group>"; };
 		D1000000000000000000003A /* WorkReasoningCard.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "WorkReasoningCard.swift"; path = "ADE/Views/Work/WorkReasoningCard.swift"; sourceTree = "<group>"; };
+		D10000000000000000000F0A /* WorkCardExpansion.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "WorkCardExpansion.swift"; path = "ADE/Views/Work/WorkCardExpansion.swift"; sourceTree = "<group>"; };
 		D1000000000000000000003B /* WorkActivityIndicator.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = WorkActivityIndicator.swift; path = ADE/Views/Work/WorkActivityIndicator.swift; sourceTree = "<group>"; };
 		D1000000000000000000003E /* WorkContextCompactDivider.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = WorkContextCompactDivider.swift; path = ADE/Views/Work/WorkContextCompactDivider.swift; sourceTree = "<group>"; };
 		D1000000000000000000003F /* WorkModelCatalog.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = WorkModelCatalog.swift; path = ADE/Views/Work/WorkModelCatalog.swift; sourceTree = "<group>"; };
@@ -620,6 +623,7 @@
 		C5A00000000000000000000D /* SSHPairingView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SSHPairingView.swift; path = ADE/Views/Settings/SSHPairingView.swift; sourceTree = "<group>"; };
 		C5A00000000000000000000E /* SSHBootstrapTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SSHBootstrapTests.swift; path = ADETests/SSHBootstrapTests.swift; sourceTree = "<group>"; };
 		FA000000000000000000C2C3 /* WorkAssistantRenderingTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = WorkAssistantRenderingTests.swift; path = ADETests/WorkAssistantRenderingTests.swift; sourceTree = "<group>"; };
+		FA000000000000000000C2D0 /* WorkCardExpansionTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = WorkCardExpansionTests.swift; path = ADETests/WorkCardExpansionTests.swift; sourceTree = "<group>"; };
 		FA000000000000000000C2C4 /* WorkLiveRosterHydrationTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = WorkLiveRosterHydrationTests.swift; path = ADETests/WorkLiveRosterHydrationTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -888,6 +892,7 @@
 				D1000000000000000000002B /* WorkChatSessionView+Actions.swift */,
 				D10000000000000000000039 /* WorkChatSessionView+Timeline.swift */,
 				D1000000000000000000003A /* WorkReasoningCard.swift */,
+				D10000000000000000000F0A /* WorkCardExpansion.swift */,
 				D1000000000000000000003B /* WorkActivityIndicator.swift */,
 				D1000000000000000000003E /* WorkContextCompactDivider.swift */,
 				D1000000000000000000003F /* WorkModelCatalog.swift */,
@@ -1170,6 +1175,7 @@
 				D3000000000000000000000A /* WorkPromptStashTests.swift */,
 				FA000000000000000000C2C2 /* WorkSessionCanonicalStateTests.swift */,
 				FA000000000000000000C2C3 /* WorkAssistantRenderingTests.swift */,
+				FA000000000000000000C2D0 /* WorkCardExpansionTests.swift */,
 				FA000000000000000000C2C4 /* WorkLiveRosterHydrationTests.swift */,
 				A90000000000000000000013 /* ProductAnalyticsPolicyTests.swift */,
 				A90000000000000000000014 /* PrGitHubDescriptionParserTests.swift */,
@@ -1611,6 +1617,7 @@
 				E1000000000000000000002B /* WorkChatSessionView+Actions.swift in Sources */,
 				E10000000000000000000039 /* WorkChatSessionView+Timeline.swift in Sources */,
 				E1000000000000000000003A /* WorkReasoningCard.swift in Sources */,
+				E10000000000000000000F0A /* WorkCardExpansion.swift in Sources */,
 				E1000000000000000000003B /* WorkActivityIndicator.swift in Sources */,
 				E1000000000000000000003E /* WorkContextCompactDivider.swift in Sources */,
 				E1000000000000000000003F /* WorkModelCatalog.swift in Sources */,
@@ -1701,6 +1708,7 @@
 				D31000000000000000000019 /* WorkPromptStashTests.swift in Sources */,
 				FB000000000000000000C2C2 /* WorkSessionCanonicalStateTests.swift in Sources */,
 				FB000000000000000000C2C3 /* WorkAssistantRenderingTests.swift in Sources */,
+				FB000000000000000000C2D0 /* WorkCardExpansionTests.swift in Sources */,
 				FB000000000000000000C2C4 /* WorkLiveRosterHydrationTests.swift in Sources */,
 				A90000000000000000000003 /* ProductAnalyticsPolicyTests.swift in Sources */,
 				A90000000000000000000004 /* PrGitHubDescriptionParserTests.swift in Sources */,

--- a/apps/ios/ADE.xcodeproj/project.pbxproj
+++ b/apps/ios/ADE.xcodeproj/project.pbxproj
@@ -268,6 +268,7 @@
 		E10000000000000000000041 /* WorkNewChatScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = D10000000000000000000041 /* WorkNewChatScreen.swift */; };
 		E30000000000000000000041 /* WorkUsageActivityCarousel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D30000000000000000000041 /* WorkUsageActivityCarousel.swift */; };
 		E10000000000000000000056 /* WorkImportSessionScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = D10000000000000000000056 /* WorkImportSessionScreen.swift */; };
+		E10000000000000000000F1 /* WorkOutputViewerScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = D10000000000000000000F1 /* WorkOutputViewerScreen.swift */; };
 		E10000000000000000000057 /* WorkExternalSessionAffordances.swift in Sources */ = {isa = PBXBuildFile; fileRef = D10000000000000000000057 /* WorkExternalSessionAffordances.swift */; };
 		E10000000000000000000051 /* WorkLanePickerDropdown.swift in Sources */ = {isa = PBXBuildFile; fileRef = D10000000000000000000051 /* WorkLanePickerDropdown.swift */; };
 		E10000000000000000000042 /* WorkPreviews.swift in Sources */ = {isa = PBXBuildFile; fileRef = D10000000000000000000042 /* WorkPreviews.swift */; };
@@ -434,6 +435,7 @@
 		D10000000000000000000041 /* WorkNewChatScreen.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = WorkNewChatScreen.swift; path = ADE/Views/Work/WorkNewChatScreen.swift; sourceTree = "<group>"; };
 		D30000000000000000000041 /* WorkUsageActivityCarousel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = WorkUsageActivityCarousel.swift; path = ADE/Views/Work/WorkUsageActivityCarousel.swift; sourceTree = "<group>"; };
 		D10000000000000000000056 /* WorkImportSessionScreen.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = WorkImportSessionScreen.swift; path = ADE/Views/Work/WorkImportSessionScreen.swift; sourceTree = "<group>"; };
+		D10000000000000000000F1 /* WorkOutputViewerScreen.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = WorkOutputViewerScreen.swift; path = ADE/Views/Work/WorkOutputViewerScreen.swift; sourceTree = "<group>"; };
 		D10000000000000000000057 /* WorkExternalSessionAffordances.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = WorkExternalSessionAffordances.swift; path = ADE/Views/Work/WorkExternalSessionAffordances.swift; sourceTree = "<group>"; };
 		D10000000000000000000051 /* WorkLanePickerDropdown.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = WorkLanePickerDropdown.swift; path = ADE/Views/Work/WorkLanePickerDropdown.swift; sourceTree = "<group>"; };
 		D10000000000000000000042 /* WorkPreviews.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = WorkPreviews.swift; path = ADE/Views/Work/WorkPreviews.swift; sourceTree = "<group>"; };
@@ -893,6 +895,7 @@
 				D10000000000000000000041 /* WorkNewChatScreen.swift */,
 				D30000000000000000000041 /* WorkUsageActivityCarousel.swift */,
 				D10000000000000000000056 /* WorkImportSessionScreen.swift */,
+				D10000000000000000000F1 /* WorkOutputViewerScreen.swift */,
 				D10000000000000000000057 /* WorkExternalSessionAffordances.swift */,
 				D10000000000000000000051 /* WorkLanePickerDropdown.swift */,
 				D10000000000000000000042 /* WorkPreviews.swift */,
@@ -1615,6 +1618,7 @@
 				E10000000000000000000041 /* WorkNewChatScreen.swift in Sources */,
 				E30000000000000000000041 /* WorkUsageActivityCarousel.swift in Sources */,
 				E10000000000000000000056 /* WorkImportSessionScreen.swift in Sources */,
+				E10000000000000000000F1 /* WorkOutputViewerScreen.swift in Sources */,
 				E10000000000000000000057 /* WorkExternalSessionAffordances.swift in Sources */,
 				E10000000000000000000051 /* WorkLanePickerDropdown.swift in Sources */,
 				E10000000000000000000042 /* WorkPreviews.swift in Sources */,

--- a/apps/ios/ADE/Models/RemoteModels.swift
+++ b/apps/ios/ADE/Models/RemoteModels.swift
@@ -3369,6 +3369,12 @@ struct AgentChatSteerRequest: Codable, Equatable {
   var sessionId: String
   var text: String
   var attachments: [AgentChatFileRef]? = nil
+  /// `"inline"` or `"interrupt"` — the desktop's `dispatchMode` spelling, kept
+  /// character-identical because the host validates the string. Present only
+  /// when the user picked an active-turn mode: the host then dispatches in this
+  /// same round-trip instead of staging the message, so nothing reaches the
+  /// staged strip. Omitted (nil) for a plain staged steer.
+  var dispatchMode: String? = nil
 }
 
 struct AgentChatCancelSteerRequest: Codable, Equatable {

--- a/apps/ios/ADE/Services/SyncService.swift
+++ b/apps/ios/ADE/Services/SyncService.swift
@@ -13561,12 +13561,18 @@ final class SyncService: ObservableObject {
   func steerChatSession(
     sessionId: String,
     text: String,
-    attachments: [AgentChatFileRef]? = nil
+    attachments: [AgentChatFileRef]? = nil,
+    dispatchMode: String? = nil
   ) async throws -> SyncChatMessageDelivery {
     let scope = chatCommandScope(for: sessionId)
     let response = try await sendChatCommand(
       action: chatActionName("chat.steer", sessionId: sessionId),
-      payload: AgentChatSteerRequest(sessionId: sessionId, text: text, attachments: attachments),
+      payload: AgentChatSteerRequest(
+        sessionId: sessionId,
+        text: text,
+        attachments: attachments,
+        dispatchMode: dispatchMode
+      ),
       targetProjectId: scope.projectId,
       targetProjectRootPath: scope.rootPath
     )

--- a/apps/ios/ADE/Views/Work/WorkArtifactTerminalViews.swift
+++ b/apps/ios/ADE/Views/Work/WorkArtifactTerminalViews.swift
@@ -39,14 +39,15 @@ struct WorkArtifactVideoPlayerView: View {
 struct WorkArtifactView: View {
   let artifact: ComputerUseArtifactSummary
   let content: WorkLoadedArtifactContent?
+  let isExpanded: Bool
+  let onToggle: () -> Void
   let onAppear: () -> Void
   let onOpenImage: (UIImage) -> Void
-  @State private var isExpanded = false
 
   var body: some View {
     VStack(alignment: .leading, spacing: 8) {
       Button {
-        isExpanded.toggle()
+        onToggle()
       } label: {
         HStack(spacing: 8) {
           Image(systemName: workArtifactKindIcon(artifact))

--- a/apps/ios/ADE/Views/Work/WorkCardExpansion.swift
+++ b/apps/ios/ADE/Views/Work/WorkCardExpansion.swift
@@ -1,0 +1,317 @@
+import SwiftUI
+
+// MARK: - Central expansion state
+
+/// Expansion state for every collapsible card in the Work transcript, held once
+/// at the session level instead of per-row.
+///
+/// Two reasons it does not live in the rows:
+///
+/// 1. A row's `@State` dies whenever the `LazyVStack` recycles it, so a card the
+///    reader opened silently snapped shut the moment it scrolled off screen.
+/// 2. Turn end has to collapse the whole turn at once, which no row can do to
+///    itself.
+///
+/// The two sets are overrides on top of a per-card default. `defaultsOpen` is
+/// what the card would show on its own — today's behavior while its turn is
+/// live — and the reader's tap records only the *disagreement* with it, which
+/// is what makes "collapse this while it is still running" survive the next
+/// streaming delta.
+struct WorkCardExpansionState: Equatable {
+  /// Cards the reader opened by hand.
+  private(set) var expandedIds: Set<String> = []
+  /// Cards the reader shut by hand while their turn was still live.
+  private(set) var collapsedIds: Set<String> = []
+
+  init(expandedIds: Set<String> = [], collapsedIds: Set<String> = []) {
+    self.expandedIds = expandedIds
+    self.collapsedIds = collapsedIds
+  }
+
+  func isExpanded(id: String, defaultsOpen: Bool) -> Bool {
+    if expandedIds.contains(id) { return true }
+    if collapsedIds.contains(id) { return false }
+    return defaultsOpen
+  }
+
+  mutating func toggle(id: String, defaultsOpen: Bool) {
+    set(id: id, expanded: !isExpanded(id: id, defaultsOpen: defaultsOpen), defaultsOpen: defaultsOpen)
+  }
+
+  mutating func set(id: String, expanded: Bool, defaultsOpen: Bool) {
+    if expanded == defaultsOpen {
+      // Back in agreement with the card's own default: drop the override rather
+      // than carry a redundant entry that the turn-end sweep has to clear.
+      expandedIds.remove(id)
+      collapsedIds.remove(id)
+    } else if expanded {
+      collapsedIds.remove(id)
+      expandedIds.insert(id)
+    } else {
+      expandedIds.remove(id)
+      collapsedIds.insert(id)
+    }
+  }
+
+  /// A turn ending collapses everything it produced, and drops the overrides
+  /// that were only meaningful while it was live. Reopening a chat lands here
+  /// too, because nothing is streaming: history renders collapsed.
+  mutating func clearForTurnEnd() {
+    guard !expandedIds.isEmpty || !collapsedIds.isEmpty else { return }
+    expandedIds.removeAll()
+    collapsedIds.removeAll()
+  }
+
+  var isEmpty: Bool { expandedIds.isEmpty && collapsedIds.isEmpty }
+}
+
+/// Order-independent fingerprint of the expansion state. `WorkChatSessionView`
+/// carries it as a plain `Int` so SwiftUI's view-identity compare actually sees
+/// an expand/collapse — a `@Binding` alone compares equal no matter what.
+func workCardExpansionRenderSignature(_ state: WorkCardExpansionState) -> Int {
+  var hasher = Hasher()
+  hasher.combine(state.expandedIds.count)
+  hasher.combine(state.collapsedIds.count)
+  for id in state.expandedIds.sorted() {
+    hasher.combine(id)
+  }
+  hasher.combine(0)
+  for id in state.collapsedIds.sorted() {
+    hasher.combine(id)
+  }
+  return hasher.finalize()
+}
+
+// MARK: - Collapsed summaries
+
+/// One right-aligned count chip on a collapsed card row.
+struct WorkCollapsedStatusChip: Identifiable, Equatable {
+  let id: String
+  /// Compact glyph form, e.g. `18✓`.
+  let label: String
+  let tone: WorkAdeCardTone
+  /// Spoken form, e.g. "18 passed".
+  let accessibilityText: String
+}
+
+/// Pass/fail counts for a collapsed `ade_card`. A zero count draws no chip —
+/// "18✓" alone says a clean run better than "18✓ 0✕" does.
+func workAdeCardCollapsedChips(_ card: WorkAdeCardModel) -> [WorkCollapsedStatusChip] {
+  guard let progress = card.progress else { return [] }
+  var chips: [WorkCollapsedStatusChip] = []
+  if progress.passed > 0 {
+    chips.append(
+      WorkCollapsedStatusChip(
+        id: "passed",
+        label: "\(progress.passed)✓",
+        tone: .success,
+        accessibilityText: "\(progress.passed) passed"
+      )
+    )
+  }
+  if progress.failed > 0 {
+    chips.append(
+      WorkCollapsedStatusChip(
+        id: "failed",
+        label: "\(progress.failed)✕",
+        // Amber, not red: `adeCard.ts`'s tone policy has no red path, and the
+        // expanded card right below this row uses the same tint.
+        tone: .warning,
+        accessibilityText: "\(progress.failed) failed"
+      )
+    )
+  }
+  return chips
+}
+
+/// `Title · first subtitle segment` — for a `pr_ci` card that reads
+/// "CI passing · PR #490". The subtitle's later segments (run name, failure
+/// reason) belong to the expanded card, not to a one-line row.
+func workAdeCardCollapsedSummary(_ card: WorkAdeCardModel) -> String {
+  var parts: [String] = []
+  let title = card.title.trimmingCharacters(in: .whitespacesAndNewlines)
+  // A titleless payload gets the raw variant slug as its title (see
+  // `makeWorkAdeCardModel`). That slug is wire vocabulary — `pr_ci`, not "CI" —
+  // so drop it and let the fallback prose speak, which is exactly what the
+  // expanded card renders for the same payload.
+  if !title.isEmpty, title != card.variant.trimmingCharacters(in: .whitespacesAndNewlines) {
+    parts.append(title)
+  }
+  if let subtitle = card.subtitle?.trimmingCharacters(in: .whitespacesAndNewlines),
+     !subtitle.isEmpty,
+     let lead = subtitle.components(separatedBy: " · ").first?
+      .trimmingCharacters(in: .whitespacesAndNewlines),
+     !lead.isEmpty {
+    parts.append(lead)
+  }
+  if parts.isEmpty {
+    return card.fallbackText
+  }
+  return parts.joined(separator: " · ")
+}
+
+/// Leading glyph for a collapsed `ade_card`. Variant-shaped and status-neutral —
+/// the pass/fail reading belongs to the chips on the right, not to the icon.
+func workAdeCardCollapsedGlyph(_ card: WorkAdeCardModel) -> String {
+  switch card.variant.trimmingCharacters(in: .whitespacesAndNewlines) {
+  case "pr_ci": return "checklist"
+  case "pr_review": return "text.bubble"
+  case "pr_merged", "pr_merge_ready": return "arrow.triangle.merge"
+  case "pr_conflict": return "exclamationmark.triangle"
+  case "proof_artifact": return "cube.transparent"
+  case "claude_session_quota": return "gauge.with.dots.needle.33percent"
+  default: return "square.stack"
+  }
+}
+
+func workAdeCardCollapsedAccessibilityLabel(_ card: WorkAdeCardModel) -> String {
+  var parts = [workAdeCardCollapsedSummary(card)]
+  parts.append(contentsOf: workAdeCardCollapsedChips(card).map(\.accessibilityText))
+  parts.append("collapsed")
+  return parts.joined(separator: ", ")
+}
+
+/// `Plan · <first pending step, or the plan's own summary>`.
+func workPlanCardCollapsedSummary(_ card: WorkEventCardModel) -> String {
+  let steps = card.planSteps
+  let detail = workPlanCardCollapsedDetail(card)
+  guard let detail else {
+    return steps.isEmpty ? "Plan" : "Plan · \(steps.count) step\(steps.count == 1 ? "" : "s")"
+  }
+  return "Plan · \(detail)"
+}
+
+private func workPlanCardCollapsedDetail(_ card: WorkEventCardModel) -> String? {
+  let title = card.title.trimmingCharacters(in: .whitespacesAndNewlines)
+  if !title.isEmpty, title.caseInsensitiveCompare("Plan") != .orderedSame {
+    return workSummarizeInlineText(title, maxChars: 64)
+  }
+  let steps = card.planSteps
+  // The step the reader would act on next, falling back to the first one when
+  // the plan has not started (or has finished).
+  let active = steps.first { !workPlanStepIsCompleted($0.status) } ?? steps.first
+  if let text = active?.text.trimmingCharacters(in: .whitespacesAndNewlines), !text.isEmpty {
+    return workSummarizeInlineText(text, maxChars: 64)
+  }
+  if let body = card.body?.trimmingCharacters(in: .whitespacesAndNewlines), !body.isEmpty {
+    return workSummarizeInlineText(body, maxChars: 64)
+  }
+  return nil
+}
+
+/// Same mapping `WorkProposedPlanCard` normalizes with, so the collapsed row's
+/// `4/7` can never disagree with the expanded checklist's.
+func workPlanStepIsCompleted(_ status: String) -> Bool {
+  switch status.lowercased().replacingOccurrences(of: "_", with: "-") {
+  case "completed", "done", "complete", "success": return true
+  default: return false
+  }
+}
+
+func workPlanCardCompletedStepCount(_ card: WorkEventCardModel) -> Int {
+  card.planSteps.filter { workPlanStepIsCompleted($0.status) }.count
+}
+
+/// `4/7`, or nil for a plan that has no steps yet.
+func workPlanCardCollapsedProgressLabel(_ card: WorkEventCardModel) -> String? {
+  let steps = card.planSteps
+  guard !steps.isEmpty else { return nil }
+  return "\(workPlanCardCompletedStepCount(card))/\(steps.count)"
+}
+
+func workPlanCardCollapsedAccessibilityLabel(_ card: WorkEventCardModel) -> String {
+  var parts = [workPlanCardCollapsedSummary(card)]
+  if workPlanCardCollapsedProgressLabel(card) != nil {
+    parts.append("\(workPlanCardCompletedStepCount(card)) of \(card.planSteps.count) steps done")
+  }
+  parts.append("collapsed")
+  return parts.joined(separator: ", ")
+}
+
+// MARK: - Shared collapsed row
+
+/// The one-line form every auto-collapsed card takes: glyph, summary, count
+/// chips, chevron — one 44pt row, tapped to expand in place.
+struct WorkCollapsedCardRow: View {
+  let systemImage: String
+  let glyphTint: Color
+  let summary: String
+  var chips: [WorkCollapsedStatusChip] = []
+  let accessibilityText: String
+  let onToggle: () -> Void
+
+  var body: some View {
+    Button(action: onToggle) {
+      HStack(spacing: 8) {
+        Image(systemName: systemImage)
+          .font(.system(size: 12, weight: .semibold))
+          .foregroundStyle(glyphTint)
+          .frame(width: 16)
+
+        Text(summary)
+          .font(.footnote.weight(.medium))
+          .foregroundStyle(ADEColor.textPrimary)
+          .lineLimit(1)
+          .truncationMode(.tail)
+
+        Spacer(minLength: 6)
+
+        ForEach(chips) { chip in
+          Text(chip.label)
+            .font(.caption.weight(.semibold).monospacedDigit())
+            .foregroundStyle(workAdeCardToneColor(chip.tone))
+            .padding(.horizontal, 7)
+            .padding(.vertical, 2)
+            .background(
+              workAdeCardToneColor(chip.tone).opacity(0.12),
+              in: Capsule(style: .continuous)
+            )
+        }
+
+        Image(systemName: "chevron.right")
+          .font(.system(size: 10, weight: .semibold))
+          .foregroundStyle(ADEColor.textMuted)
+      }
+      .padding(.horizontal, 12)
+      .frame(minHeight: 44)
+      .contentShape(Rectangle())
+    }
+    .buttonStyle(.plain)
+    .accessibilityElement(children: .combine)
+    .accessibilityLabel(accessibilityText)
+    .accessibilityHint("Double tap to expand.")
+  }
+}
+
+/// Long-press peek: the full card, rendered as a non-interactive context-menu
+/// preview so the reader can check a collapsed row without expanding it and
+/// pushing the transcript around.
+extension View {
+  @ViewBuilder
+  func workCollapsedCardPeek<Preview: View>(
+    enabled: Bool = true,
+    onExpand: @escaping () -> Void,
+    @ViewBuilder preview: @escaping () -> Preview
+  ) -> some View {
+    if enabled {
+      contextMenu {
+        Button {
+          onExpand()
+        } label: {
+          Label("Expand", systemImage: "chevron.down")
+        }
+      } preview: {
+        ScrollView {
+          preview()
+            .allowsHitTesting(false)
+            .padding(14)
+            .frame(maxWidth: .infinity, alignment: .leading)
+        }
+        .frame(width: 340)
+        .background(ADEColor.pageBackground)
+      }
+    } else {
+      self
+    }
+  }
+}

--- a/apps/ios/ADE/Views/Work/WorkChatComposerAndInputViews.swift
+++ b/apps/ios/ADE/Views/Work/WorkChatComposerAndInputViews.swift
@@ -582,111 +582,103 @@ struct WorkComposerChipStrip: View {
 
 }
 
+/// The strip only ever renders messages the user explicitly queued — an
+/// atomically dispatched send never produces a staged row — so it no longer
+/// hides behind an accordion. A single queued message is one compact card with
+/// its four actions visible; only a pile-up gets a slim count above the rows.
 struct WorkQueuedSteerStrip: View {
   let steers: [WorkPendingSteerModel]
   @Binding var drafts: [String: String]
   let busy: Bool
   let isLive: Bool
+  /// Drives the queued card's live indicator: a message waiting behind a
+  /// running turn breathes, one waiting on an idle session sits still.
+  let turnActive: Bool
   let onCancel: @MainActor (String) async -> Void
   let onSaveEdit: @MainActor (String, String) async -> Void
   let onDispatchInline: (@MainActor (String) async -> Void)?
   let onDispatchInterrupt: (@MainActor (String) async -> Void)?
 
-  // Expanded by default so Send now / Interrupt / Edit / Cancel have the same
-  // immediate affordance as desktop and the TUI after a steer is staged.
-  @State private var isExpanded: Bool = true
   // Cancel haptic token: bumped each time a row's cancel lands so the
   // whole strip can drive a single sensoryFeedback modifier.
   @State private var cancelHapticToken: Int = 0
-  // Always expand while any row is actively being edited so edits aren't
-  // hidden behind a collapse tap.
-  private var anyEditing: Bool {
-    steers.contains(where: { drafts[$0.id] != nil })
-  }
 
   var body: some View {
-    VStack(alignment: .leading, spacing: 10) {
-      header
+    VStack(alignment: .leading, spacing: 6) {
+      if steers.count > 1 { header }
 
-      if isExpanded || anyEditing {
-        VStack(spacing: 6) {
-          ForEach(steers) { steer in
-            WorkQueuedSteerRow(
-              steer: steer,
-              draft: Binding(
-                get: { drafts[steer.id] ?? steer.text },
-                set: { drafts[steer.id] = $0 }
-              ),
-              isEditing: drafts[steer.id] != nil,
-              busy: busy,
-              isLive: isLive,
-              onBeginEdit: { drafts[steer.id] = steer.text },
-              onCancelEdit: { drafts.removeValue(forKey: steer.id) },
-              onCancel: {
-                cancelHapticToken &+= 1
-                await onCancel(steer.id)
-              },
-              onSave: { text in await onSaveEdit(steer.id, text) },
-              onDispatchInline: onDispatchInline.map { dispatch in
-                { await dispatch(steer.id) }
-              },
-              onDispatchInterrupt: onDispatchInterrupt.map { dispatch in
-                { await dispatch(steer.id) }
-              }
-            )
+      ForEach(steers) { steer in
+        WorkQueuedSteerRow(
+          steer: steer,
+          draft: Binding(
+            get: { drafts[steer.id] ?? steer.text },
+            set: { drafts[steer.id] = $0 }
+          ),
+          isEditing: drafts[steer.id] != nil,
+          busy: busy,
+          isLive: isLive,
+          turnActive: turnActive,
+          onBeginEdit: { drafts[steer.id] = steer.text },
+          onCancelEdit: { drafts.removeValue(forKey: steer.id) },
+          onCancel: {
+            cancelHapticToken &+= 1
+            await onCancel(steer.id)
+          },
+          onSave: { text in await onSaveEdit(steer.id, text) },
+          onDispatchInline: onDispatchInline.map { dispatch in
+            { await dispatch(steer.id) }
+          },
+          onDispatchInterrupt: onDispatchInterrupt.map { dispatch in
+            { await dispatch(steer.id) }
           }
-        }
-        .transition(.opacity.combined(with: .move(edge: .top)))
+        )
       }
     }
-    .padding(10)
+    .padding(6)
     .background(ADEColor.accent.opacity(0.08), in: RoundedRectangle(cornerRadius: 14, style: .continuous))
     .overlay(
       RoundedRectangle(cornerRadius: 14, style: .continuous)
         .stroke(ADEColor.accent.opacity(0.22), lineWidth: 0.8)
     )
     .sensoryFeedback(.impact(weight: .light), trigger: cancelHapticToken)
-    .animation(.smooth(duration: 0.22), value: isExpanded)
-    .animation(.smooth(duration: 0.22), value: anyEditing)
     .accessibilityElement(children: .contain)
   }
 
+  /// Static label, not a disclosure control — the rows below it are always
+  /// visible. Kept only so a queue of several reads as a queue.
   private var header: some View {
-    Button {
-      withAnimation(.smooth(duration: 0.22)) {
-        isExpanded.toggle()
-      }
-    } label: {
-      HStack(spacing: 6) {
-        Image(systemName: "paperplane.circle")
-          .font(.caption.weight(.semibold))
-          .foregroundStyle(ADEColor.accent)
-        Text(steers.count == 1 ? "1 staged" : "\(steers.count) staged")
-          .font(.caption.weight(.semibold))
-          .foregroundStyle(ADEColor.textSecondary)
-        if !isExpanded && !anyEditing, let preview = steers.first?.text {
-          Text("·")
-            .font(.caption2)
-            .foregroundStyle(ADEColor.textMuted)
-          Text(preview)
-            .font(.caption)
-            .foregroundStyle(ADEColor.textSecondary)
-            .lineLimit(1)
-            .truncationMode(.tail)
-        }
-        Spacer(minLength: 4)
-        Image(systemName: isExpanded || anyEditing ? "chevron.up" : "chevron.down")
-          .font(.caption2.weight(.semibold))
-          .foregroundStyle(ADEColor.textMuted)
-      }
-      .contentShape(Rectangle())
-    }
-    .buttonStyle(.plain)
-    .accessibilityLabel(steers.count == 1 ? "1 staged message" : "\(steers.count) staged messages")
-    .accessibilityHint(isExpanded || anyEditing ? "Collapse staged messages" : "Expand to send now, interrupt, edit, or cancel staged messages")
-    .accessibilityIdentifier("Work.Chat.StagedStrip.Header")
-    .disabled(anyEditing)
+    Text("\(steers.count) queued")
+      .font(.caption.weight(.semibold))
+      .foregroundStyle(ADEColor.textSecondary)
+      .padding(.horizontal, 4)
+      .frame(maxWidth: .infinity, alignment: .leading)
+      .accessibilityLabel("\(steers.count) queued messages")
+      .accessibilityIdentifier("Work.Chat.StagedStrip.Header")
   }
+}
+
+/// Clock glyph that breathes while a turn is running, so a queued message reads
+/// as waiting rather than stuck. Still under Reduce Motion, where the glyph is
+/// simply drawn at full strength.
+private struct WorkQueuedSteerWaitingGlyph: View {
+  @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
+  let waiting: Bool
+
+  @State private var pulsing = false
+
+  var body: some View {
+    Image(systemName: "clock")
+      .font(.system(size: 13, weight: .semibold))
+      .foregroundStyle(ADEColor.accent)
+      .opacity(animates && pulsing ? 0.4 : 1)
+      .animation(ADEMotion.pulse(reduceMotion: reduceMotion), value: pulsing)
+      .onAppear { pulsing = animates }
+      .onChange(of: animates) { _, isAnimating in pulsing = isAnimating }
+      .accessibilityHidden(true)
+  }
+
+  private var animates: Bool { waiting && !reduceMotion }
 }
 
 struct WorkQueuedSteerRow: View {
@@ -695,6 +687,7 @@ struct WorkQueuedSteerRow: View {
   let isEditing: Bool
   let busy: Bool
   let isLive: Bool
+  let turnActive: Bool
   let onBeginEdit: () -> Void
   let onCancelEdit: () -> Void
   let onCancel: @MainActor () async -> Void
@@ -750,77 +743,78 @@ struct WorkQueuedSteerRow: View {
           }
         }
       } else {
-        // Compact row (mirrors the desktop staged strip): one truncated line of
-        // text, then a muted disposition + timestamp line with icon-only actions.
-        // Icon-only buttons are the fix for mid-word label wrapping ("Inter-rupt")
-        // that the old titleAndIcon chips hit in this non-scrolling HStack.
-        Text(steer.text)
-          .font(.system(size: 13.5))
-          .foregroundStyle(ADEColor.textPrimary)
-          .lineLimit(1)
-          .truncationMode(.tail)
+        // One compact card, no accordion: waiting glyph, a single truncated line
+        // of the message with its disposition beneath it, and the four actions
+        // as icon-only buttons. Icon-only is the fix for mid-word label wrapping
+        // ("Inter-rupt") that the old titleAndIcon chips hit in this
+        // non-scrolling HStack; the tap targets stay 44pt tall regardless.
+        HStack(spacing: 8) {
+          WorkQueuedSteerWaitingGlyph(waiting: turnActive)
+
+          VStack(alignment: .leading, spacing: 1) {
+            Text(steer.text)
+              .font(.system(size: 13.5))
+              .foregroundStyle(ADEColor.textPrimary)
+              .lineLimit(1)
+              .truncationMode(.tail)
+
+            Text(dispositionText)
+              .font(.caption2)
+              .foregroundStyle(ADEColor.textMuted)
+              .lineLimit(1)
+          }
           .frame(maxWidth: .infinity, alignment: .leading)
 
-        HStack(spacing: 6) {
-          Text("Sends after turn")
-            .font(.caption2)
-            .foregroundStyle(ADEColor.textMuted)
-          Text("·")
-            .font(.caption2)
-            .foregroundStyle(ADEColor.textMuted)
-          Text(relativeTimestamp(steer.timestamp))
-            .font(.caption2)
-            .foregroundStyle(ADEColor.textMuted)
-
-          Spacer(minLength: 8)
-
-          if let onDispatchInline {
-            steerActionButton(
-              systemImage: "paperplane.fill",
-              tint: ADEColor.accent,
-              label: "Send now",
-              hint: "Fold this message into the active turn",
-              identifier: "Work.Chat.StagedStrip.SendNow"
-            ) {
-              await onDispatchInline()
+          HStack(spacing: 0) {
+            if let onDispatchInline {
+              steerActionButton(
+                systemImage: "paperplane.fill",
+                tint: ADEColor.accent,
+                label: "Send now",
+                hint: "Fold this message into the active turn",
+                identifier: "Work.Chat.StagedStrip.SendNow"
+              ) {
+                await onDispatchInline()
+              }
             }
-          }
 
-          if let onDispatchInterrupt {
-            steerActionButton(
-              systemImage: "bolt.fill",
-              tint: ADEColor.warning,
-              label: "Interrupt",
-              hint: "Stop the current turn and run this instead",
-              identifier: "Work.Chat.StagedStrip.Interrupt"
-            ) {
-              await onDispatchInterrupt()
+            if let onDispatchInterrupt {
+              steerActionButton(
+                systemImage: "bolt.fill",
+                tint: ADEColor.warning,
+                label: "Interrupt",
+                hint: "Stop the current turn and run this instead",
+                identifier: "Work.Chat.StagedStrip.Interrupt"
+              ) {
+                await onDispatchInterrupt()
+              }
             }
-          }
 
-          steerActionButton(
-            systemImage: "pencil",
-            tint: ADEColor.textSecondary,
-            label: "Edit",
-            hint: nil,
-            identifier: "Work.Chat.StagedStrip.Edit"
-          ) {
-            onBeginEdit()
-          }
+            steerActionButton(
+              systemImage: "pencil",
+              tint: ADEColor.textSecondary,
+              label: "Edit",
+              hint: nil,
+              identifier: "Work.Chat.StagedStrip.Edit"
+            ) {
+              onBeginEdit()
+            }
 
-          steerActionButton(
-            systemImage: "xmark",
-            tint: ADEColor.danger,
-            label: "Cancel staged message",
-            hint: nil,
-            identifier: "Work.Chat.StagedStrip.Cancel"
-          ) {
-            await onCancel()
+            steerActionButton(
+              systemImage: "xmark",
+              tint: ADEColor.danger,
+              label: "Cancel queued message",
+              hint: nil,
+              identifier: "Work.Chat.StagedStrip.Cancel"
+            ) {
+              await onCancel()
+            }
           }
         }
       }
     }
-    .padding(10)
+    .padding(.horizontal, 10)
+    .padding(.vertical, isEditing ? 10 : 2)
     .background(ADEColor.surfaceBackground.opacity(0.86), in: RoundedRectangle(cornerRadius: 12, style: .continuous))
     .overlay(
       RoundedRectangle(cornerRadius: 12, style: .continuous)
@@ -829,8 +823,15 @@ struct WorkQueuedSteerRow: View {
     .accessibilityElement(children: .contain)
   }
 
-  // Icon-only tap target (≥32pt) with an accessibility label so the row's
-  // actions stay compact and never wrap their titles.
+  /// Says what happens next, not when it was typed: a queued message's
+  /// timestamp is always "a moment ago" and carried no information.
+  private var dispositionText: String {
+    turnActive ? "sends when turn ends" : "after turn"
+  }
+
+  // Icon-only tap target with an accessibility label so the row's actions stay
+  // compact and never wrap their titles. The glyph is small; the touch area is
+  // a full 44pt tall via contentShape.
   @ViewBuilder
   private func steerActionButton(
     systemImage: String,
@@ -844,9 +845,9 @@ struct WorkQueuedSteerRow: View {
       Task { await action() }
     } label: {
       Image(systemName: systemImage)
-        .font(.system(size: 14, weight: .semibold))
+        .font(.system(size: 13.5, weight: .semibold))
         .foregroundStyle(tint)
-        .frame(width: 34, height: 32)
+        .frame(width: 38, height: 44)
         .contentShape(Rectangle())
     }
     .buttonStyle(.plain)

--- a/apps/ios/ADE/Views/Work/WorkChatHeaderAndMessageViews.swift
+++ b/apps/ios/ADE/Views/Work/WorkChatHeaderAndMessageViews.swift
@@ -292,7 +292,16 @@ struct WorkChatHeaderMenu: View, Equatable {
 /// the centered turn separator). User messages stay right-aligned but size to
 /// their content so short replies don't look like banner ads, and they drop
 /// the per-message timestamp for the same reason.
-struct WorkChatMessageBubble: View {
+struct WorkChatMessageBubble: View, Equatable {
+  /// Rows are compared, not re-rendered. Closures are excluded on purpose: they
+  /// are rebuilt on every parent body pass and never change what is drawn.
+  static func == (lhs: WorkChatMessageBubble, rhs: WorkChatMessageBubble) -> Bool {
+    lhs.message == rhs.message
+      && lhs.isStreaming == rhs.isStreaming
+      && lhs.maxUserBubbleWidth == rhs.maxUserBubbleWidth
+      && (lhs.onShowMore == nil) == (rhs.onShowMore == nil)
+  }
+
   let message: WorkChatMessage
   /// True only for the assistant message still receiving streaming deltas.
   /// Switches its markdown block parsing to the tail-only streaming parser so
@@ -304,7 +313,15 @@ struct WorkChatMessageBubble: View {
   var onRunUnprocessed: (@MainActor (WorkChatMessage) async throws -> Void)? = nil
   var onEditUnprocessed: (@MainActor (WorkChatMessage) async throws -> Void)? = nil
   var onDismissUnprocessed: (@MainActor (WorkChatMessage) async throws -> Void)? = nil
-  @State private var assistantLineBudget = workAssistantMessageInitialLineBudget
+  /// One "Show more" step for this message, owned by the transcript.
+  ///
+  /// The bubble used to keep its own `@State` budget and re-slice the message
+  /// itself, so the two show-more paths (this one and the split-row controls)
+  /// disagreed about how much of a message was on screen, and the bubble's half
+  /// was lost whenever the `LazyVStack` recycled the row. The transcript's
+  /// shared budget map is now the only owner; the preview on `message` already
+  /// reflects it.
+  var onShowMore: (() -> Void)? = nil
 
   /// Provider string for the current chat session (e.g. "claude", "codex", "cursor").
   /// Injected via `.environment(\.workChatProvider, ...)` by the session view.
@@ -429,15 +446,15 @@ struct WorkChatMessageBubble: View {
 
           // Anything still truncated can still be expanded: one more step per
           // tap, with no ceiling to strand the reader partway through.
-          Button {
-            assistantLineBudget += workAssistantMessageLineBudgetStep
-          } label: {
-            Label("Show more", systemImage: "chevron.down")
-              .labelStyle(.titleAndIcon)
-              .font(.caption2.weight(.semibold))
+          if let onShowMore {
+            Button(action: onShowMore) {
+              Label("Show more", systemImage: "chevron.down")
+                .labelStyle(.titleAndIcon)
+                .font(.caption2.weight(.semibold))
+            }
+            .buttonStyle(.plain)
+            .foregroundStyle(ADEColor.accent)
           }
-          .buttonStyle(.plain)
-          .foregroundStyle(ADEColor.accent)
         }
       }
     }
@@ -543,18 +560,11 @@ struct WorkChatMessageBubble: View {
     )
   }
 
+  /// Always the preview the transcript computed for this message. Re-slicing it
+  /// here would be a second, disagreeing source of truth — and O(message) on the
+  /// main thread for every body pass.
   private var assistantPreview: WorkAssistantMessagePreview {
-    if assistantLineBudget == workAssistantMessageInitialLineBudget,
-       let preview = message.assistantPreview {
-      return preview
-    }
-    return workAssistantMessagePreview(
-      message.markdown,
-      lineBudget: assistantLineBudget,
-      characterBudget: workAssistantMessageCharacterBudget(forLineBudget: assistantLineBudget),
-      anchor: .head,
-      classification: message.assistantPreview?.usesMonospacedRendering
-    )
+    message.assistantPreview ?? workInitialAssistantMessagePreview(message.markdown)
   }
 
   private var userMessageAccessibilityLabel: String {
@@ -668,7 +678,7 @@ let workAssistantMessageWideInitialLineBudget = 24
 let workAssistantMessageWideLineBudgetStep = 24
 let workChatAccessibilityPreviewLimit = 800
 
-enum WorkAssistantMessagePreviewAnchor: Equatable {
+enum WorkAssistantMessagePreviewAnchor: Hashable {
   case head
   case tail
 }
@@ -687,29 +697,83 @@ struct WorkAssistantMessagePreview: Equatable {
   let anchor: WorkAssistantMessagePreviewAnchor
 }
 
+/// Previews for the visible assistant messages, keyed by message id.
+///
+/// Every entry is invalidated by identity, never by re-hashing: the message's
+/// stamped `markdownDigest` (a short string) decides a hit, so a cache HIT costs
+/// nothing proportional to the message. The previous version recomputed
+/// `markdown.utf8.count` and `markdown.hashValue` on every lookup, so the hot
+/// path — presentation refresh, several times a second, over every visible
+/// message — was O(total visible text) even when nothing had changed.
+///
+/// Previews are held per line budget, not just for the initial one. A message
+/// expanded through "Show more", or held at the tail-full budget after its turn
+/// ended, would otherwise re-slice its whole text on every refresh.
 final class WorkAssistantPreviewCache {
-  private struct Entry {
-    let utf8Count: Int
-    let textHash: Int
-    let anchor: WorkAssistantMessagePreviewAnchor
-    let preview: WorkAssistantMessagePreview
+  private final class Entry {
+    var identity: String
+    var anchor: WorkAssistantMessagePreviewAnchor
+    var previewsByLineBudget: [Int: WorkAssistantMessagePreview]
+
+    init(identity: String, anchor: WorkAssistantMessagePreviewAnchor) {
+      self.identity = identity
+      self.anchor = anchor
+      self.previewsByLineBudget = [:]
+    }
   }
 
   private var entries: [String: Entry] = [:]
 
-  func preview(for message: WorkChatMessage, anchor: WorkAssistantMessagePreviewAnchor = .head) -> WorkAssistantMessagePreview {
-    let utf8Count = message.markdown.utf8.count
-    let textHash = message.markdown.hashValue
-    if let entry = entries[message.id],
-       entry.utf8Count == utf8Count,
-       entry.textHash == textHash,
-       entry.anchor == anchor,
-       entry.preview.anchor == anchor {
-      return entry.preview
+  /// Cheap stand-in for the message text. Prefers the digest stamped by the
+  /// snapshot fold; messages built outside it fall back to a length probe plus
+  /// the text itself, which still avoids hashing on the common path.
+  private func identity(for message: WorkChatMessage) -> String {
+    if let digest = message.markdownDigest { return digest }
+    return "raw:\(message.markdown.utf8.count):\(message.markdown)"
+  }
+
+  func preview(
+    for message: WorkChatMessage,
+    anchor: WorkAssistantMessagePreviewAnchor = .head
+  ) -> WorkAssistantMessagePreview {
+    preview(
+      for: message,
+      anchor: anchor,
+      lineBudget: workAssistantMessageInitialLineBudget,
+      characterBudget: workAssistantMessageCharacterBudget(
+        forLineBudget: workAssistantMessageInitialLineBudget
+      ),
+      classification: nil
+    )
+  }
+
+  func preview(
+    for message: WorkChatMessage,
+    anchor: WorkAssistantMessagePreviewAnchor,
+    lineBudget: Int,
+    characterBudget: Int,
+    classification: Bool?
+  ) -> WorkAssistantMessagePreview {
+    let identity = identity(for: message)
+    let entry: Entry
+    if let existing = entries[message.id], existing.identity == identity, existing.anchor == anchor {
+      entry = existing
+      if let cached = entry.previewsByLineBudget[lineBudget] {
+        return cached
+      }
+    } else {
+      entry = Entry(identity: identity, anchor: anchor)
+      entries[message.id] = entry
     }
 
-    let preview = workInitialAssistantMessagePreview(message.markdown, anchor: anchor)
-    entries[message.id] = Entry(utf8Count: utf8Count, textHash: textHash, anchor: anchor, preview: preview)
+    let preview = workAssistantMessagePreview(
+      message.markdown,
+      lineBudget: lineBudget,
+      characterBudget: characterBudget,
+      anchor: anchor,
+      classification: classification
+    )
+    entry.previewsByLineBudget[lineBudget] = preview
     return preview
   }
 
@@ -728,6 +792,13 @@ func workInitialAssistantMessagePreview(
     characterBudget: workAssistantMessageCharacterBudget(forLineBudget: workAssistantMessageInitialLineBudget),
     anchor: anchor
   )
+}
+
+/// The budget one "Show more" tap asks for, given what the message is rendering
+/// under now. Shared by both show-more paths so a tap steps the same distance
+/// wherever it is made.
+func workAssistantMessageShowMoreLineBudget(current: Int?) -> Int {
+  max(current ?? 0, workAssistantMessageInitialLineBudget) + workAssistantMessageLineBudgetStep
 }
 
 func workAssistantMessageCharacterBudget(forLineBudget lineBudget: Int) -> Int {
@@ -753,7 +824,13 @@ func workAssistantMessagePreview(
   anchor: WorkAssistantMessagePreviewAnchor = .head,
   classification: Bool? = nil
 ) -> WorkAssistantMessagePreview {
-  let normalized = markdown.replacingOccurrences(of: "\r\n", with: "\n")
+  // `replacingOccurrences` allocates a second copy of the whole message even
+  // when there is nothing to replace, which is the overwhelmingly common case
+  // (host transcripts are LF). Scan first, copy only when it would change
+  // something.
+  let normalized = markdown.utf8.contains(0x0D)
+    ? markdown.replacingOccurrences(of: "\r\n", with: "\n")
+    : markdown
   guard !normalized.isEmpty else {
     return WorkAssistantMessagePreview(
       text: markdown,

--- a/apps/ios/ADE/Views/Work/WorkChatHeaderAndMessageViews.swift
+++ b/apps/ios/ADE/Views/Work/WorkChatHeaderAndMessageViews.swift
@@ -848,6 +848,37 @@ func workAssistantMessageCharacterBudget(forLineBudget lineBudget: Int, tailCanR
   return tailCanRenderFull ? max(steppedBudget, workAssistantMessageTailFullCharacterBudget) : steppedBudget
 }
 
+/// Whether the next bounded preview rung will still need its own control row.
+///
+/// The decision must use the same effective line/character budgets as
+/// `workAssistantMessagePreview`. Comparing the requested line budget with the
+/// message's line count is not enough: a single very long line can remain
+/// character-truncated after the final line budget, leaving a Show More row
+/// whose source entry has already replaced it.
+func workAssistantMessageWillRemainTruncated(
+  _ preview: WorkAssistantMessagePreview,
+  nextLineBudget: Int
+) -> Bool {
+  let requestedLineBudget = max(nextLineBudget, 1)
+  let effectiveLineBudget = workAssistantMessageEffectiveLineBudget(
+    requestedLineBudget: requestedLineBudget,
+    usesMonospacedPreview: preview.usesMonospacedRendering
+  )
+  let requestedCharacterBudget = workAssistantMessageCharacterBudget(forLineBudget: requestedLineBudget)
+  let characterBudget = max(
+    preview.usesMonospacedRendering
+      ? max(
+        requestedCharacterBudget,
+        workAssistantMessageWideCharacterBudget(forLineBudget: effectiveLineBudget)
+      )
+      : requestedCharacterBudget,
+    256
+  )
+  let smallFullCharacterBudget = max(characterBudget, workAssistantMessageSmallFullCharacterBudget)
+  return preview.totalLineCount > effectiveLineBudget
+    || preview.totalCharacterCount > smallFullCharacterBudget
+}
+
 func workAssistantMessagePreview(
   _ markdown: String,
   lineBudget: Int,

--- a/apps/ios/ADE/Views/Work/WorkChatHeaderAndMessageViews.swift
+++ b/apps/ios/ADE/Views/Work/WorkChatHeaderAndMessageViews.swift
@@ -416,7 +416,8 @@ struct WorkChatMessageBubble: View, Equatable {
             markdown: preview.text,
             streamingCacheKey: isStreaming ? message.id : nil,
             fullMarkdown: message.markdown,
-            previewAnchor: preview.anchor
+            previewAnchor: preview.anchor,
+            fullMarkdownIdentity: "\(message.markdownDigest ?? workStableDigest(message.markdown)):\(message.markdownRevision)"
           )
             .accessibilityLabel(workAssistantMessageAccessibilityLabel(preview))
         }
@@ -742,8 +743,8 @@ final class WorkAssistantPreviewCache {
 
   private var entries: [String: Entry] = [:]
   /// Cheap stand-in for the message text. Prefers the digest stamped by the
-  /// snapshot fold; messages built outside it fall back to a length probe plus
-  /// the text itself, which still avoids hashing on the common path.
+  /// snapshot fold; messages built outside it use their streaming revision or
+  /// a raw fallback only until the next snapshot fold.
   private func identity(for message: WorkChatMessage) -> String {
     if let digest = message.markdownDigest {
       return "\(digest):revision=\(message.markdownRevision)"
@@ -754,7 +755,7 @@ final class WorkAssistantPreviewCache {
       // this cache a unique content identity for the current message.
       return "streaming:\(message.id):revision=\(message.markdownRevision)"
     }
-    return "raw:\(message.markdown.utf8.count):\(message.markdown)"
+    return "raw:\(message.markdown.utf8.count):\(message.markdown.hashValue)"
   }
 
   func preview(
@@ -800,7 +801,8 @@ final class WorkAssistantPreviewCache {
       knownLineCount: message.markdownLineCount,
       knownCharacterCount: message.markdownCharacterCount,
       knownMarkdownHasCarriageReturn: message.markdownHasCarriageReturn,
-      knownMarkdownContainsFence: message.markdownContainsFence
+      knownMarkdownContainsFence: message.markdownContainsFence,
+      knownMarkdownOpeningFence: message.markdownOpenFenceMarker
     )
     entry.previewsByLineBudget[lineBudget] = preview
     return preview
@@ -855,7 +857,8 @@ func workAssistantMessagePreview(
   knownLineCount: Int? = nil,
   knownCharacterCount: Int? = nil,
   knownMarkdownHasCarriageReturn: Bool? = nil,
-  knownMarkdownContainsFence: Bool? = nil
+  knownMarkdownContainsFence: Bool? = nil,
+  knownMarkdownOpeningFence: String? = nil
 ) -> WorkAssistantMessagePreview {
   // `replacingOccurrences` allocates a second copy of the whole message even
   // when there is nothing to replace, which is the overwhelmingly common case
@@ -912,12 +915,13 @@ func workAssistantMessagePreview(
       totalLineCount: totalLineCount,
       totalCharacterCount: totalCharacterCount,
       usesMonospacedRendering: usesMonospacedPreview,
-      containsFence: knownMarkdownContainsFence
+      containsFence: knownMarkdownContainsFence,
+      openingFence: knownMarkdownOpeningFence
     )
   }
 
   var rendered = String()
-  rendered.reserveCapacity(min(normalized.count, clampedCharacterBudget))
+  rendered.reserveCapacity(min(totalCharacterCount, clampedCharacterBudget))
   var usedCharacters = 0
   var visibleLineCount = 0
   var lineStart = normalized.startIndex
@@ -952,7 +956,7 @@ func workAssistantMessagePreview(
 
   return WorkAssistantMessagePreview(
     text: rendered,
-    isTruncated: visibleLineCount < totalLineCount || rendered.count < normalized.count,
+    isTruncated: visibleLineCount < totalLineCount || rendered.count < totalCharacterCount,
     usesMonospacedRendering: usesMonospacedPreview,
     visibleLineCount: visibleLineCount,
     totalLineCount: totalLineCount,
@@ -969,13 +973,14 @@ private func workAssistantMessageTailPreview(
   totalLineCount: Int,
   totalCharacterCount: Int,
   usesMonospacedRendering: Bool,
-  containsFence: Bool? = nil
+  containsFence: Bool? = nil,
+  openingFence: String? = nil
 ) -> WorkAssistantMessagePreview {
   // A long one-line answer is the common streaming shape for prose. Searching
   // backwards for a newline would scan the entire growing line on every delta;
   // the known line count makes the tail a direct bounded suffix instead.
   if totalLineCount == 1, containsFence != true {
-    let visibleCharacterCount = min(characterBudget, normalized.count)
+    let visibleCharacterCount = min(characterBudget, totalCharacterCount)
     let suffixStart = normalized.index(normalized.endIndex, offsetBy: -visibleCharacterCount)
     let sourceRendered = String(normalized[suffixStart...])
     return WorkAssistantMessagePreview(
@@ -995,12 +1000,21 @@ private func workAssistantMessageTailPreview(
   var usedCharacters = 0
   var visibleLineCount = 0
   var lineEnd = normalized.endIndex
+  var searchCursor = normalized.endIndex
 
   while lineEnd >= normalized.startIndex, visibleLineCount < lineBudget {
-    let lineStart = normalized[..<lineEnd]
-      .lastIndex(of: "\n")
-      .map { normalized.index(after: $0) }
-      ?? normalized.startIndex
+    var lineStart = normalized.startIndex
+    var newlineIndex: String.Index?
+    var cursor = searchCursor
+    while cursor > normalized.startIndex {
+      let previous = normalized.index(before: cursor)
+      if normalized[previous] == "\n" {
+        newlineIndex = previous
+        lineStart = normalized.index(after: previous)
+        break
+      }
+      cursor = previous
+    }
     let newlineCost = segments.isEmpty ? 0 : 1
     let remaining = characterBudget - usedCharacters - newlineCost
     guard remaining > 0 else { break }
@@ -1018,24 +1032,25 @@ private func workAssistantMessageTailPreview(
     usedCharacters += lineLength + newlineCost
     visibleLineCount += 1
 
-    guard lineStart > normalized.startIndex else { break }
-    lineEnd = normalized.index(before: lineStart)
+    guard let newlineIndex else { break }
+    lineEnd = newlineIndex
+    searchCursor = newlineIndex
   }
 
   let sourceRendered = segments.reversed().joined(separator: "\n")
-  let openingFence: String?
+  let resolvedOpeningFence: String?
   if containsFence == false {
-    openingFence = nil
+    resolvedOpeningFence = nil
   } else {
-    openingFence = workOpeningMarkdownFenceBeforeTail(
+    resolvedOpeningFence = openingFence ?? workOpeningMarkdownFenceBeforeTail(
       in: normalized,
       tailStart: segments.last?.startIndex ?? normalized.endIndex
     )
   }
-  let rendered = openingFence.map { "\($0)\n\(sourceRendered)" } ?? sourceRendered
+  let rendered = resolvedOpeningFence.map { "\($0)\n\(sourceRendered)" } ?? sourceRendered
   return WorkAssistantMessagePreview(
     text: rendered,
-    isTruncated: visibleLineCount < totalLineCount || sourceRendered.count < normalized.count,
+    isTruncated: visibleLineCount < totalLineCount || sourceRendered.count < totalCharacterCount,
     usesMonospacedRendering: usesMonospacedRendering,
     visibleLineCount: visibleLineCount,
     totalLineCount: totalLineCount,

--- a/apps/ios/ADE/Views/Work/WorkChatHeaderAndMessageViews.swift
+++ b/apps/ios/ADE/Views/Work/WorkChatHeaderAndMessageViews.swift
@@ -741,12 +741,19 @@ final class WorkAssistantPreviewCache {
   }
 
   private var entries: [String: Entry] = [:]
-
   /// Cheap stand-in for the message text. Prefers the digest stamped by the
   /// snapshot fold; messages built outside it fall back to a length probe plus
   /// the text itself, which still avoids hashing on the common path.
   private func identity(for message: WorkChatMessage) -> String {
-    if let digest = message.markdownDigest { return digest }
+    if let digest = message.markdownDigest {
+      return "\(digest):revision=\(message.markdownRevision)"
+    }
+    if message.markdownRevision > 0 {
+      // Incremental messages have not gone through the snapshot fold yet. Do
+      // not interpolate the growing markdown here: the revision already gives
+      // this cache a unique content identity for the current message.
+      return "streaming:\(message.id):revision=\(message.markdownRevision)"
+    }
     return "raw:\(message.markdown.utf8.count):\(message.markdown)"
   }
 
@@ -789,7 +796,11 @@ final class WorkAssistantPreviewCache {
       lineBudget: lineBudget,
       characterBudget: characterBudget,
       anchor: anchor,
-      classification: classification
+      classification: classification ?? message.markdownMonospacedClassifier?.usesMonospacedRendering,
+      knownLineCount: message.markdownLineCount,
+      knownCharacterCount: message.markdownCharacterCount,
+      knownMarkdownHasCarriageReturn: message.markdownHasCarriageReturn,
+      knownMarkdownContainsFence: message.markdownContainsFence
     )
     entry.previewsByLineBudget[lineBudget] = preview
     return preview
@@ -840,13 +851,17 @@ func workAssistantMessagePreview(
   lineBudget: Int,
   characterBudget: Int,
   anchor: WorkAssistantMessagePreviewAnchor = .head,
-  classification: Bool? = nil
+  classification: Bool? = nil,
+  knownLineCount: Int? = nil,
+  knownCharacterCount: Int? = nil,
+  knownMarkdownHasCarriageReturn: Bool? = nil,
+  knownMarkdownContainsFence: Bool? = nil
 ) -> WorkAssistantMessagePreview {
   // `replacingOccurrences` allocates a second copy of the whole message even
   // when there is nothing to replace, which is the overwhelmingly common case
   // (host transcripts are LF). Scan first, copy only when it would change
   // something.
-  let normalized = markdown.utf8.contains(0x0D)
+  let normalized = (knownMarkdownHasCarriageReturn ?? markdown.utf8.contains(0x0D))
     ? markdown.replacingOccurrences(of: "\r\n", with: "\n")
     : markdown
   guard !normalized.isEmpty else {
@@ -873,10 +888,10 @@ func workAssistantMessagePreview(
       : characterBudget,
     256
   )
-  let totalLineCount = workAssistantMessageLineCount(normalized)
-  let totalCharacterCount = normalized.count
+  let totalLineCount = knownLineCount ?? workAssistantMessageLineCount(normalized)
+  let totalCharacterCount = knownCharacterCount ?? normalized.count
   let smallFullCharacterBudget = max(clampedCharacterBudget, workAssistantMessageSmallFullCharacterBudget)
-  if totalLineCount <= clampedLineBudget && normalized.count <= smallFullCharacterBudget {
+  if totalLineCount <= clampedLineBudget && totalCharacterCount <= smallFullCharacterBudget {
     return WorkAssistantMessagePreview(
       text: markdown,
       isTruncated: false,
@@ -896,7 +911,8 @@ func workAssistantMessagePreview(
       characterBudget: clampedCharacterBudget,
       totalLineCount: totalLineCount,
       totalCharacterCount: totalCharacterCount,
-      usesMonospacedRendering: usesMonospacedPreview
+      usesMonospacedRendering: usesMonospacedPreview,
+      containsFence: knownMarkdownContainsFence
     )
   }
 
@@ -952,8 +968,28 @@ private func workAssistantMessageTailPreview(
   characterBudget: Int,
   totalLineCount: Int,
   totalCharacterCount: Int,
-  usesMonospacedRendering: Bool
+  usesMonospacedRendering: Bool,
+  containsFence: Bool? = nil
 ) -> WorkAssistantMessagePreview {
+  // A long one-line answer is the common streaming shape for prose. Searching
+  // backwards for a newline would scan the entire growing line on every delta;
+  // the known line count makes the tail a direct bounded suffix instead.
+  if totalLineCount == 1, containsFence != true {
+    let visibleCharacterCount = min(characterBudget, normalized.count)
+    let suffixStart = normalized.index(normalized.endIndex, offsetBy: -visibleCharacterCount)
+    let sourceRendered = String(normalized[suffixStart...])
+    return WorkAssistantMessagePreview(
+      text: sourceRendered,
+      isTruncated: visibleCharacterCount < totalCharacterCount,
+      usesMonospacedRendering: usesMonospacedRendering,
+      visibleLineCount: 1,
+      totalLineCount: totalLineCount,
+      visibleCharacterCount: visibleCharacterCount,
+      totalCharacterCount: totalCharacterCount,
+      anchor: .tail
+    )
+  }
+
   var segments: [Substring] = []
   segments.reserveCapacity(min(lineBudget, 16))
   var usedCharacters = 0
@@ -987,10 +1023,15 @@ private func workAssistantMessageTailPreview(
   }
 
   let sourceRendered = segments.reversed().joined(separator: "\n")
-  let openingFence = workOpeningMarkdownFenceBeforeTail(
-    in: normalized,
-    tailStart: segments.last?.startIndex ?? normalized.endIndex
-  )
+  let openingFence: String?
+  if containsFence == false {
+    openingFence = nil
+  } else {
+    openingFence = workOpeningMarkdownFenceBeforeTail(
+      in: normalized,
+      tailStart: segments.last?.startIndex ?? normalized.endIndex
+    )
+  }
   let rendered = openingFence.map { "\($0)\n\(sourceRendered)" } ?? sourceRendered
   return WorkAssistantMessagePreview(
     text: rendered,

--- a/apps/ios/ADE/Views/Work/WorkChatHeaderAndMessageViews.swift
+++ b/apps/ios/ADE/Views/Work/WorkChatHeaderAndMessageViews.swift
@@ -299,6 +299,7 @@ struct WorkChatMessageBubble: View, Equatable {
     lhs.message == rhs.message
       && lhs.isStreaming == rhs.isStreaming
       && lhs.maxUserBubbleWidth == rhs.maxUserBubbleWidth
+      && lhs.hasExpandedInPlace == rhs.hasExpandedInPlace
       && (lhs.onShowMore == nil) == (rhs.onShowMore == nil)
   }
 
@@ -322,6 +323,9 @@ struct WorkChatMessageBubble: View, Equatable {
   /// shared budget map is now the only owner; the preview on `message` already
   /// reflects it.
   var onShowMore: (() -> Void)? = nil
+  /// The reader has already taken one "Show more" step here, so the next rung
+  /// of the ladder is the full-screen viewer instead of another step.
+  var hasExpandedInPlace = false
 
   /// Provider string for the current chat session (e.g. "claude", "codex", "cursor").
   /// Injected via `.environment(\.workChatProvider, ...)` by the session view.
@@ -410,7 +414,9 @@ struct WorkChatMessageBubble: View, Equatable {
         } else {
           WorkMarkdownRenderer(
             markdown: preview.text,
-            streamingCacheKey: isStreaming ? message.id : nil
+            streamingCacheKey: isStreaming ? message.id : nil,
+            fullMarkdown: message.markdown,
+            previewAnchor: preview.anchor
           )
             .accessibilityLabel(workAssistantMessageAccessibilityLabel(preview))
         }
@@ -440,20 +446,32 @@ struct WorkChatMessageBubble: View, Equatable {
             Label("Copy full", systemImage: "doc.on.doc")
               .labelStyle(.titleAndIcon)
               .font(.caption2.weight(.semibold))
+              .frame(minHeight: 44)
+              .contentShape(Rectangle())
           }
           .buttonStyle(.plain)
           .foregroundStyle(ADEColor.textSecondary)
 
-          // Anything still truncated can still be expanded: one more step per
-          // tap, with no ceiling to strand the reader partway through.
-          if let onShowMore {
+          // Hybrid ladder: the first tap expands downward in place; anything
+          // still truncated after that goes to the full-screen viewer rather
+          // than paginating the reader through a thousand more lines.
+          if let onShowMore, !hasExpandedInPlace {
             Button(action: onShowMore) {
               Label("Show more", systemImage: "chevron.down")
                 .labelStyle(.titleAndIcon)
                 .font(.caption2.weight(.semibold))
+                .frame(minHeight: 44)
+                .contentShape(Rectangle())
             }
             .buttonStyle(.plain)
             .foregroundStyle(ADEColor.accent)
+          } else {
+            WorkOpenFullOutputButton(
+              title: "Response",
+              text: message.markdown,
+              label: "Open full output",
+              prominent: true
+            )
           }
         }
       }

--- a/apps/ios/ADE/Views/Work/WorkChatHeaderAndMessageViews.swift
+++ b/apps/ios/ADE/Views/Work/WorkChatHeaderAndMessageViews.swift
@@ -305,8 +305,8 @@ struct WorkChatMessageBubble: View, Equatable {
 
   let message: WorkChatMessage
   /// True only for the assistant message still receiving streaming deltas.
-  /// Switches its markdown block parsing to the tail-only streaming parser so
-  /// each delta re-parses just the growing tail instead of the whole message.
+  /// Switches its markdown block parsing to the bounded streaming parser so
+  /// each delta re-parses only the visible preview instead of the full message.
   var isStreaming: Bool = false
   /// Computed once by the parent transcript view. Avoids installing one
   /// GeometryReader per user row while preserving the desktop-style max width.

--- a/apps/ios/ADE/Views/Work/WorkChatPrViews.swift
+++ b/apps/ios/ADE/Views/Work/WorkChatPrViews.swift
@@ -79,11 +79,11 @@ struct WorkChatPrActivePopup: View {
       accessibilityLabel: accessibilityText,
       onOpen: onOpen
     ) {
+      // No text label: the chip is icon + CI glyph + state tint. Everything the
+      // label used to say (PR number, state, CI state) is in
+      // `accessibilityText`, which VoiceOver reads instead.
       Image(systemName: "arrow.triangle.pull")
-        .font(.system(size: 12, weight: .semibold))
-      Text(badge.label)
-        .font(.caption.weight(.semibold))
-        .lineLimit(1)
+        .font(.system(size: 13, weight: .semibold))
       if let stack = badge.stack {
         GitHubStackPositionBadge(stack: stack, compact: true)
       }

--- a/apps/ios/ADE/Views/Work/WorkChatRichCardViews.swift
+++ b/apps/ios/ADE/Views/Work/WorkChatRichCardViews.swift
@@ -171,21 +171,15 @@ struct WorkToolCardView: View, Equatable {
             WorkStructuredOutputBlock(title: "Arguments", text: argsText)
           }
           if let resultText = toolCard.resultText, !resultText.isEmpty {
-            let truncated = workToolResultTruncate(resultText, expanded: resultExpanded)
-            WorkStructuredOutputBlock(title: "Result", text: truncated.text)
-            if truncated.didTruncate {
-              Button {
-                resultExpanded.toggle()
-              } label: {
-                Text(resultExpanded
-                  ? "Collapse"
-                  : "Show all (\(workToolResultByteLabel(resultText)))")
-                  .font(.caption2.weight(.semibold))
-                  .foregroundStyle(ADEColor.accent)
-              }
-              .buttonStyle(.plain)
-              .accessibilityLabel(resultExpanded ? "Collapse tool result" : "Show full tool result")
-            }
+            let result = workToolResultBlockText(resultText, expanded: resultExpanded)
+            // The block displays a slice; Copy and the viewer get the whole
+            // result.
+            WorkStructuredOutputBlock(title: "Result", text: result.displayed, copyText: result.copy)
+            toolResultAffordances(
+              resultText: result.copy,
+              displayedText: result.displayed,
+              didTruncate: result.didTruncate
+            )
           }
         }
       }
@@ -207,6 +201,68 @@ struct WorkToolCardView: View, Equatable {
         "status": toolCard.status.rawValue
       ]
     )
+  }
+
+  /// Hybrid ladder under the result box: one expansion in place, then the
+  /// full-screen viewer. A second in-place step would only add text the box
+  /// clips away.
+  @ViewBuilder
+  private func toolResultAffordances(
+    resultText: String,
+    displayedText: String,
+    didTruncate: Bool
+  ) -> some View {
+    let affordance = workTruncatedOutputAffordance(
+      isTruncated: didTruncate,
+      hasExpandedInPlace: resultExpanded,
+      isClipped: workOutputBoxOverflows(
+        displayedText,
+        lineCapacity: workStructuredOutputBoxLineCapacity,
+        columnCapacity: workStructuredOutputBoxColumnCapacity
+      )
+    )
+    HStack(spacing: 12) {
+      switch affordance {
+      case .none:
+        EmptyView()
+      case .showMore:
+        Button {
+          resultExpanded = true
+        } label: {
+          Text("Show all (\(workToolResultByteLabel(resultText)))")
+            .font(.caption2.weight(.semibold))
+            .foregroundStyle(ADEColor.accent)
+            .frame(minHeight: 44)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel("Show full tool result")
+      case .openFullOutput:
+        WorkOpenFullOutputButton(
+          title: toolDisplayName(toolCard.toolName),
+          subtitle: "Result",
+          text: resultText,
+          label: "Open full output",
+          prominent: true
+        )
+      }
+
+      if resultExpanded {
+        Button {
+          resultExpanded = false
+        } label: {
+          Text("Collapse")
+            .font(.caption2.weight(.semibold))
+            .foregroundStyle(ADEColor.textSecondary)
+            .frame(minHeight: 44)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel("Collapse tool result")
+      }
+
+      Spacer(minLength: 0)
+    }
   }
 
   /// Single-line compact row used once the tool completes — matches the
@@ -779,6 +835,20 @@ func workToolResultTruncate(_ text: String, expanded: Bool) -> (text: String, di
   return (String(text[..<end]) + "…", didTruncate: true)
 }
 
+/// What the result box shows versus what Copy and the viewer hand over.
+///
+/// These are deliberately two different strings: the box displays a bounded
+/// slice so a 200KB result cannot stall the transcript, but a clipboard that
+/// silently held a 500-character preview of the output was a data-loss bug
+/// wearing a Copy button.
+func workToolResultBlockText(
+  _ resultText: String,
+  expanded: Bool
+) -> (displayed: String, copy: String, didTruncate: Bool) {
+  let truncated = workToolResultTruncate(resultText, expanded: expanded)
+  return (displayed: truncated.text, copy: resultText, didTruncate: truncated.didTruncate)
+}
+
 /// Short "N chars" label used in the "Show all" affordance. Uses the raw
 /// character count — this is display copy, not a byte-precise measurement.
 func workToolResultByteLabel(_ text: String) -> String {
@@ -791,15 +861,30 @@ func workToolResultByteLabel(_ text: String) -> String {
 struct WorkStructuredOutputBlock: View {
   let title: String
   let text: String
+  /// Authoritative text for Copy and the viewer. Defaults to what is displayed;
+  /// call sites that show a truncated slice pass the whole thing, so the
+  /// clipboard is never a preview of the output.
+  var copyText: String? = nil
+
+  private var fullText: String { copyText ?? text }
+
+  private var isClipped: Bool {
+    fullText.utf8.count > text.utf8.count
+      || workOutputBoxOverflows(
+        text,
+        lineCapacity: workStructuredOutputBoxLineCapacity,
+        columnCapacity: workStructuredOutputBoxColumnCapacity
+      )
+  }
 
   var body: some View {
     VStack(alignment: .leading, spacing: 6) {
-      WorkOutputBlockHeader(title: title, copyText: text)
+      WorkOutputBlockHeader(title: title, copyText: fullText, showsOpen: isClipped)
       // Clipped, not scrollable. A vertical scroll view nested inside the
       // transcript's own vertical scroll view competes for every drag that
       // starts on it, and it only ever clipped: there was no way to reach past
-      // its 180pt from inside the box anyway. The card-level "Show all" control
-      // is still how the full text is reached.
+      // its 180pt from inside the box anyway. What is cut off is reached
+      // through the full-screen viewer — from the header, or by tapping here.
       Text(text)
         .frame(maxWidth: .infinity, alignment: .leading)
         .font(.system(.caption, design: .monospaced))
@@ -809,6 +894,7 @@ struct WorkStructuredOutputBlock: View {
         .clipped()
         .padding(10)
       .background(ADEColor.recessedBackground.opacity(0.9), in: RoundedRectangle(cornerRadius: 12, style: .continuous))
+      .workOpensFullOutput(isClipped, title: title, text: fullText)
     }
   }
 }
@@ -819,7 +905,15 @@ struct WorkANSIOutputBlock: View {
 
   var body: some View {
     VStack(alignment: .leading, spacing: 6) {
-      WorkOutputBlockHeader(title: title, copyText: text)
+      WorkOutputBlockHeader(
+        title: title,
+        copyText: text,
+        showsOpen: workOutputBoxOverflows(
+          text,
+          lineCapacity: workStructuredOutputBoxLineCapacity,
+          columnCapacity: nil
+        )
+      )
       ScrollView([.horizontal, .vertical]) {
         Text(ansiAttributedString(text))
           .frame(maxWidth: .infinity, alignment: .leading)
@@ -835,7 +929,13 @@ struct WorkANSIOutputBlock: View {
 
 struct WorkOutputBlockHeader: View {
   let title: String
+  /// Always the whole output, never the slice the box happens to be showing.
   let copyText: String
+  /// Set when the box clips its content: the header then offers the viewer
+  /// beside Copy.
+  var showsOpen = false
+  var viewerKind: WorkOutputViewerRequest.Kind = .text
+  var viewerSubtitle: String? = nil
   @State var copied = false
 
   var body: some View {
@@ -844,6 +944,14 @@ struct WorkOutputBlockHeader: View {
         .font(.caption2.weight(.semibold))
         .foregroundStyle(ADEColor.textMuted)
       Spacer(minLength: 0)
+      if showsOpen {
+        WorkOpenFullOutputButton(
+          title: title,
+          subtitle: viewerSubtitle,
+          text: copyText,
+          kind: viewerKind
+        )
+      }
       Button {
         UIPasteboard.general.string = copyText
         copied = true
@@ -858,10 +966,41 @@ struct WorkOutputBlockHeader: View {
         }
         .font(.caption2.weight(.semibold))
         .foregroundStyle(copied ? ADEColor.success : ADEColor.textSecondary)
+        .frame(minHeight: 44)
+        .contentShape(Rectangle())
       }
       .buttonStyle(.plain)
       .accessibilityLabel(copied ? "Copied to clipboard" : "Copy \(title.lowercased())")
     }
+  }
+}
+
+/// Copy control for the diff boxes, which carry no header row of their own.
+struct WorkDiffCopyButton: View {
+  let diff: String
+  let label: String
+  @State private var copied = false
+
+  var body: some View {
+    Button {
+      UIPasteboard.general.string = diff
+      copied = true
+      Task { @MainActor in
+        try? await Task.sleep(nanoseconds: 1_400_000_000)
+        copied = false
+      }
+    } label: {
+      HStack(spacing: 4) {
+        Image(systemName: copied ? "checkmark" : "doc.on.doc")
+        Text(copied ? "Copied" : "Copy")
+      }
+      .font(.caption2.weight(.semibold))
+      .foregroundStyle(copied ? ADEColor.success : ADEColor.textSecondary)
+      .frame(minHeight: 44)
+      .contentShape(Rectangle())
+    }
+    .buttonStyle(.plain)
+    .accessibilityLabel(copied ? "Copied to clipboard" : "Copy diff for \(label)")
   }
 }
 
@@ -958,11 +1097,18 @@ struct WorkDiffOutputBlock: View {
   let title: String
   let diff: String
 
+  private var isClipped: Bool {
+    workOutputBoxOverflows(diff, lineCapacity: workDiffOutputBoxLineCapacity, columnCapacity: nil)
+  }
+
   var body: some View {
     VStack(alignment: .leading, spacing: 6) {
-      Text(title)
-        .font(.caption2.weight(.semibold))
-        .foregroundStyle(ADEColor.textMuted)
+      WorkOutputBlockHeader(
+        title: title,
+        copyText: diff,
+        showsOpen: isClipped,
+        viewerKind: .diff
+      )
       // Horizontal only: the vertical axis competed with the transcript's own
       // scroll view for drags that started on the diff, and only clipped.
       ScrollView(.horizontal) {
@@ -984,14 +1130,47 @@ struct WorkDiffOutputBlock: View {
       .clipped()
       .padding(10)
       .background(ADEColor.recessedBackground.opacity(0.9), in: RoundedRectangle(cornerRadius: 12, style: .continuous))
+      .workOpensFullOutput(isClipped, title: title, text: diff, kind: .diff)
     }
   }
 }
 
 struct WorkInlineDiffPreview: View {
+  /// File path this diff belongs to. Titles the viewer.
+  var path: String? = nil
   let diff: String
 
+  private var isClipped: Bool {
+    workOutputBoxOverflows(diff, lineCapacity: workInlineDiffPreviewLineCapacity, columnCapacity: nil)
+  }
+
+  private var viewerTitle: String {
+    guard let path, !path.isEmpty else { return "Diff" }
+    return (path as NSString).lastPathComponent
+  }
+
   var body: some View {
+    VStack(alignment: .leading, spacing: 4) {
+      HStack(spacing: 6) {
+        Spacer(minLength: 0)
+        if isClipped {
+          WorkOpenFullOutputButton(
+            title: viewerTitle,
+            subtitle: path,
+            text: diff,
+            kind: .diff
+          )
+        }
+        WorkDiffCopyButton(diff: diff, label: viewerTitle)
+      }
+      .padding(.leading, 18)
+
+      diffBody
+        .workOpensFullOutput(isClipped, title: viewerTitle, subtitle: path, text: diff, kind: .diff)
+    }
+  }
+
+  private var diffBody: some View {
     ScrollView(.horizontal) {
       LazyVStack(alignment: .leading, spacing: 2) {
         ForEach(Array(diff.components(separatedBy: "\n").enumerated()), id: \.offset) { _, line in
@@ -1101,7 +1280,7 @@ struct WorkFileChangeCardView: View, Equatable {
 
       if isExpanded {
         if hasDiff {
-          WorkInlineDiffPreview(diff: card.diff)
+          WorkInlineDiffPreview(path: card.path, diff: card.diff)
         } else {
           Text("No diff payload available.")
             .font(.caption.monospaced())

--- a/apps/ios/ADE/Views/Work/WorkChatRichCardViews.swift
+++ b/apps/ios/ADE/Views/Work/WorkChatRichCardViews.swift
@@ -602,6 +602,10 @@ struct WorkToolCallsPanelView: View {
 struct WorkTurnActivitySheet: View {
   let group: WorkToolGroupModel
   @State private var expanded = true
+  /// The panel's member expansion moved out to its caller, so the sheet has to
+  /// hold it: without this every call in the sheet rendered permanently shut and
+  /// tapping one did nothing — and the sheet is the whole-turn view of the work.
+  @State private var expandedMemberIds: Set<String> = []
 
   var body: some View {
     NavigationStack {
@@ -609,7 +613,15 @@ struct WorkTurnActivitySheet: View {
         WorkToolCallsPanelView(
           group: group,
           isExpanded: expanded,
-          onToggle: { withAnimation(.easeInOut(duration: 0.18)) { expanded.toggle() } }
+          onToggle: { withAnimation(.easeInOut(duration: 0.18)) { expanded.toggle() } },
+          expandedMemberIds: expandedMemberIds,
+          onToggleMember: { memberId in
+            if expandedMemberIds.contains(memberId) {
+              expandedMemberIds.remove(memberId)
+            } else {
+              expandedMemberIds.insert(memberId)
+            }
+          }
         )
         .padding(.horizontal, 20)
         .padding(.vertical, 16)

--- a/apps/ios/ADE/Views/Work/WorkChatRichCardViews.swift
+++ b/apps/ios/ADE/Views/Work/WorkChatRichCardViews.swift
@@ -795,15 +795,19 @@ struct WorkStructuredOutputBlock: View {
   var body: some View {
     VStack(alignment: .leading, spacing: 6) {
       WorkOutputBlockHeader(title: title, copyText: text)
-      ScrollView {
-        Text(text)
-          .frame(maxWidth: .infinity, alignment: .leading)
-          .font(.system(.caption, design: .monospaced))
-          .foregroundStyle(ADEColor.textPrimary)
-          .textSelection(.enabled)
-      }
-      .frame(maxHeight: 180)
-      .padding(10)
+      // Clipped, not scrollable. A vertical scroll view nested inside the
+      // transcript's own vertical scroll view competes for every drag that
+      // starts on it, and it only ever clipped: there was no way to reach past
+      // its 180pt from inside the box anyway. The card-level "Show all" control
+      // is still how the full text is reached.
+      Text(text)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .font(.system(.caption, design: .monospaced))
+        .foregroundStyle(ADEColor.textPrimary)
+        .textSelection(.enabled)
+        .frame(maxHeight: 180, alignment: .top)
+        .clipped()
+        .padding(10)
       .background(ADEColor.recessedBackground.opacity(0.9), in: RoundedRectangle(cornerRadius: 12, style: .continuous))
     }
   }
@@ -959,7 +963,9 @@ struct WorkDiffOutputBlock: View {
       Text(title)
         .font(.caption2.weight(.semibold))
         .foregroundStyle(ADEColor.textMuted)
-      ScrollView([.horizontal, .vertical]) {
+      // Horizontal only: the vertical axis competed with the transcript's own
+      // scroll view for drags that started on the diff, and only clipped.
+      ScrollView(.horizontal) {
         VStack(alignment: .leading, spacing: 2) {
           ForEach(Array(diff.components(separatedBy: "\n").enumerated()), id: \.offset) { _, line in
             Text(line.isEmpty ? " " : line)
@@ -974,7 +980,8 @@ struct WorkDiffOutputBlock: View {
         }
         .frame(maxWidth: .infinity, alignment: .leading)
       }
-      .frame(maxHeight: 220)
+      .frame(maxHeight: 220, alignment: .top)
+      .clipped()
       .padding(10)
       .background(ADEColor.recessedBackground.opacity(0.9), in: RoundedRectangle(cornerRadius: 12, style: .continuous))
     }
@@ -985,7 +992,7 @@ struct WorkInlineDiffPreview: View {
   let diff: String
 
   var body: some View {
-    ScrollView([.horizontal, .vertical]) {
+    ScrollView(.horizontal) {
       LazyVStack(alignment: .leading, spacing: 2) {
         ForEach(Array(diff.components(separatedBy: "\n").enumerated()), id: \.offset) { _, line in
           Text(line.isEmpty ? " " : line)
@@ -996,7 +1003,8 @@ struct WorkInlineDiffPreview: View {
       }
       .frame(maxWidth: .infinity, alignment: .leading)
     }
-    .frame(maxHeight: 320)
+    .frame(maxHeight: 320, alignment: .top)
+    .clipped()
     .padding(.top, 8)
     .padding(.leading, 18)
     .overlay(alignment: .topLeading) {

--- a/apps/ios/ADE/Views/Work/WorkChatRichCardViews.swift
+++ b/apps/ios/ADE/Views/Work/WorkChatRichCardViews.swift
@@ -73,9 +73,16 @@ private struct WorkWebSearchSource: Identifiable {
   let url: URL
 }
 
-struct WorkToolCardView: View {
+struct WorkToolCardView: View, Equatable {
+  static func == (lhs: WorkToolCardView, rhs: WorkToolCardView) -> Bool {
+    lhs.toolCard == rhs.toolCard && lhs.isExpanded == rhs.isExpanded
+  }
+
   let toolCard: WorkToolCardModel
-  let references: WorkNavigationTargets
+  /// Derived from `toolCard`, so it is deliberately absent from `==`. Computed
+  /// lazily below rather than passed in: extracting them concatenates the tool's
+  /// arguments and result, which is not work a collapsed row should ever do.
+  var references: WorkNavigationTargets { workToolCardNavigationTargets(toolCard) }
   let isExpanded: Bool
   let onToggle: () -> Void
   let onOpenFile: (String) -> Void
@@ -718,9 +725,6 @@ private struct WorkToolGroupMemberRow: View {
     case .tool(let card):
       WorkToolCardView(
         toolCard: card,
-        references: extractWorkNavigationTargets(
-          from: [card.argsText, card.resultText].compactMap { $0 }.joined(separator: "\n")
-        ),
         // Running cards stay auto-expanded so live args/output remain visible
         // during streaming — the whole point of the tool-streaming flow.
         isExpanded: card.status == .running || localExpanded,
@@ -749,11 +753,27 @@ func workToolResultPreview(_ text: String?) -> String? {
   return nil
 }
 
+/// File paths and PR numbers mentioned by a tool call. Extracted from the
+/// concatenation of its arguments and result, so it is only ever asked for by an
+/// expanded card.
+func workToolCardNavigationTargets(_ card: WorkToolCardModel) -> WorkNavigationTargets {
+  extractWorkNavigationTargets(
+    from: [card.argsText, card.resultText].compactMap { $0 }.joined(separator: "\n")
+  )
+}
+
 /// Returns the text to render in the result block, plus whether it was
 /// actually truncated. `expanded == true` always returns the full text.
 func workToolResultTruncate(_ text: String, expanded: Bool) -> (text: String, didTruncate: Bool) {
-  guard !expanded, text.count > workToolResultTruncateLimit else {
-    return (text, didTruncate: !expanded && text.count > workToolResultTruncateLimit)
+  // `text.count` walks the whole string counting graphemes, and this runs on
+  // every body pass of every tool card. UTF-8 length is stored, and is always
+  // >= the character count, so a string that fits in UTF-8 bytes provably fits
+  // in characters — only the rare long result pays for the exact count.
+  guard !expanded, text.utf8.count > workToolResultTruncateLimit else {
+    return (text, didTruncate: false)
+  }
+  guard text.count > workToolResultTruncateLimit else {
+    return (text, didTruncate: false)
   }
   let end = text.index(text.startIndex, offsetBy: workToolResultTruncateLimit)
   return (String(text[..<end]) + "…", didTruncate: true)
@@ -841,7 +861,13 @@ struct WorkOutputBlockHeader: View {
   }
 }
 
-struct WorkCommandCardView: View {
+struct WorkCommandCardView: View, Equatable {
+  /// Row-level gate: the card only redraws when its model changes. Its own
+  /// expansion is `@State`, which invalidates independently of this compare.
+  static func == (lhs: WorkCommandCardView, rhs: WorkCommandCardView) -> Bool {
+    lhs.card == rhs.card
+  }
+
   let card: WorkCommandCardModel
   @State private var isExpanded = false
 
@@ -982,7 +1008,11 @@ struct WorkInlineDiffPreview: View {
   }
 }
 
-struct WorkFileChangeCardView: View {
+struct WorkFileChangeCardView: View, Equatable {
+  static func == (lhs: WorkFileChangeCardView, rhs: WorkFileChangeCardView) -> Bool {
+    lhs.card == rhs.card
+  }
+
   let card: WorkFileChangeCardModel
   @Environment(\.accessibilityReduceMotion) private var reduceMotion
   @State private var isExpanded = false
@@ -1084,7 +1114,11 @@ struct WorkFileChangeCardView: View {
   }
 }
 
-struct WorkEventCardView: View {
+struct WorkEventCardView: View, Equatable {
+  static func == (lhs: WorkEventCardView, rhs: WorkEventCardView) -> Bool {
+    lhs.card == rhs.card
+  }
+
   let card: WorkEventCardModel
   var onOpenFile: ((String) -> Void)? = nil
   var onOpenPr: ((Int) -> Void)? = nil
@@ -3971,7 +4005,11 @@ func workAdeCardNavLabel(_ target: WorkAdeCardNavTarget?) -> String? {
 /// Tone note: failures are AMBER here, never red. The wire contract has no
 /// danger tone and `workAdeCardTone(from:)` folds red-ish values into
 /// `.warning`, so this view has no red path to take.
-struct WorkAdeCardView: View {
+struct WorkAdeCardView: View, Equatable {
+  static func == (lhs: WorkAdeCardView, rhs: WorkAdeCardView) -> Bool {
+    lhs.card == rhs.card
+  }
+
   let card: WorkAdeCardModel
   /// Dispatch for host-specific actions. The reserved `open` action is handled
   /// locally through `navTarget` on every client.

--- a/apps/ios/ADE/Views/Work/WorkChatRichCardViews.swift
+++ b/apps/ios/ADE/Views/Work/WorkChatRichCardViews.swift
@@ -201,6 +201,17 @@ struct WorkToolCardView: View, Equatable {
         "status": toolCard.status.rawValue
       ]
     )
+    .workCollapsedCardPeek(enabled: !isExpanded && peekText != nil, onExpand: onToggle) {
+      WorkStructuredOutputBlock(title: "Result", text: peekText ?? "")
+    }
+  }
+
+  /// What a long press on the collapsed row shows: the result if there is one,
+  /// otherwise the arguments that produced it.
+  private var peekText: String? {
+    if let result = toolCard.resultText, !result.isEmpty { return result }
+    if let args = toolCard.argsText, !args.isEmpty { return args }
+    return nil
   }
 
   /// Hybrid ladder under the result box: one expansion in place, then the
@@ -388,8 +399,10 @@ struct WorkToolCallsPanelView: View {
   let group: WorkToolGroupModel
   let isExpanded: Bool
   let onToggle: () -> Void
-
-  @State private var expandedMemberIds: Set<String> = []
+  /// Member expansion comes from the session's central set, so an opened call
+  /// survives recycling and is swept when its turn ends.
+  var expandedMemberIds: Set<String> = []
+  var onToggleMember: (String) -> Void = { _ in }
 
   var body: some View {
     VStack(alignment: .leading, spacing: 0) {
@@ -408,18 +421,18 @@ struct WorkToolCallsPanelView: View {
     .accessibilityLabel("Tool calls cluster, \(group.count) calls, \(isExpanded ? "expanded" : "collapsed")")
   }
 
+  /// Same grammar as every other collapsed card row: leading glyph, one-line
+  /// summary, right-aligned count, trailing chevron.
   private var header: some View {
     Button(action: onToggle) {
       HStack(alignment: .center, spacing: 6) {
-        Image(systemName: isExpanded ? "chevron.down" : "chevron.right")
-          .font(.system(size: 9, weight: .bold))
-          .foregroundStyle(ADEColor.textMuted.opacity(0.65))
+        Image(systemName: "wrench.and.screwdriver")
+          .font(.system(size: 11, weight: .semibold))
+          .foregroundStyle(ADEColor.textMuted)
+          .frame(width: 16)
         Text("Tool calls")
           .font(.caption.weight(.medium))
           .foregroundStyle(ADEColor.textMuted)
-        Text("(\(group.count))")
-          .font(.caption2.monospacedDigit())
-          .foregroundStyle(ADEColor.textMuted.opacity(0.55))
         if !isExpanded, let latest = group.latest {
           WorkToolStatusGlyph(status: latest.status)
           Text(memberSlug(latest))
@@ -434,12 +447,48 @@ struct WorkToolCallsPanelView: View {
               .truncationMode(.tail)
           }
         }
-        Spacer(minLength: 0)
+        Spacer(minLength: 6)
+        Text("\(group.count)")
+          .font(.caption.weight(.semibold).monospacedDigit())
+          .foregroundStyle(ADEColor.textMuted)
+          .padding(.horizontal, 7)
+          .padding(.vertical, 2)
+          .background(ADEColor.textMuted.opacity(0.10), in: Capsule(style: .continuous))
+        Image(systemName: isExpanded ? "chevron.down" : "chevron.right")
+          .font(.system(size: 10, weight: .semibold))
+          .foregroundStyle(ADEColor.textMuted)
       }
       .padding(.vertical, 2)
       .frame(minHeight: 44)
+      .contentShape(Rectangle())
     }
     .buttonStyle(.plain)
+    .workCollapsedCardPeek(enabled: !isExpanded, onExpand: onToggle) {
+      collapsedPeekBody
+    }
+  }
+
+  /// Long-press peek for the collapsed cluster: the calls it would reveal,
+  /// without moving the transcript.
+  private var collapsedPeekBody: some View {
+    VStack(alignment: .leading, spacing: 6) {
+      ForEach(group.members) { member in
+        HStack(alignment: .firstTextBaseline, spacing: 8) {
+          WorkToolStatusGlyph(status: member.status)
+          Text(memberSlug(member))
+            .font(.caption.monospaced().weight(.semibold))
+            .foregroundStyle(rowVerbColor(member.status))
+          if let target = memberTarget(member), !target.isEmpty {
+            Text(target)
+              .font(.caption.monospaced())
+              .foregroundStyle(ADEColor.textMuted)
+              .lineLimit(1)
+              .truncationMode(.middle)
+          }
+          Spacer(minLength: 4)
+        }
+      }
+    }
   }
 
   @ViewBuilder
@@ -449,11 +498,7 @@ struct WorkToolCallsPanelView: View {
     let target = memberTarget(member)
 
     Button {
-      if expandedMemberIds.contains(memberId) {
-        expandedMemberIds.remove(memberId)
-      } else {
-        expandedMemberIds.insert(memberId)
-      }
+      onToggleMember(memberId)
     } label: {
       VStack(alignment: .leading, spacing: 4) {
         HStack(alignment: .firstTextBaseline, spacing: 8) {
@@ -582,9 +627,11 @@ struct WorkChangedFilesPanelView: View {
   let group: WorkChangedFilesGroupModel
   let isExpanded: Bool
   let onToggle: () -> Void
+  /// Per-file expansion comes from the session's central set (see
+  /// `WorkCardExpansionState`), not from view state that dies on recycle.
+  var expandedFileIds: Set<String> = []
+  var onToggleFile: (String) -> Void = { _ in }
   let onUndo: (() -> Void)?
-
-  @State private var expandedFileIds: Set<String> = []
 
   var body: some View {
     VStack(alignment: .leading, spacing: 0) {
@@ -607,23 +654,35 @@ struct WorkChangedFilesPanelView: View {
     HStack(alignment: .center, spacing: 6) {
       Button(action: onToggle) {
         HStack(alignment: .center, spacing: 6) {
-          Image(systemName: isExpanded ? "chevron.down" : "chevron.right")
-            .font(.system(size: 9, weight: .bold))
-            .foregroundStyle(ADEColor.textMuted.opacity(0.65))
+          Image(systemName: "doc.on.doc")
+            .font(.system(size: 11, weight: .semibold))
+            .foregroundStyle(ADEColor.textMuted)
+            .frame(width: 16)
           Text("Files changed")
             .font(.caption.weight(.medium))
             .foregroundStyle(ADEColor.textMuted)
-          Text("(\(group.count))")
-            .font(.caption2.monospacedDigit())
-            .foregroundStyle(ADEColor.textMuted.opacity(0.55))
           if !isExpanded {
             collapsedPreview
           }
-          Spacer(minLength: 0)
+          Spacer(minLength: 6)
+          Text("\(group.count)")
+            .font(.caption.weight(.semibold).monospacedDigit())
+            .foregroundStyle(ADEColor.textMuted)
+            .padding(.horizontal, 7)
+            .padding(.vertical, 2)
+            .background(ADEColor.textMuted.opacity(0.10), in: Capsule(style: .continuous))
+          Image(systemName: isExpanded ? "chevron.down" : "chevron.right")
+            .font(.system(size: 10, weight: .semibold))
+            .foregroundStyle(ADEColor.textMuted)
         }
         .padding(.vertical, 2)
+        .frame(minHeight: 44)
+        .contentShape(Rectangle())
       }
       .buttonStyle(.plain)
+      .workCollapsedCardPeek(enabled: !isExpanded, onExpand: onToggle) {
+        collapsedPeekBody
+      }
       if isExpanded, let onUndo {
         Button(action: onUndo) {
           HStack(spacing: 4) {
@@ -665,15 +724,31 @@ struct WorkChangedFilesPanelView: View {
     }
   }
 
+  /// Long-press peek for the collapsed cluster: the file list it would reveal,
+  /// without moving the transcript.
+  private var collapsedPeekBody: some View {
+    VStack(alignment: .leading, spacing: 6) {
+      ForEach(group.files) { file in
+        HStack(spacing: 8) {
+          Text(fileExtBadge(file.path))
+            .font(.system(size: 9, weight: .heavy, design: .monospaced))
+            .foregroundStyle(ADEColor.textMuted)
+          Text(file.path)
+            .font(.caption.monospaced())
+            .foregroundStyle(ADEColor.textSecondary)
+            .lineLimit(1)
+            .truncationMode(.middle)
+          Spacer(minLength: 4)
+        }
+      }
+    }
+  }
+
   @ViewBuilder
   private func fileRow(_ file: WorkChangedFileEntry) -> some View {
     let expanded = expandedFileIds.contains(file.id)
     Button {
-      if expandedFileIds.contains(file.id) {
-        expandedFileIds.remove(file.id)
-      } else {
-        expandedFileIds.insert(file.id)
-      }
+      onToggleFile(file.id)
     } label: {
       VStack(alignment: .leading, spacing: 4) {
         HStack(alignment: .firstTextBaseline, spacing: 10) {
@@ -763,35 +838,6 @@ struct WorkChangedFilesPanelView: View {
     case "delete", "remove": return "Deleted"
     case "rename": return "Renamed"
     default: return nil
-    }
-  }
-}
-
-/// One expanded member of a tool group. Keeps its own expansion state so the
-/// group container only toggles cluster-level collapse — individual cards can
-/// still drill into args/output without leaking state up to the parent.
-private struct WorkToolGroupMemberRow: View {
-  let member: WorkToolGroupMember
-  let onOpenFile: (String) -> Void
-  let onOpenPr: (Int) -> Void
-  @State private var localExpanded = false
-
-  var body: some View {
-    switch member {
-    case .tool(let card):
-      WorkToolCardView(
-        toolCard: card,
-        // Running cards stay auto-expanded so live args/output remain visible
-        // during streaming — the whole point of the tool-streaming flow.
-        isExpanded: card.status == .running || localExpanded,
-        onToggle: { localExpanded.toggle() },
-        onOpenFile: onOpenFile,
-        onOpenPr: onOpenPr
-      )
-    case .command(let card):
-      WorkCommandCardView(card: card)
-    case .fileChange(let card):
-      WorkFileChangeCardView(card: card)
     }
   }
 }
@@ -1005,19 +1051,21 @@ struct WorkDiffCopyButton: View {
 }
 
 struct WorkCommandCardView: View, Equatable {
-  /// Row-level gate: the card only redraws when its model changes. Its own
-  /// expansion is `@State`, which invalidates independently of this compare.
+  /// Row-level gate: the card only redraws when its model or its expansion
+  /// changes. Expansion lives in the session's central set, not in `@State`, so
+  /// it has to be part of the compare.
   static func == (lhs: WorkCommandCardView, rhs: WorkCommandCardView) -> Bool {
-    lhs.card == rhs.card
+    lhs.card == rhs.card && lhs.isExpanded == rhs.isExpanded
   }
 
   let card: WorkCommandCardModel
-  @State private var isExpanded = false
+  let isExpanded: Bool
+  let onToggle: () -> Void
 
   var body: some View {
     VStack(alignment: .leading, spacing: 12) {
       Button {
-        isExpanded.toggle()
+        onToggle()
       } label: {
         HStack(alignment: .top, spacing: 10) {
           Image(systemName: statusIcon)
@@ -1082,6 +1130,9 @@ struct WorkCommandCardView: View, Equatable {
     )
     .accessibilityElement(children: .combine)
     .accessibilityLabel("Command, \(card.status.rawValue). Tap to \(isExpanded ? "collapse" : "expand") output.")
+    .workCollapsedCardPeek(enabled: !isExpanded && !card.output.isEmpty, onExpand: onToggle) {
+      WorkANSIOutputBlock(title: card.command, text: card.output)
+    }
   }
 
   var statusTint: Color {
@@ -1197,12 +1248,13 @@ struct WorkInlineDiffPreview: View {
 
 struct WorkFileChangeCardView: View, Equatable {
   static func == (lhs: WorkFileChangeCardView, rhs: WorkFileChangeCardView) -> Bool {
-    lhs.card == rhs.card
+    lhs.card == rhs.card && lhs.isExpanded == rhs.isExpanded
   }
 
   let card: WorkFileChangeCardModel
+  let isExpanded: Bool
+  let onToggle: () -> Void
   @Environment(\.accessibilityReduceMotion) private var reduceMotion
-  @State private var isExpanded = false
 
   private var diffStats: (additions: Int, deletions: Int) {
     aggregateDiffStats(card.diff)
@@ -1234,7 +1286,7 @@ struct WorkFileChangeCardView: View, Equatable {
       Button {
         guard hasDiff else { return }
         withAnimation(ADEMotion.quick(reduceMotion: reduceMotion)) {
-          isExpanded.toggle()
+          onToggle()
         }
       } label: {
         HStack(spacing: 8) {
@@ -1292,6 +1344,9 @@ struct WorkFileChangeCardView: View, Equatable {
     .padding(.vertical, 4)
     .accessibilityElement(children: .combine)
     .accessibilityLabel("File change, \(card.path), \(changeCountDescription). \(hasDiff ? "Tap to \(isExpanded ? "collapse" : "expand") diff." : "No diff payload available.")")
+    .workCollapsedCardPeek(enabled: !isExpanded && hasDiff, onExpand: onToggle) {
+      WorkInlineDiffPreview(path: card.path, diff: card.diff)
+    }
   }
 
   private var fileExtensionBadge: String {
@@ -1725,8 +1780,8 @@ func workCodexRecoveryMoreOptions(_ options: [String]) -> [String] {
 
 struct WorkTurnDiagnosticsDisclosureView: View {
   let card: WorkEventCardModel
-
-  @State private var isExpanded = false
+  let isExpanded: Bool
+  let onToggle: () -> Void
 
   private var summary: String {
     var parts: [String] = []
@@ -1741,7 +1796,18 @@ struct WorkTurnDiagnosticsDisclosureView: View {
   }
 
   var body: some View {
-    DisclosureGroup(isExpanded: $isExpanded) {
+    DisclosureGroup(
+      // `onToggle` flips, so only forward a value that actually disagrees with
+      // what we are already showing — SwiftUI re-sends the current value on
+      // some layout passes, and a blind toggle there would snap the group shut.
+      isExpanded: Binding(
+        get: { isExpanded },
+        set: { wantsExpanded in
+          guard wantsExpanded != isExpanded else { return }
+          onToggle()
+        }
+      )
+    ) {
       VStack(alignment: .leading, spacing: 8) {
         if card.diagnosticModerationChecks > 0 {
           Label(
@@ -2168,11 +2234,15 @@ struct WorkResolvedApprovalChip: View {
 /// feel like a plan, not a dumped array.
 struct WorkProposedPlanCard: View {
   let card: WorkEventCardModel
+  /// The checklist while the plan is being written; `Plan · <step>  4/7` after
+  /// its turn ends.
+  var isExpanded: Bool = true
+  var onToggle: () -> Void = {}
 
   private var steps: [WorkPlanStep] { card.planSteps }
 
   private var completed: Int {
-    steps.filter { normalize($0.status) == .completed }.count
+    workPlanCardCompletedStepCount(card)
   }
 
   private var inProgress: Int {
@@ -2185,6 +2255,50 @@ struct WorkProposedPlanCard: View {
   }
 
   var body: some View {
+    Group {
+      if isExpanded {
+        expandedBody
+          .padding(14)
+      } else {
+        collapsedRow
+      }
+    }
+    .background(
+      RoundedRectangle(cornerRadius: 16, style: .continuous)
+        .fill(ADEColor.cardBackground.opacity(0.45))
+    )
+    .overlay(
+      RoundedRectangle(cornerRadius: 16, style: .continuous)
+        .stroke(ADEColor.brandClaude.opacity(0.22), lineWidth: 1)
+    )
+    .accessibilityElement(children: .combine)
+    .accessibilityLabel(isExpanded ? accessibilitySummary : workPlanCardCollapsedAccessibilityLabel(card))
+    .workCollapsedCardPeek(enabled: !isExpanded, onExpand: onToggle) {
+      expandedBody
+    }
+  }
+
+  private var collapsedRow: some View {
+    WorkCollapsedCardRow(
+      systemImage: "list.bullet.clipboard",
+      glyphTint: ADEColor.brandClaude,
+      summary: workPlanCardCollapsedSummary(card),
+      chips: workPlanCardCollapsedProgressLabel(card).map { label in
+        [
+          WorkCollapsedStatusChip(
+            id: "progress",
+            label: label,
+            tone: completed == steps.count ? .success : .accent,
+            accessibilityText: "\(completed) of \(steps.count) steps done"
+          )
+        ]
+      } ?? [],
+      accessibilityText: workPlanCardCollapsedAccessibilityLabel(card),
+      onToggle: onToggle
+    )
+  }
+
+  private var expandedBody: some View {
     VStack(alignment: .leading, spacing: 12) {
       header
 
@@ -2205,17 +2319,6 @@ struct WorkProposedPlanCard: View {
         }
       }
     }
-    .padding(14)
-    .background(
-      RoundedRectangle(cornerRadius: 16, style: .continuous)
-        .fill(ADEColor.cardBackground.opacity(0.45))
-    )
-    .overlay(
-      RoundedRectangle(cornerRadius: 16, style: .continuous)
-        .stroke(ADEColor.brandClaude.opacity(0.22), lineWidth: 1)
-    )
-    .accessibilityElement(children: .combine)
-    .accessibilityLabel(accessibilitySummary)
   }
 
   private var header: some View {
@@ -2242,7 +2345,13 @@ struct WorkProposedPlanCard: View {
           .font(.caption.weight(.semibold).monospacedDigit())
           .foregroundStyle(progressFraction == 1 ? ADEColor.success : ADEColor.brandClaude)
       }
+
+      Image(systemName: "chevron.down")
+        .font(.system(size: 10, weight: .semibold))
+        .foregroundStyle(ADEColor.textMuted)
     }
+    .contentShape(Rectangle())
+    .onTapGesture { onToggle() }
   }
 
   private var progressBar: some View {
@@ -2713,36 +2822,13 @@ struct WorkComposerBadgeCapsule<Content: View>: View {
   }
 }
 
-struct WorkSubagentActivePopup: View {
-  let count: Int
-  let onOpen: () -> Void
-
-  private var label: String {
-    count == 1 ? "Subagent" : "Subagents"
-  }
-
-  var body: some View {
-    WorkComposerBadgeCapsule(
-      tint: ADEColor.accent,
-      spacing: 8,
-      accessibilityLabel: "\(count) \(label.lowercased())",
-      onOpen: onOpen
-    ) {
-      Image(systemName: "person.2.fill")
-        .font(.system(size: 12, weight: .semibold))
-      Text(label)
-        .font(.caption.weight(.semibold))
-      if count > 1 {
-        Text("\(count)")
-          .font(.caption2.weight(.bold))
-          .padding(.horizontal, 6)
-          .padding(.vertical, 2)
-          .background(ADEColor.accent.opacity(0.14), in: Capsule(style: .continuous))
-      }
-    }
-  }
-}
-
+/// The single chat-activity chip above the composer: icon plus a count, no
+/// label. It replaced a separate "Subagents" capsule that opened the very same
+/// sheet — two chips, one destination, and between them enough text to squeeze
+/// the PR chip into an ellipsis.
+///
+/// `count` is `workChatInfoItemCount` — subagents, background work and
+/// schedules together, which is exactly what the sheet lists.
 struct WorkChatInfoActivePopup: View {
   let count: Int
   let onOpen: () -> Void
@@ -2750,16 +2836,14 @@ struct WorkChatInfoActivePopup: View {
   var body: some View {
     WorkComposerBadgeCapsule(
       tint: ADEColor.accent,
-      accessibilityLabel: "Chat Info, \(count) scheduled item\(count == 1 ? "" : "s")",
+      spacing: 6,
+      accessibilityLabel: "Chat info, \(count) item\(count == 1 ? "" : "s")",
       onOpen: onOpen
     ) {
       Image(systemName: "info.circle.fill")
-        .font(.system(size: 12, weight: .semibold))
-      Text("Chat Info")
-        .font(.caption.weight(.semibold))
-        .lineLimit(1)
+        .font(.system(size: 13, weight: .semibold))
       Text("\(count)")
-        .font(.caption2.weight(.bold))
+        .font(.caption2.weight(.bold).monospacedDigit())
         .padding(.horizontal, 6)
         .padding(.vertical, 2)
         .background(ADEColor.accent.opacity(0.14), in: Capsule(style: .continuous))
@@ -3833,11 +3917,11 @@ struct WorkSubagentTimelineRowView: View {
 /// "jump to start"). Never a red error block.
 struct WorkSubagentStoppedGroupCardView: View {
   let model: WorkSubagentStoppedGroupModel
+  let isExpanded: Bool
+  let onToggle: () -> Void
   /// Same opener the result rows use; nil in previews/offline renders leaves the
   /// list inert (and hides the per-row open affordance).
   let onOpen: (@MainActor (WorkSubagentSnapshot) async -> Void)?
-
-  @State private var expanded = false
 
   private var headline: String {
     "\(model.count) \(model.count == 1 ? "agent" : "agents") stopped when you interrupted"
@@ -3848,7 +3932,7 @@ struct WorkSubagentStoppedGroupCardView: View {
       Button {
         // No height animation — mirror the desktop card, which just toggles the
         // list, and stay calm under Reduce Motion.
-        expanded.toggle()
+        onToggle()
       } label: {
         HStack(spacing: 10) {
           Image(systemName: "stop.fill")
@@ -3860,7 +3944,7 @@ struct WorkSubagentStoppedGroupCardView: View {
             .lineLimit(1)
             .truncationMode(.tail)
           Spacer(minLength: 6)
-          Image(systemName: expanded ? "chevron.down" : "chevron.right")
+          Image(systemName: isExpanded ? "chevron.down" : "chevron.right")
             .font(.system(size: 11, weight: .semibold))
             .foregroundStyle(ADEColor.textMuted)
         }
@@ -3868,9 +3952,9 @@ struct WorkSubagentStoppedGroupCardView: View {
       }
       .buttonStyle(.plain)
       .accessibilityLabel(headline)
-      .accessibilityHint(expanded ? "Collapse list" : "Expand list")
+      .accessibilityHint(isExpanded ? "Collapse list" : "Expand list")
 
-      if expanded {
+      if isExpanded {
         VStack(alignment: .leading, spacing: 0) {
           ForEach(model.rows) { row in
             stoppedItem(row)
@@ -4194,10 +4278,14 @@ func workAdeCardNavLabel(_ target: WorkAdeCardNavTarget?) -> String? {
 /// `.warning`, so this view has no red path to take.
 struct WorkAdeCardView: View, Equatable {
   static func == (lhs: WorkAdeCardView, rhs: WorkAdeCardView) -> Bool {
-    lhs.card == rhs.card
+    lhs.card == rhs.card && lhs.isExpanded == rhs.isExpanded
   }
 
   let card: WorkAdeCardModel
+  /// Full card while its turn is live; a single "CI · PR #490  18✓ 3✕" row once
+  /// the turn has ended. Owned by the session so a reopened chat starts folded.
+  var isExpanded: Bool = true
+  var onToggle: () -> Void = {}
   /// Dispatch for host-specific actions. The reserved `open` action is handled
   /// locally through `navTarget` on every client.
   var onAction: ((WorkAdeCardAction) -> Void)? = nil
@@ -4231,11 +4319,15 @@ struct WorkAdeCardView: View, Equatable {
 
   var body: some View {
     VStack(alignment: .leading, spacing: 0) {
-      progressBar
-      if card.isKnownVariant {
-        richBody
+      if isExpanded {
+        progressBar
+        if card.isKnownVariant {
+          richBody
+        } else {
+          fallbackBody
+        }
       } else {
-        fallbackBody
+        collapsedRow
       }
     }
     .background(ADEColor.cardBackground.opacity(0.45), in: RoundedRectangle(cornerRadius: 14, style: .continuous))
@@ -4245,7 +4337,32 @@ struct WorkAdeCardView: View, Equatable {
     )
     .clipShape(RoundedRectangle(cornerRadius: 14, style: .continuous))
     .accessibilityElement(children: .contain)
-    .accessibilityLabel(card.fallbackText)
+    .accessibilityLabel(isExpanded ? card.fallbackText : workAdeCardCollapsedAccessibilityLabel(card))
+    .workCollapsedCardPeek(enabled: !isExpanded, onExpand: onToggle) {
+      expandedPeekBody
+    }
+  }
+
+  /// The one-line form: glyph, `Title · PR #490`, pass/fail chips, chevron.
+  private var collapsedRow: some View {
+    WorkCollapsedCardRow(
+      systemImage: workAdeCardCollapsedGlyph(card),
+      glyphTint: accentTint,
+      summary: workAdeCardCollapsedSummary(card),
+      chips: workAdeCardCollapsedChips(card),
+      accessibilityText: workAdeCardCollapsedAccessibilityLabel(card),
+      onToggle: onToggle
+    )
+  }
+
+  private var expandedPeekBody: some View {
+    VStack(alignment: .leading, spacing: 0) {
+      if card.isKnownVariant {
+        richBody
+      } else {
+        fallbackBody
+      }
+    }
   }
 
   // MARK: Progress
@@ -4323,8 +4440,13 @@ struct WorkAdeCardView: View, Equatable {
         .buttonStyle(.plain)
         .accessibilityLabel("Open \(label)")
       }
+      Image(systemName: "chevron.up")
+        .font(.system(size: 10, weight: .semibold))
+        .foregroundStyle(ADEColor.textMuted)
     }
     .padding(.horizontal, 12)
+    .contentShape(Rectangle())
+    .onTapGesture { onToggle() }
   }
 
   private var degradedStatus: some View {

--- a/apps/ios/ADE/Views/Work/WorkChatSessionView+Actions.swift
+++ b/apps/ios/ADE/Views/Work/WorkChatSessionView+Actions.swift
@@ -125,6 +125,7 @@ private func workSnapshotByApplyingAssistantTextTail(
   )
   nextSnapshot.latestMessageAssistantId = workIncrementalLatestAssistantId(timeline)
   nextSnapshot.latestTurnEndTurnId = workLatestTurnEndTurnId(in: timeline)
+  nextSnapshot.liveTurnEntryIds = workEntryIdsAfterLatestTurnEnd(in: timeline)
   nextSnapshot.transcriptIndicatesActiveTurn = true
   nextSnapshot.transcriptLatestTurnEnded = false
   // Keep interruptibility consistent with the full-rebuild path (which derives
@@ -936,13 +937,37 @@ extension WorkChatSessionView {
     return true
   }
 
+  /// True while this timeline row belongs to the turn that is streaming right
+  /// now. Every other row — including everything in a freshly opened chat — is
+  /// history, and history renders collapsed.
+  func isLiveTurnEntry(_ entryId: String) -> Bool {
+    isStreamingTurn && timelineSnapshot.liveTurnEntryIds.contains(entryId)
+  }
+
+  /// `keepsOpenWhileLive` is the card's own behavior during its turn: plans and
+  /// `ade_card`s render in full while they are being written, everything else
+  /// opens only on a tap.
+  func cardIsExpanded(_ id: String, entryId: String, keepsOpenWhileLive: Bool = false) -> Bool {
+    cardExpansion.isExpanded(
+      id: id,
+      defaultsOpen: keepsOpenWhileLive && isLiveTurnEntry(entryId)
+    )
+  }
+
   @MainActor
-  func toggleToolCard(_ id: String) {
-    if expandedToolCardIds.contains(id) {
-      expandedToolCardIds.remove(id)
-    } else {
-      expandedToolCardIds.insert(id)
-    }
+  func toggleCard(_ id: String, entryId: String, keepsOpenWhileLive: Bool = false) {
+    cardExpansion.toggle(
+      id: id,
+      defaultsOpen: keepsOpenWhileLive && isLiveTurnEntry(entryId)
+    )
+  }
+
+  /// Nested rows (a file inside the changed-files panel, a call inside a tool
+  /// cluster) share the central set so they survive recycling and get swept at
+  /// turn end with their parent. They never auto-open.
+  @MainActor
+  func toggleNestedCard(_ id: String) {
+    cardExpansion.toggle(id: id, defaultsOpen: false)
   }
 
   @MainActor

--- a/apps/ios/ADE/Views/Work/WorkChatSessionView+Actions.swift
+++ b/apps/ios/ADE/Views/Work/WorkChatSessionView+Actions.swift
@@ -4,6 +4,7 @@ import AVKit
 
 struct WorkTimelineIncrementalCache {
   fileprivate var transcriptCount = 0
+  fileprivate var transcriptRevision = 0
   fileprivate var transcriptHeadKey: String?
   fileprivate var transcriptTailKey: String?
   fileprivate var fallbackSignature = 0
@@ -14,6 +15,7 @@ struct WorkTimelineIncrementalCache {
 
   mutating func reset() {
     transcriptCount = 0
+    transcriptRevision = 0
     transcriptHeadKey = nil
     transcriptTailKey = nil
     fallbackSignature = 0
@@ -27,9 +29,11 @@ struct WorkTimelineIncrementalCache {
     transcript: [WorkChatEnvelope],
     fallbackEntries: [AgentChatTranscriptEntry],
     artifacts: [ComputerUseArtifactSummary],
-    localEchoMessages: [WorkLocalEchoMessage]
+    localEchoMessages: [WorkLocalEchoMessage],
+    transcriptRevision: Int
   ) {
     transcriptCount = transcript.count
+    self.transcriptRevision = transcriptRevision
     transcriptHeadKey = transcript.first.map(workIncrementalEnvelopeKey)
     transcriptTailKey = transcript.last.map(workIncrementalEnvelopeKey)
     fallbackSignature = workIncrementalFallbackSignature(fallbackEntries, transcriptIsEmpty: transcript.isEmpty)
@@ -75,21 +79,51 @@ private func workSnapshotByApplyingAssistantTextTail(
   to snapshot: WorkChatTimelineSnapshot,
   cache: WorkTimelineIncrementalCache,
   transcript: [WorkChatEnvelope],
+  incrementalTranscriptDelta: [WorkChatEnvelope],
   fallbackEntries: [AgentChatTranscriptEntry],
   artifacts: [ComputerUseArtifactSummary],
-  localEchoMessages: [WorkLocalEchoMessage]
+  localEchoMessages: [WorkLocalEchoMessage],
+  transcriptRevision: Int,
+  allowsIncrementalTranscriptUpdate: Bool
 ) -> WorkChatTimelineSnapshot? {
+  let hasExplicitIncrementalDelta = allowsIncrementalTranscriptUpdate && !incrementalTranscriptDelta.isEmpty
   guard !snapshot.timeline.isEmpty,
         cache.transcriptCount > 0,
         !transcript.isEmpty,
         cache.transcriptHeadKey == transcript.first.map(workIncrementalEnvelopeKey),
         cache.fallbackSignature == workIncrementalFallbackSignature(fallbackEntries, transcriptIsEmpty: transcript.isEmpty),
         cache.artifactSignature == workIncrementalArtifactSignature(artifacts),
-        cache.localEchoSignature == workIncrementalLocalEchoSignature(localEchoMessages)
+        cache.localEchoSignature == workIncrementalLocalEchoSignature(localEchoMessages),
+        hasExplicitIncrementalDelta || cache.transcriptRevision == transcriptRevision
   else { return nil }
 
+  // The delta is one-shot. Once this exact transcript revision has been folded
+  // into the snapshot, a later state-only refresh must not append the same
+  // fragment again. The parent clears the binding after a successful fold; this
+  // guard also protects the small window before that binding update is painted.
+  if hasExplicitIncrementalDelta {
+    guard cache.transcriptRevision != transcriptRevision else { return nil }
+  }
+
   let candidateEnvelopes: ArraySlice<WorkChatEnvelope>
-  if transcript.count == cache.transcriptCount {
+  if hasExplicitIncrementalDelta {
+    guard transcript.count >= cache.transcriptCount,
+          incrementalTranscriptDelta.allSatisfy(workIncrementalEnvelopeCanApplyWithoutFullRebuild)
+    else { return nil }
+    if transcript.count == cache.transcriptCount {
+      guard cache.transcriptTailKey == transcript.last.map(workIncrementalEnvelopeKey) else { return nil }
+    } else {
+      let previousTailIndex = cache.transcriptCount - 1
+      guard transcript.indices.contains(previousTailIndex),
+            workIncrementalEnvelopeKey(transcript[previousTailIndex]) == cache.transcriptTailKey,
+            workIncrementalEnvelopeOrderIsAppendOnly(
+              previous: transcript[previousTailIndex],
+              suffix: incrementalTranscriptDelta[...]
+            )
+      else { return nil }
+    }
+    candidateEnvelopes = incrementalTranscriptDelta[...]
+  } else if transcript.count == cache.transcriptCount {
     guard cache.transcriptTailKey == transcript.last.map(workIncrementalEnvelopeKey),
           let last = transcript.last,
           workIncrementalEnvelopeCanApplyWithoutFullRebuild(last)
@@ -110,43 +144,60 @@ private func workSnapshotByApplyingAssistantTextTail(
   }
 
   var timeline = snapshot.timeline
-  var refreshEventCards = false
+  var eventCards = snapshot.eventCards
+  var newTimelineEntryIDs = Set<String>()
+  // Keep the active assistant bubble's index across the accepted suffix. The
+  // timeline is only sorted after the suffix has been folded, so appending
+  // metadata or updating that bubble cannot invalidate this cursor. Without
+  // it, every token delta would reverse-scan the entire transcript to find
+  // the same message again.
+  var assistantTargetIndex: Int?
   for envelope in candidateEnvelopes {
-    guard workIncrementalApplyEnvelope(envelope, to: &timeline) else {
+    guard workIncrementalApplyEnvelope(
+      envelope,
+      to: &timeline,
+      eventCards: &eventCards,
+      assistantTargetIndex: &assistantTargetIndex,
+      newTimelineEntryIDs: &newTimelineEntryIDs
+    ) else {
       return nil
-    }
-    if case .reasoning = envelope.event {
-      refreshEventCards = true
     }
   }
   timeline = workIncrementalSortTimeline(timeline)
 
   var nextSnapshot = snapshot
   nextSnapshot.timeline = timeline
-  if refreshEventCards {
-    // `eventCards` is also the source for live-reasoning presentation state;
-    // keep it in lockstep with the timeline when the append-only path accepts
-    // a reasoning envelope. Other incremental deltas avoid this O(n) fold.
-    nextSnapshot.eventCards = workIncrementalEventCards(from: timeline)
-  }
+  nextSnapshot.eventCards = eventCards
   nextSnapshot.latestTranscriptTimestamp = workIncrementalLatestTimestamp(
     existing: snapshot.latestTranscriptTimestamp,
     envelopes: candidateEnvelopes
   )
-  nextSnapshot.latestMessageAssistantId = workIncrementalLatestAssistantId(timeline)
-  nextSnapshot.latestTurnEndTurnId = workLatestTurnEndTurnId(in: timeline)
-  nextSnapshot.liveTurnEntryIds = workEntryIdsAfterLatestTurnEnd(in: timeline)
+  let timelineTail = workIncrementalUpdatedTailSummary(
+    previous: snapshot,
+    timeline: timeline,
+    previousTimelineCount: snapshot.timeline.count,
+    candidateEnvelopes: candidateEnvelopes,
+    newTimelineEntryIDs: newTimelineEntryIDs
+  )
+  nextSnapshot.latestMessageAssistantId = timelineTail.latestAssistantMessageId
+  nextSnapshot.latestMessageAssistantItemId = timelineTail.latestAssistantMessageItemId
+  nextSnapshot.latestTurnEndTurnId = snapshot.latestTurnEndTurnId
+  nextSnapshot.liveTurnEntryIds = timelineTail.liveTurnEntryIds
   nextSnapshot.transcriptIndicatesActiveTurn = true
   nextSnapshot.transcriptLatestTurnEnded = false
-  // Keep interruptibility consistent with the full-rebuild path (which derives
-  // it from the transcript). Otherwise the Stop control can stay hidden while a
-  // newly-streaming assistant response begins over a previously-idle snapshot.
+  // Terminal events are intentionally outside this append-only path. Once a
+  // live assistant/user/activity envelope arrives, the turn is interruptible;
+  // carrying the previous true value also keeps a running turn alive while a
+  // token-only metadata delta is folded. The full rebuild remains responsible
+  // for clearing this flag at done/terminal boundaries.
   nextSnapshot.transcriptHasInterruptibleActivity =
-    WorkActivityIndicator.derivePresentation(from: transcript) != nil
+    snapshot.transcriptHasInterruptibleActivity
+      || workIncrementalEnvelopeSliceHasInterruptibleActivity(candidateEnvelopes)
   nextSnapshot.signature = workIncrementalSnapshotSignature(
     base: snapshot.signature,
     transcript: transcript,
-    timeline: timeline
+    transcriptRevision: transcriptRevision,
+    latestAssistantMessage: nil
   )
   return nextSnapshot
 }
@@ -174,7 +225,8 @@ private func workSnapshotByApplyingLocalEchoTail(
   transcript: [WorkChatEnvelope],
   fallbackEntries: [AgentChatTranscriptEntry],
   artifacts: [ComputerUseArtifactSummary],
-  localEchoMessages: [WorkLocalEchoMessage]
+  localEchoMessages: [WorkLocalEchoMessage],
+  transcriptRevision: Int
 ) -> WorkChatTimelineSnapshot? {
   guard !snapshot.timeline.isEmpty,
         cache.transcriptCount == transcript.count,
@@ -182,6 +234,7 @@ private func workSnapshotByApplyingLocalEchoTail(
         cache.transcriptTailKey == transcript.last.map(workIncrementalEnvelopeKey),
         cache.fallbackSignature == workIncrementalFallbackSignature(fallbackEntries, transcriptIsEmpty: transcript.isEmpty),
         cache.artifactSignature == workIncrementalArtifactSignature(artifacts),
+        cache.transcriptRevision == transcriptRevision,
         localEchoMessages.count > cache.localEchoCount
   else { return nil }
 
@@ -229,24 +282,45 @@ private func workSnapshotByApplyingLocalEchoTail(
     existing: snapshot.latestTranscriptTimestamp,
     localEchoMessages: localEchoMessages[cache.localEchoCount..<localEchoMessages.count]
   )
+  let timelineTail = workIncrementalUpdatedTailSummary(
+    previous: snapshot,
+    timeline: timeline,
+    previousTimelineCount: snapshot.timeline.count
+  )
+  nextSnapshot.latestMessageAssistantId = timelineTail.latestAssistantMessageId
+  nextSnapshot.latestMessageAssistantItemId = timelineTail.latestAssistantMessageItemId
+  nextSnapshot.latestTurnEndTurnId = snapshot.latestTurnEndTurnId
+  nextSnapshot.liveTurnEntryIds = timelineTail.liveTurnEntryIds
   nextSnapshot.signature = workIncrementalSnapshotSignature(
     base: snapshot.signature,
     transcript: transcript,
-    timeline: timeline
+    transcriptRevision: transcriptRevision,
+    latestAssistantMessage: nil
   )
   return nextSnapshot
 }
 
 private func workIncrementalApplyEnvelope(
   _ envelope: WorkChatEnvelope,
-  to timeline: inout [WorkTimelineEntry]
+  to timeline: inout [WorkTimelineEntry],
+  eventCards: inout [WorkEventCardModel],
+  assistantTargetIndex: inout Int?,
+  newTimelineEntryIDs: inout Set<String>
 ) -> Bool {
   if workIncrementalEnvelopeIsLiveMetadata(envelope) {
-    return workIncrementalApplyLiveMetadata(envelope, to: &timeline)
+    return workIncrementalApplyLiveMetadataInternal(
+      envelope,
+      to: &timeline,
+      eventCards: &eventCards,
+      newTimelineEntryIDs: &newTimelineEntryIDs
+    )
   }
   if case .userMessage(let text, let attachments, let turnId, let steerId, let deliveryState, let processed) = envelope.event {
     guard deliveryState != "queued" || steerId == nil else { return false }
     workIncrementalRemoveDuplicateEchoes(matching: text, from: &timeline)
+    // A canonical user message is a hard assistant-tail boundary. Any cached
+    // index may also have shifted when a matching local echo was removed.
+    assistantTargetIndex = nil
     let message = WorkChatMessage(
       id: envelope.id,
       role: "user",
@@ -259,12 +333,14 @@ private func workIncrementalApplyEnvelope(
       processed: processed,
       attachments: attachments
     )
-    timeline.append(WorkTimelineEntry(
+    let entry = WorkTimelineEntry(
       id: "message-\(message.id)",
       timestamp: envelope.timestamp,
       rank: workIncrementalNextMessageRank(in: timeline),
       payload: .message(message)
-    ))
+    )
+    timeline.append(entry)
+    newTimelineEntryIDs.insert(entry.id)
     return true
   }
 
@@ -276,8 +352,10 @@ private func workIncrementalApplyEnvelope(
     in: timeline,
     turnId: turnId,
     itemId: itemId,
-    envelopeId: envelope.id
+    envelopeId: envelope.id,
+    cachedIndex: assistantTargetIndex
   ) {
+    assistantTargetIndex = targetIndex
     guard case .message(var message) = timeline[targetIndex].payload else { return false }
     workApplyStreamingAssistantText(text, to: &message)
     timeline[targetIndex] = WorkTimelineEntry(
@@ -297,13 +375,32 @@ private func workIncrementalApplyEnvelope(
     turnId: turnId,
     itemId: itemId
   )
-  timeline.append(WorkTimelineEntry(
+  let entry = WorkTimelineEntry(
     id: "message-\(message.id)",
     timestamp: envelope.timestamp,
     rank: workIncrementalNextMessageRank(in: timeline),
     payload: .message(message)
-  ))
+  )
+  timeline.append(entry)
+  newTimelineEntryIDs.insert(entry.id)
+  assistantTargetIndex = timeline.count - 1
   return true
+}
+
+private func workIncrementalApplyEnvelope(
+  _ envelope: WorkChatEnvelope,
+  to timeline: inout [WorkTimelineEntry]
+) -> Bool {
+  var eventCards: [WorkEventCardModel] = []
+  var newTimelineEntryIDs = Set<String>()
+  var assistantTargetIndex: Int?
+  return workIncrementalApplyEnvelope(
+    envelope,
+    to: &timeline,
+    eventCards: &eventCards,
+    assistantTargetIndex: &assistantTargetIndex,
+    newTimelineEntryIDs: &newTimelineEntryIDs
+  )
 }
 
 /// Applies the metadata envelopes that the append-only path is allowed to
@@ -314,12 +411,73 @@ func workIncrementalApplyLiveMetadata(
   _ envelope: WorkChatEnvelope,
   to timeline: inout [WorkTimelineEntry]
 ) -> Bool {
+  var eventCards: [WorkEventCardModel] = []
+  var newTimelineEntryIDs = Set<String>()
+  return workIncrementalApplyLiveMetadataInternal(
+    envelope,
+    to: &timeline,
+    eventCards: &eventCards,
+    newTimelineEntryIDs: &newTimelineEntryIDs
+  )
+}
+
+func workIncrementalApplyLiveMetadata(
+  _ envelope: WorkChatEnvelope,
+  to timeline: inout [WorkTimelineEntry],
+  eventCards: inout [WorkEventCardModel]
+) -> Bool {
+  var newTimelineEntryIDs = Set<String>()
+  return workIncrementalApplyLiveMetadataInternal(
+    envelope,
+    to: &timeline,
+    eventCards: &eventCards,
+    newTimelineEntryIDs: &newTimelineEntryIDs
+  )
+}
+
+private func workIncrementalApplyLiveMetadataInternal(
+  _ envelope: WorkChatEnvelope,
+  to timeline: inout [WorkTimelineEntry],
+  eventCards: inout [WorkEventCardModel],
+  newTimelineEntryIDs: inout Set<String>
+) -> Bool {
   guard let incomingCard = workIncrementalEventCard(for: envelope), incomingCard.kind == "reasoning" else {
     return true
   }
 
-  let entryId = "event-\(incomingCard.id)"
-  if let existingIndex = timeline.lastIndex(where: { $0.id == entryId }) {
+  let incomingEntryId = "event-\(incomingCard.id)"
+  // Only the active tail phase can conflict with an incoming reasoning row.
+  // Historical reasoning cards are already separated from the current turn by
+  // a later timeline entry; scanning the entire transcript here would put the
+  // full rebuild back on every reasoning delta in a long chat.
+  if let lastEntry = timeline.last {
+    if lastEntry.id == incomingEntryId {
+      // This is an update to the existing live card and can merge in place.
+    } else if lastEntry.id.hasPrefix("activity-phase-reasoning:") {
+      return false
+    } else if case .eventCard(let lastCard) = lastEntry.payload,
+              lastCard.kind == "reasoning" {
+      return false
+    }
+  }
+
+  let entryId = incomingEntryId
+  let existingEventCardIndex: Int? = {
+    if eventCards.last?.id == incomingCard.id { return eventCards.count - 1 }
+    return eventCards.lastIndex { $0.id == incomingCard.id }
+  }()
+  let existingTimelineCardIndex: Int? = {
+    if timeline.last?.id == entryId { return timeline.count - 1 }
+    return timeline.lastIndex(where: { $0.id == entryId })
+  }()
+  // A historical reasoning card can live only in the collapsed phase row. If
+  // the same item is replayed later, appending a raw event card would render a
+  // duplicate beside that phase. Decline once and let the canonical rebuild
+  // reconcile the historical representation.
+  if existingEventCardIndex != nil, existingTimelineCardIndex == nil {
+    return false
+  }
+  if let existingIndex = existingTimelineCardIndex {
     guard case .eventCard(let existingCard) = timeline[existingIndex].payload,
           let mergedCard = workIncrementalMergedEventCard(existingCard, with: incomingCard)
     else { return false }
@@ -329,16 +487,37 @@ func workIncrementalApplyLiveMetadata(
       rank: timeline[existingIndex].rank,
       payload: .eventCard(mergedCard)
     )
-  } else {
-    let eventRank = 1_500 + timeline.reduce(into: 0) { count, entry in
-      if case .eventCard = entry.payload { count += 1 }
+    if let existingEventCardIndex,
+       let mergedEventCard = workIncrementalMergedEventCard(
+         eventCards[existingEventCardIndex],
+         with: incomingCard
+       ) {
+      eventCards[existingEventCardIndex] = mergedEventCard
+    } else if existingEventCardIndex == nil {
+      eventCards.append(mergedCard)
     }
-    timeline.append(WorkTimelineEntry(
+  } else {
+    let cardToRender: WorkEventCardModel
+    if let existingEventCardIndex,
+       let mergedEventCard = workIncrementalMergedEventCard(
+         eventCards[existingEventCardIndex],
+         with: incomingCard
+       ) {
+      cardToRender = mergedEventCard
+      eventCards[existingEventCardIndex] = mergedEventCard
+    } else {
+      cardToRender = incomingCard
+      eventCards.append(incomingCard)
+    }
+    let eventRank = 1_500 + eventCards.count - 1
+    let entry = WorkTimelineEntry(
       id: entryId,
-      timestamp: incomingCard.timestamp,
+      timestamp: cardToRender.timestamp,
       rank: eventRank,
-      payload: .eventCard(incomingCard)
-    ))
+      payload: .eventCard(cardToRender)
+    )
+    timeline.append(entry)
+    newTimelineEntryIDs.insert(entry.id)
   }
   return true
 }
@@ -347,9 +526,31 @@ private func workIncrementalAssistantTargetIndex(
   in timeline: [WorkTimelineEntry],
   turnId: String?,
   itemId: String?,
-  envelopeId: String
+  envelopeId: String,
+  cachedIndex: Int?
 ) -> Int? {
   let entryId = "message-\(envelopeId)"
+
+  if let cachedIndex,
+     timeline.indices.contains(cachedIndex),
+     case .message(let cachedMessage) = timeline[cachedIndex].payload,
+     cachedMessage.role == "assistant" {
+    if timeline[cachedIndex].id == entryId {
+      return cachedIndex
+    }
+    let normalizedItemId = itemId?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+    let cachedItemId = cachedMessage.itemId?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+    if !normalizedItemId.isEmpty,
+       cachedItemId == normalizedItemId,
+       workIncrementalStableItemTurnIdsMatch(cachedMessage.turnId, turnId) {
+      return cachedIndex
+    }
+    if normalizedItemId.isEmpty,
+       workIncrementalTurnIdsMatch(cachedMessage.turnId, turnId) {
+      return cachedIndex
+    }
+  }
+
   if let exactIndex = timeline.indices.last(where: { timeline[$0].id == entryId }) {
     return exactIndex
   }
@@ -446,8 +647,25 @@ private func workIncrementalEnvelopeOrderIsAppendOnly(
   return true
 }
 
+func workIncrementalTimelineNeedsSort(_ timeline: [WorkTimelineEntry]) -> Bool {
+  guard timeline.count > 1,
+        let previous = timeline.dropLast().last,
+        let last = timeline.last
+  else {
+    return false
+  }
+  return previous.timestamp > last.timestamp
+    || (previous.timestamp == last.timestamp && previous.rank > last.rank)
+}
+
 private func workIncrementalSortTimeline(_ timeline: [WorkTimelineEntry]) -> [WorkTimelineEntry] {
-  timeline.sorted { lhs, rhs in
+  guard workIncrementalTimelineNeedsSort(timeline) else {
+    // The accepted incremental envelopes are append-ordered. Existing tail
+    // updates do not move a row, so the common streaming path is already
+    // sorted and avoids allocating a second full timeline.
+    return timeline
+  }
+  return timeline.sorted { lhs, rhs in
     if lhs.timestamp == rhs.timestamp {
       return lhs.rank < rhs.rank
     }
@@ -511,14 +729,157 @@ private func workIncrementalLatestTimestamp(
   return latest
 }
 
-private func workIncrementalLatestAssistantId(_ timeline: [WorkTimelineEntry]) -> String? {
-  for entry in timeline.reversed() {
-    guard case .message(let message) = entry.payload else { continue }
-    if message.role == "assistant" {
-      return message.id
+struct WorkIncrementalUpdatedTailSummary {
+  let latestAssistantMessageId: String?
+  let latestAssistantMessageItemId: String?
+  let liveTurnEntryIds: Set<String>
+}
+
+func workIncrementalUpdatedTailSummary(
+  previous: WorkChatTimelineSnapshot,
+  timeline: [WorkTimelineEntry],
+  previousTimelineCount: Int,
+  candidateEnvelopes: ArraySlice<WorkChatEnvelope>? = nil,
+  newTimelineEntryIDs: Set<String> = []
+) -> WorkIncrementalUpdatedTailSummary {
+  var liveTurnEntryIds = previous.liveTurnEntryIds
+  guard timeline.count >= previousTimelineCount else {
+    // A duplicate-echo removal is not a streaming-tail update; keep the safe
+    // canonical path for that uncommon shape.
+    return WorkIncrementalUpdatedTailSummary(
+      latestAssistantMessageId: previous.latestMessageAssistantId,
+      latestAssistantMessageItemId: previous.latestMessageAssistantItemId,
+      liveTurnEntryIds: liveTurnEntryIds
+    )
+  }
+
+  var latestAssistantMessageId = previous.latestMessageAssistantId
+  var latestAssistantMessageItemId = previous.latestMessageAssistantItemId
+  if let candidateEnvelopes {
+    // Sorting can move a newly-created row before an existing future-dated
+    // echo or card. Track actual insertions from the fold and resolve the
+    // assistant tail against the sorted timeline instead of treating the
+    // array suffix as the delta.
+    for entryID in newTimelineEntryIDs {
+      liveTurnEntryIds.insert(entryID)
+    }
+    // A canonical user envelope can replace a local echo in place, so the
+    // timeline count may stay unchanged. Derive the message tail from the
+    // accepted delta and the actual sorted timeline in either case.
+    let assistantTail = workIncrementalLatestAssistantTail(
+      previous: latestAssistantMessageId,
+      previousItemId: latestAssistantMessageItemId,
+      timeline: timeline,
+      candidateEnvelopes: candidateEnvelopes
+    )
+    latestAssistantMessageId = assistantTail.messageId
+    latestAssistantMessageItemId = assistantTail.itemId
+  } else {
+    let appendedEntries = timeline[previousTimelineCount...]
+    for entry in appendedEntries {
+      liveTurnEntryIds.insert(entry.id)
+    }
+    for entry in appendedEntries.reversed() {
+      guard case .message(let message) = entry.payload else { continue }
+      latestAssistantMessageId = message.role == "assistant" ? message.id : nil
+      latestAssistantMessageItemId = message.role == "assistant" ? message.itemId : nil
+      break
     }
   }
-  return nil
+  return WorkIncrementalUpdatedTailSummary(
+    latestAssistantMessageId: latestAssistantMessageId,
+    latestAssistantMessageItemId: latestAssistantMessageItemId,
+    liveTurnEntryIds: liveTurnEntryIds
+  )
+}
+
+/// Updates the streaming-message hint from only the accepted transcript delta.
+/// Most assistant deltas keep the existing hint and therefore avoid a timeline
+/// scan. A user message, or the first assistant message after one, is a tail
+/// boundary; only that uncommon transition needs the canonical reverse lookup.
+func workIncrementalLatestAssistantMessageId(
+  previous: String?,
+  previousItemId: String? = nil,
+  timeline: [WorkTimelineEntry],
+  candidateEnvelopes: ArraySlice<WorkChatEnvelope>
+) -> String? {
+  workIncrementalLatestAssistantTail(
+    previous: previous,
+    previousItemId: previousItemId,
+    timeline: timeline,
+    candidateEnvelopes: candidateEnvelopes
+  ).messageId
+}
+
+private struct WorkIncrementalAssistantTail {
+  let messageId: String?
+  let itemId: String?
+}
+
+private func workIncrementalLatestAssistantTail(
+  previous: String?,
+  previousItemId: String?,
+  timeline: [WorkTimelineEntry],
+  candidateEnvelopes: ArraySlice<WorkChatEnvelope>
+) -> WorkIncrementalAssistantTail {
+  var latest = previous
+  var latestItemId = previousItemId
+  var needsTailLookup = false
+
+  for envelope in candidateEnvelopes {
+    switch envelope.event {
+    case .userMessage:
+      latest = nil
+      latestItemId = nil
+    case .assistantText(_, _, let itemId):
+      let normalizedItemId = itemId?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+      if !normalizedItemId.isEmpty {
+        if normalizedItemId != latestItemId {
+          latestItemId = normalizedItemId
+          needsTailLookup = true
+        }
+      } else if latest == nil {
+        needsTailLookup = true
+      }
+    default:
+      continue
+    }
+  }
+
+  guard needsTailLookup else {
+    return WorkIncrementalAssistantTail(messageId: latest, itemId: latestItemId)
+  }
+  for entry in timeline.reversed() {
+    guard case .message(let message) = entry.payload else { continue }
+    return WorkIncrementalAssistantTail(
+      messageId: message.role == "assistant" ? message.id : nil,
+      itemId: message.role == "assistant" ? message.itemId : nil
+    )
+  }
+  return WorkIncrementalAssistantTail(messageId: nil, itemId: nil)
+}
+
+private func workIncrementalEnvelopeSliceHasInterruptibleActivity(
+  _ envelopes: ArraySlice<WorkChatEnvelope>
+) -> Bool {
+  for envelope in envelopes.reversed() {
+    switch envelope.event {
+    case .userMessage, .assistantText, .reasoning, .activity:
+      return true
+    case .status(let status, _, _):
+      switch status.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() {
+      case "started", "active", "running", "inprogress", "in_progress", "in-progress":
+        return true
+      default:
+        continue
+      }
+    case .tokens, .toolUseSummary:
+      continue
+    default:
+      continue
+    }
+  }
+  return false
 }
 
 private func workIncrementalEnvelopeKey(_ envelope: WorkChatEnvelope) -> String {
@@ -528,11 +889,13 @@ private func workIncrementalEnvelopeKey(_ envelope: WorkChatEnvelope) -> String 
 private func workIncrementalSnapshotSignature(
   base: Int,
   transcript: [WorkChatEnvelope],
-  timeline: [WorkTimelineEntry]
+  transcriptRevision: Int,
+  latestAssistantMessage: WorkChatMessage?
 ) -> Int {
   var hasher = Hasher()
   hasher.combine("assistant-tail")
   hasher.combine(base)
+  hasher.combine(transcriptRevision)
   hasher.combine(transcript.count)
   if let tail = transcript.last {
     hasher.combine(workIncrementalEnvelopeKey(tail))
@@ -541,13 +904,7 @@ private func workIncrementalSnapshotSignature(
     if case .assistantText(_, let turnId, let itemId) = tail.event {
       hasher.combine(turnId)
       hasher.combine(itemId)
-      if let latestAssistantId = workIncrementalLatestAssistantId(timeline),
-         let message = timeline.reversed().compactMap({ entry -> WorkChatMessage? in
-           guard entry.id == "message-\(latestAssistantId)",
-                 case .message(let message) = entry.payload
-           else { return nil }
-           return message
-         }).first {
+      if let message = latestAssistantMessage {
         // The live message owns an exact monotonic revision. It distinguishes
         // same-length middle replacements without hashing the growing answer
         // on the main actor for every token batch.
@@ -558,8 +915,8 @@ private func workIncrementalSnapshotSignature(
       }
     }
   }
-  if let latestAssistantId = workIncrementalLatestAssistantId(timeline) {
-    hasher.combine(latestAssistantId)
+  if let latestAssistantMessage {
+    hasher.combine(latestAssistantMessage.id)
   }
   return hasher.finalize()
 }
@@ -729,7 +1086,8 @@ extension WorkChatSessionView {
       transcript: transcript,
       fallbackEntries: fallbackEntries,
       artifacts: artifacts,
-      localEchoMessages: localEchoMessages
+      localEchoMessages: localEchoMessages,
+      transcriptRevision: transcriptRenderSignature
     ) else { return false }
 
     // A coalesced rebuild may already be inside the fold with inputs captured
@@ -742,9 +1100,13 @@ extension WorkChatSessionView {
       transcript: transcript,
       fallbackEntries: fallbackEntries,
       artifacts: artifacts,
-      localEchoMessages: localEchoMessages
+      localEchoMessages: localEchoMessages,
+      transcriptRevision: transcriptRenderSignature
     )
-    refreshTimelinePresentation(sourceTimeline: nextSnapshot.timeline)
+    refreshTimelinePresentation(
+      sourceTimeline: nextSnapshot.timeline,
+      rebuildToolActivityIndex: false
+    )
     if isNearBottom, !timelineDragActive {
       timelineLayoutPinToken &+= 1
     }
@@ -778,14 +1140,21 @@ extension WorkChatSessionView {
         let fallbackSnapshot = fallbackEntries
         let artifactSnapshot = artifacts
         let echoSnapshot = localEchoMessages
+        let transcriptRevisionSnapshot = transcriptRenderSignature
+        let allowsIncrementalTranscriptUpdate = self.allowsIncrementalTranscriptUpdate
+        let transcriptIncrementalDeltaSnapshot = transcriptIncrementalDelta
         let buildScope = timelineBuildScopeKey
 
         if applyIncrementalTimelineSnapshotIfPossible(
           transcript: transcriptSnapshot,
           fallbackEntries: fallbackSnapshot,
           artifacts: artifactSnapshot,
-          localEchoMessages: echoSnapshot
+          localEchoMessages: echoSnapshot,
+          transcriptRevision: transcriptRevisionSnapshot,
+          allowsIncrementalTranscriptUpdate: allowsIncrementalTranscriptUpdate,
+          incrementalTranscriptDelta: transcriptIncrementalDeltaSnapshot
         ) {
+          transcriptIncrementalDelta = []
           if timelineRebuildPending {
             continue
           }
@@ -812,8 +1181,10 @@ extension WorkChatSessionView {
           transcript: transcriptSnapshot,
           fallbackEntries: fallbackSnapshot,
           artifacts: artifactSnapshot,
-          localEchoMessages: echoSnapshot
+          localEchoMessages: echoSnapshot,
+          transcriptRevision: transcriptRevisionSnapshot,
         )
+        transcriptIncrementalDelta = []
         refreshTimelinePresentation(sourceTimeline: nextSnapshot.timeline)
         if isNearBottom, !timelineDragActive {
           timelineLayoutPinToken &+= 1
@@ -871,7 +1242,10 @@ extension WorkChatSessionView {
     transcript: [WorkChatEnvelope],
     fallbackEntries: [AgentChatTranscriptEntry],
     artifacts: [ComputerUseArtifactSummary],
-    localEchoMessages: [WorkLocalEchoMessage]
+    localEchoMessages: [WorkLocalEchoMessage],
+    transcriptRevision: Int,
+    allowsIncrementalTranscriptUpdate: Bool,
+    incrementalTranscriptDelta: [WorkChatEnvelope]
   ) -> Bool {
     let nextSnapshot = workSnapshotByApplyingLocalEchoTail(
       to: timelineSnapshot,
@@ -879,27 +1253,44 @@ extension WorkChatSessionView {
       transcript: transcript,
       fallbackEntries: fallbackEntries,
       artifacts: artifacts,
-      localEchoMessages: localEchoMessages
+      localEchoMessages: localEchoMessages,
+      transcriptRevision: transcriptRevision
     ) ?? workSnapshotByApplyingAssistantTextTail(
       to: timelineSnapshot,
       cache: timelineIncrementalCache,
       transcript: transcript,
+      incrementalTranscriptDelta: incrementalTranscriptDelta,
       fallbackEntries: fallbackEntries,
       artifacts: artifacts,
-      localEchoMessages: localEchoMessages
+      localEchoMessages: localEchoMessages,
+      transcriptRevision: transcriptRevision,
+      allowsIncrementalTranscriptUpdate: allowsIncrementalTranscriptUpdate
     )
     guard let nextSnapshot else {
       return false
     }
 
     timelineSnapshot = nextSnapshot
+    transcriptIncrementalDelta = []
     timelineIncrementalCache.record(
       transcript: transcript,
       fallbackEntries: fallbackEntries,
       artifacts: artifacts,
-      localEchoMessages: localEchoMessages
+      localEchoMessages: localEchoMessages,
+      transcriptRevision: transcriptRevision
     )
-    refreshTimelinePresentation(sourceTimeline: nextSnapshot.timeline)
+    let onlyTailMetadataChanged = incrementalTranscriptDelta.allSatisfy {
+      switch $0.event {
+      case .assistantText, .activity, .tokens, .toolUseSummary, .reasoning, .status:
+        return true
+      default:
+        return false
+      }
+    }
+    refreshTimelinePresentation(
+      sourceTimeline: nextSnapshot.timeline,
+      rebuildToolActivityIndex: !onlyTailMetadataChanged
+    )
     if isNearBottom, !timelineDragActive {
       timelineLayoutPinToken &+= 1
     }
@@ -917,13 +1308,15 @@ extension WorkChatSessionView {
       artifacts: artifacts,
       localEchoMessages: localEchoMessages
     )
+    transcriptIncrementalDelta = []
     guard nextSnapshot != timelineSnapshot || (timelineSnapshot.timeline.isEmpty && !nextSnapshot.timeline.isEmpty) else { return }
     timelineSnapshot = nextSnapshot
     timelineIncrementalCache.record(
       transcript: transcript,
       fallbackEntries: fallbackEntries,
       artifacts: artifacts,
-      localEchoMessages: localEchoMessages
+      localEchoMessages: localEchoMessages,
+      transcriptRevision: transcriptRenderSignature
     )
     refreshTimelinePresentation(sourceTimeline: nextSnapshot.timeline)
     if isNearBottom, !timelineDragActive {
@@ -982,7 +1375,8 @@ extension WorkChatSessionView {
       transcript: transcript,
       fallbackEntries: fallbackEntries,
       artifacts: artifacts,
-      localEchoMessages: localEchoMessages
+      localEchoMessages: localEchoMessages,
+      transcriptRevision: transcriptRenderSignature,
     )
 
     let alreadyEmpty = timelineSnapshot == .empty && timelinePresentation == .empty

--- a/apps/ios/ADE/Views/Work/WorkChatSessionView+Actions.swift
+++ b/apps/ios/ADE/Views/Work/WorkChatSessionView+Actions.swift
@@ -575,6 +575,8 @@ extension WorkChatSessionView {
     lastTimelineTailId = nil
     scrollMetrics = WorkChatScrollMetrics()
     timelineDragActive = false
+    timelineScrollPhaseUserDriven = false
+    transcriptContentFitsViewport = true
     bottomStickinessReleasedByUser = false
     olderHistoryLoadTask?.cancel()
     olderHistoryLoadTask = nil
@@ -583,20 +585,61 @@ extension WorkChatSessionView {
     olderHistoryTriggerArmed = true
     olderHistoryAutomaticContinuationPending = false
     pendingInitialBottomPinSessionId = session.id
+    initialBottomPinQuiescenceGeneration &+= 1
     cancelLatestPinTask()
     timelineIncrementalCache.reset()
   }
 
+  /// Re-applies the opening pin for as long as the content is still growing.
+  ///
+  /// Called on content-size changes only — never per scroll frame — because it
+  /// scans the visible timeline for the tail entry.
+  ///
+  /// The pin used to fire once and disarm, so any hydration that landed after
+  /// the retry ladder (0/16/80/180/320ms) grew the content under a scroll offset
+  /// nobody re-pinned, which is what opened chats "at a random spot". It now
+  /// stays armed until either the reader takes over
+  /// (`cancelPendingInitialBottomPinForUserScroll`) or the content height has
+  /// been quiet for `workChatInitialPinQuiescence` — the wall-clock reading of
+  /// "stable across consecutive layout passes", since a change-driven observer
+  /// by construction never reports the passes where nothing changed.
   @MainActor
   func resolvePendingInitialBottomPinAfterLayout(_ proxy: ScrollViewProxy, reason: String) {
     guard pendingInitialBottomPinSessionId == session.id else { return }
+    // A brand-new chat has nothing to pin: its single bubble is top-anchored
+    // (desktop parity), and forcing it to the bottom of an empty screen is the
+    // exact layout that rule exists to remove.
+    guard timeline.count > 1 else {
+      pendingInitialBottomPinSessionId = nil
+      return
+    }
     guard let tailId = timeline.last?.id, !tailId.isEmpty else { return }
     guard visibleTimeline.contains(where: { $0.id == tailId }) else {
       return
     }
+    guard workChatMayWriteScrollOffset(
+      dragActive: timelineDragActive,
+      scrollPhaseUserDriven: timelineScrollPhaseUserDriven
+    ) else { return }
 
-    pendingInitialBottomPinSessionId = nil
     forcePinToLatestAfterLayout(proxy, reason: "initial-\(reason)")
+    armInitialBottomPinQuiescence()
+  }
+
+  /// Disarms the opening pin once the content stops changing size.
+  @MainActor
+  private func armInitialBottomPinQuiescence() {
+    initialBottomPinQuiescenceGeneration &+= 1
+    let generation = initialBottomPinQuiescenceGeneration
+    let pinnedSessionId = session.id
+    Task { @MainActor in
+      try? await Task.sleep(for: .milliseconds(workChatInitialPinQuiescenceMilliseconds))
+      guard !Task.isCancelled,
+            generation == initialBottomPinQuiescenceGeneration,
+            pendingInitialBottomPinSessionId == pinnedSessionId
+      else { return }
+      pendingInitialBottomPinSessionId = nil
+    }
   }
 
   /// Paints the user's own bubble on the tap frame.
@@ -840,6 +883,8 @@ extension WorkChatSessionView {
     lastTimelineTailId = nil
     scrollMetrics = WorkChatScrollMetrics()
     timelineDragActive = false
+    timelineScrollPhaseUserDriven = false
+    transcriptContentFitsViewport = true
     bottomStickinessReleasedByUser = false
     olderHistoryLoadTask?.cancel()
     olderHistoryLoadTask = nil
@@ -848,6 +893,7 @@ extension WorkChatSessionView {
     olderHistoryTriggerArmed = true
     olderHistoryAutomaticContinuationPending = false
     pendingInitialBottomPinSessionId = session.id
+    initialBottomPinQuiescenceGeneration &+= 1
     cancelLatestPinTask()
     timelineRebuildTask?.cancel()
     timelineRebuildTask = nil
@@ -1004,11 +1050,22 @@ extension WorkChatSessionView {
     }
   }
 
+  /// The reader took the transcript over, so the initial bottom pin stands down.
+  ///
+  /// Split from `releaseBottomStickinessForUserScroll` because the two answer
+  /// different questions at different sensitivities: 2pt of travel is enough to
+  /// mean "stop following the stream", but cancelling the opening pin needs a
+  /// deliberate drag (`workChatInitialPinCancelDeadband`) — finger jitter on a
+  /// tap used to strand a freshly-opened chat mid-transcript.
+  @MainActor
+  func cancelPendingInitialBottomPinForUserScroll() {
+    guard pendingInitialBottomPinSessionId == session.id else { return }
+    pendingInitialBottomPinSessionId = nil
+    initialBottomPinQuiescenceGeneration &+= 1
+  }
+
   @MainActor
   func releaseBottomStickinessForUserScroll(reason: String) {
-    if pendingInitialBottomPinSessionId == session.id {
-      pendingInitialBottomPinSessionId = nil
-    }
     guard isNearBottom else { return }
     bottomStickinessReleasedByUser = true
     isNearBottom = false
@@ -1038,20 +1095,30 @@ extension WorkChatSessionView {
     }
   }
 
+  /// Whether an automatic pin may run right now. A pin is a scroll write, so it
+  /// defers to the reader for the whole interaction — finger-down through the
+  /// end of the fling — not just while the drag gesture is live.
+  var canWriteAutomaticScrollOffset: Bool {
+    workChatMayWriteScrollOffset(
+      dragActive: timelineDragActive,
+      scrollPhaseUserDriven: timelineScrollPhaseUserDriven
+    )
+  }
+
   @MainActor
   func pinToLatestAfterLayout(_ proxy: ScrollViewProxy, reason: String) {
-    guard isNearBottom, !timelineDragActive else { return }
+    guard isNearBottom, canWriteAutomaticScrollOffset else { return }
     latestPinGeneration &+= 1
     let generation = latestPinGeneration
     latestPinTask?.cancel()
     latestPinTask = Task { @MainActor in
-      guard generation == latestPinGeneration, isNearBottom, !timelineDragActive else { return }
+      guard generation == latestPinGeneration, isNearBottom, canWriteAutomaticScrollOffset else { return }
       scrollToLatest(proxy, animated: false)
       try? await Task.sleep(for: .milliseconds(16))
       guard !Task.isCancelled,
             generation == latestPinGeneration,
             isNearBottom,
-            !timelineDragActive else { return }
+            canWriteAutomaticScrollOffset else { return }
       scrollToLatest(proxy, animated: false)
       if generation == latestPinGeneration {
         latestPinTask = nil
@@ -1061,6 +1128,7 @@ extension WorkChatSessionView {
 
   @MainActor
   func forcePinToLatestAfterLayout(_ proxy: ScrollViewProxy, reason: String) {
+    guard canWriteAutomaticScrollOffset else { return }
     isNearBottom = true
     if unreadBelowCount > 0 {
       unreadBelowCount = 0
@@ -1069,14 +1137,14 @@ extension WorkChatSessionView {
     let generation = latestPinGeneration
     latestPinTask?.cancel()
     latestPinTask = Task { @MainActor in
-      guard generation == latestPinGeneration, isNearBottom, !timelineDragActive else { return }
+      guard generation == latestPinGeneration, isNearBottom, canWriteAutomaticScrollOffset else { return }
       scrollToLatest(proxy, animated: false)
       for delay in [16, 80, 180, 320] {
         try? await Task.sleep(for: .milliseconds(delay))
         guard !Task.isCancelled,
               generation == latestPinGeneration,
               isNearBottom,
-              !timelineDragActive else { return }
+              canWriteAutomaticScrollOffset else { return }
         scrollToLatest(proxy, animated: false)
       }
       if generation == latestPinGeneration {

--- a/apps/ios/ADE/Views/Work/WorkChatSessionView+Actions.swift
+++ b/apps/ios/ADE/Views/Work/WorkChatSessionView+Actions.swift
@@ -997,7 +997,7 @@ extension WorkChatSessionView {
   func continueAutomaticOlderHistoryIfNeeded() {
     guard olderHistoryAutomaticContinuationPending,
           !olderHistoryLoadInFlight,
-          olderHistoryLoadError == nil
+          olderHistoryLoadError == nil || hiddenTimelineCount > 0
     else { return }
     guard workChatShouldContinueAutomaticOlderHistory(
       distanceFromBottom: scrollMetrics.distanceFromBottom,

--- a/apps/ios/ADE/Views/Work/WorkChatSessionView+Actions.swift
+++ b/apps/ios/ADE/Views/Work/WorkChatSessionView+Actions.swift
@@ -110,15 +110,25 @@ private func workSnapshotByApplyingAssistantTextTail(
   }
 
   var timeline = snapshot.timeline
+  var refreshEventCards = false
   for envelope in candidateEnvelopes {
     guard workIncrementalApplyEnvelope(envelope, to: &timeline) else {
       return nil
+    }
+    if case .reasoning = envelope.event {
+      refreshEventCards = true
     }
   }
   timeline = workIncrementalSortTimeline(timeline)
 
   var nextSnapshot = snapshot
   nextSnapshot.timeline = timeline
+  if refreshEventCards {
+    // `eventCards` is also the source for live-reasoning presentation state;
+    // keep it in lockstep with the timeline when the append-only path accepts
+    // a reasoning envelope. Other incremental deltas avoid this O(n) fold.
+    nextSnapshot.eventCards = workIncrementalEventCards(from: timeline)
+  }
   nextSnapshot.latestTranscriptTimestamp = workIncrementalLatestTimestamp(
     existing: snapshot.latestTranscriptTimestamp,
     envelopes: candidateEnvelopes
@@ -232,7 +242,7 @@ private func workIncrementalApplyEnvelope(
   to timeline: inout [WorkTimelineEntry]
 ) -> Bool {
   if workIncrementalEnvelopeIsLiveMetadata(envelope) {
-    return true
+    return workIncrementalApplyLiveMetadata(envelope, to: &timeline)
   }
   if case .userMessage(let text, let attachments, let turnId, let steerId, let deliveryState, let processed) = envelope.event {
     guard deliveryState != "queued" || steerId == nil else { return false }
@@ -293,6 +303,43 @@ private func workIncrementalApplyEnvelope(
     rank: workIncrementalNextMessageRank(in: timeline),
     payload: .message(message)
   ))
+  return true
+}
+
+/// Applies the metadata envelopes that the append-only path is allowed to
+/// accept without a full snapshot rebuild. Reasoning owns a visible card and
+/// therefore has to merge into that card; the remaining accepted metadata
+/// envelopes intentionally have no mobile timeline payload.
+func workIncrementalApplyLiveMetadata(
+  _ envelope: WorkChatEnvelope,
+  to timeline: inout [WorkTimelineEntry]
+) -> Bool {
+  guard let incomingCard = workIncrementalEventCard(for: envelope), incomingCard.kind == "reasoning" else {
+    return true
+  }
+
+  let entryId = "event-\(incomingCard.id)"
+  if let existingIndex = timeline.lastIndex(where: { $0.id == entryId }) {
+    guard case .eventCard(let existingCard) = timeline[existingIndex].payload,
+          let mergedCard = workIncrementalMergedEventCard(existingCard, with: incomingCard)
+    else { return false }
+    timeline[existingIndex] = WorkTimelineEntry(
+      id: entryId,
+      timestamp: mergedCard.timestamp,
+      rank: timeline[existingIndex].rank,
+      payload: .eventCard(mergedCard)
+    )
+  } else {
+    let eventRank = 1_500 + timeline.reduce(into: 0) { count, entry in
+      if case .eventCard = entry.payload { count += 1 }
+    }
+    timeline.append(WorkTimelineEntry(
+      id: entryId,
+      timestamp: incomingCard.timestamp,
+      rank: eventRank,
+      payload: .eventCard(incomingCard)
+    ))
+  }
   return true
 }
 
@@ -491,31 +538,30 @@ private func workIncrementalSnapshotSignature(
     hasher.combine(workIncrementalEnvelopeKey(tail))
     hasher.combine(tail.timestamp)
     hasher.combine(tail.sequence)
-    if case .assistantText(let text, let turnId, let itemId) = tail.event {
-      workCombineBoundedTextSignature(text, into: &hasher)
+    if case .assistantText(_, let turnId, let itemId) = tail.event {
       hasher.combine(turnId)
       hasher.combine(itemId)
+      if let latestAssistantId = workIncrementalLatestAssistantId(timeline),
+         let message = timeline.reversed().compactMap({ entry -> WorkChatMessage? in
+           guard entry.id == "message-\(latestAssistantId)",
+                 case .message(let message) = entry.payload
+           else { return nil }
+           return message
+         }).first {
+        // The live message owns an exact monotonic revision. It distinguishes
+        // same-length middle replacements without hashing the growing answer
+        // on the main actor for every token batch.
+        hasher.combine(message.markdownRevision)
+        hasher.combine(message.markdownCharacterCount)
+        hasher.combine(message.markdownLineCount)
+        hasher.combine(message.markdownTrailingBacktickRun)
+      }
     }
   }
   if let latestAssistantId = workIncrementalLatestAssistantId(timeline) {
     hasher.combine(latestAssistantId)
   }
   return hasher.finalize()
-}
-
-/// Keep the incremental snapshot signature proportional to a small fixed
-/// window. The live path already has the envelope's sequence and byte count;
-/// the ends distinguish edits/replays without hashing a growing response on
-/// the main actor for every delta.
-func workCombineBoundedTextSignature(_ text: String, into hasher: inout Hasher) {
-  let utf8Count = text.utf8.count
-  hasher.combine(utf8Count)
-  guard utf8Count > 1_024 else {
-    hasher.combine(text)
-    return
-  }
-  hasher.combine(text.prefix(512))
-  hasher.combine(text.suffix(512))
 }
 
 private func workIncrementalFallbackSignature(_ fallbackEntries: [AgentChatTranscriptEntry], transcriptIsEmpty: Bool) -> Int {

--- a/apps/ios/ADE/Views/Work/WorkChatSessionView+Actions.swift
+++ b/apps/ios/ADE/Views/Work/WorkChatSessionView+Actions.swift
@@ -269,8 +269,7 @@ private func workIncrementalApplyEnvelope(
     envelopeId: envelope.id
   ) {
     guard case .message(var message) = timeline[targetIndex].payload else { return false }
-    message.markdown = mergeWorkStreamingText(message.markdown, text)
-    message.assistantPreview = nil
+    workApplyStreamingAssistantText(text, to: &message)
     timeline[targetIndex] = WorkTimelineEntry(
       id: timeline[targetIndex].id,
       timestamp: timeline[targetIndex].timestamp,
@@ -493,8 +492,7 @@ private func workIncrementalSnapshotSignature(
     hasher.combine(tail.timestamp)
     hasher.combine(tail.sequence)
     if case .assistantText(let text, let turnId, let itemId) = tail.event {
-      hasher.combine(text.utf8.count)
-      hasher.combine(text.hashValue)
+      workCombineBoundedTextSignature(text, into: &hasher)
       hasher.combine(turnId)
       hasher.combine(itemId)
     }
@@ -503,6 +501,21 @@ private func workIncrementalSnapshotSignature(
     hasher.combine(latestAssistantId)
   }
   return hasher.finalize()
+}
+
+/// Keep the incremental snapshot signature proportional to a small fixed
+/// window. The live path already has the envelope's sequence and byte count;
+/// the ends distinguish edits/replays without hashing a growing response on
+/// the main actor for every delta.
+func workCombineBoundedTextSignature(_ text: String, into hasher: inout Hasher) {
+  let utf8Count = text.utf8.count
+  hasher.combine(utf8Count)
+  guard utf8Count > 1_024 else {
+    hasher.combine(text)
+    return
+  }
+  hasher.combine(text.prefix(512))
+  hasher.combine(text.suffix(512))
 }
 
 private func workIncrementalFallbackSignature(_ fallbackEntries: [AgentChatTranscriptEntry], transcriptIsEmpty: Bool) -> Int {

--- a/apps/ios/ADE/Views/Work/WorkChatSessionView+Timeline.swift
+++ b/apps/ios/ADE/Views/Work/WorkChatSessionView+Timeline.swift
@@ -45,14 +45,43 @@ extension WorkChatSessionView {
         controls: model,
         onCopyMessage: { copyAssistantMarkdown(messageId: model.messageId) },
         onShowMore: {
-          assistantLineBudgets[model.messageId] = model.nextLineBudget
-          refreshTimelinePresentation()
-          if isNearBottom {
-            pinToLatestAfterLayout(proxy, reason: "assistant-show-more")
-          }
+          expandAssistantMessage(
+            messageId: model.messageId,
+            nextLineBudget: model.nextLineBudget,
+            controlsRowId: model.id,
+            proxy: proxy
+          )
         }
       )
       .equatable()
+    }
+  }
+
+  /// One "Show more" step, for both render paths.
+  ///
+  /// Expansion grows the message DOWNWARD from a head anchor, so the reader's
+  /// current view is unchanged and the right thing to do with the scroll offset
+  /// is to leave the row they tapped where it is. It used to re-pin the
+  /// transcript to its bottom, which threw the reader to the end of the chat
+  /// for asking to see more of a message in the middle of it.
+  @MainActor
+  func expandAssistantMessage(
+    messageId: String,
+    nextLineBudget: Int,
+    controlsRowId: String,
+    proxy: ScrollViewProxy
+  ) {
+    assistantLineBudgets[messageId] = nextLineBudget
+    assistantHeadAnchorOverrides.insert(messageId)
+    refreshTimelinePresentation()
+    // Not animated: the expansion inserts a screenful of text, and animating
+    // the offset onto it reads as the transcript lurching.
+    var transaction = Transaction()
+    transaction.disablesAnimations = true
+    Task { @MainActor in
+      withTransaction(transaction) {
+        proxy.scrollTo(controlsRowId, anchor: .bottom)
+      }
     }
   }
 
@@ -92,8 +121,21 @@ extension WorkChatSessionView {
         maxUserBubbleWidth: maxUserBubbleWidth,
         onRunUnprocessed: onRunUnprocessedMessage,
         onEditUnprocessed: onEditUnprocessedMessage,
-        onDismissUnprocessed: onDismissUnprocessedMessage
+        onDismissUnprocessed: onDismissUnprocessedMessage,
+        onShowMore: message.role == "assistant"
+          ? {
+            expandAssistantMessage(
+              messageId: message.id,
+              nextLineBudget: workAssistantMessageShowMoreLineBudget(
+                current: assistantLineBudgets[message.id] ?? assistantBudgetFloors[message.id]
+              ),
+              controlsRowId: entry.id,
+              proxy: proxy
+            )
+          }
+          : nil
       )
+      .equatable()
     case .toolCard(let toolCard):
       timelineToolCard(toolCard)
     case .eventCard(let card):
@@ -112,6 +154,7 @@ extension WorkChatSessionView {
             }
             : nil
         )
+        .equatable()
       }
     case .usageSummary(let summary):
       WorkTurnUsageSummaryBanner(
@@ -121,8 +164,10 @@ extension WorkChatSessionView {
       )
     case .commandCard(let commandCard):
       WorkCommandCardView(card: commandCard)
+        .equatable()
     case .fileChangeCard(let fileChangeCard):
       WorkFileChangeCardView(card: fileChangeCard)
+        .equatable()
     case .subagent(let row):
       WorkSubagentTimelineRowView(row: row, onOpen: onSelectSubagentRow)
     case .subagentStoppedGroup(let model):
@@ -261,7 +306,6 @@ extension WorkChatSessionView {
   func timelineToolCard(_ toolCard: WorkToolCardModel) -> some View {
     WorkToolCardView(
       toolCard: toolCard,
-      references: extractWorkNavigationTargets(from: [toolCard.argsText, toolCard.resultText].compactMap { $0 }.joined(separator: "\n")),
       isExpanded: expandedToolCardIds.contains(toolCard.id),
       onToggle: { toggleToolCard(toolCard.id) },
       onOpenFile: { path in
@@ -271,6 +315,7 @@ extension WorkChatSessionView {
         Task { await onOpenPr(prNumber) }
       }
     )
+    .equatable()
   }
 
   @ViewBuilder
@@ -303,6 +348,7 @@ extension WorkChatSessionView {
         onOpenFile: { path in Task { await onOpenFile(path) } },
         onOpenPr: { number in Task { await onOpenPr(number) } }
       )
+      .equatable()
     }
   }
 

--- a/apps/ios/ADE/Views/Work/WorkChatSessionView+Timeline.swift
+++ b/apps/ios/ADE/Views/Work/WorkChatSessionView+Timeline.swift
@@ -51,7 +51,8 @@ extension WorkChatSessionView {
             controlsRowId: model.id,
             proxy: proxy
           )
-        }
+        },
+        onOpenFullOutput: { openAssistantMessageFullOutput(messageId: model.messageId) }
       )
       .equatable()
     }
@@ -83,6 +84,16 @@ extension WorkChatSessionView {
         proxy.scrollTo(controlsRowId, anchor: .bottom)
       }
     }
+  }
+
+  /// Second rung of the message-level ladder: the whole answer, on its own
+  /// screen, instead of another bounded step through it.
+  @MainActor
+  func openAssistantMessageFullOutput(messageId: String) {
+    guard let markdown = assistantMarkdown(messageId: messageId) else { return }
+    outputViewer.present(
+      WorkOutputViewerRequest(title: "Response", text: markdown, kind: .text)
+    )
   }
 
   func copyAssistantMarkdown(messageId: String) {
@@ -133,7 +144,10 @@ extension WorkChatSessionView {
               proxy: proxy
             )
           }
-          : nil
+          : nil,
+        // Only an explicit tap writes this map, so its presence *is* "already
+        // expanded once".
+        hasExpandedInPlace: assistantLineBudgets[message.id] != nil
       )
       .equatable()
     case .toolCard(let toolCard):
@@ -449,7 +463,11 @@ struct WorkAssistantMarkdownBlockRow: View, Equatable {
   }
 
   var body: some View {
-    WorkMarkdownBlockView(block: model.block, isStreamingTail: model.isStreamingTail)
+    WorkMarkdownBlockView(
+      block: model.block,
+      isStreamingTail: model.isStreamingTail,
+      codeSource: model.codeSource
+    )
       .frame(maxWidth: .infinity, alignment: .leading)
       .contextMenu {
         Button(action: onCopyMessage) {
@@ -500,9 +518,18 @@ struct WorkAssistantMessageControlsView: View, Equatable {
   let controls: WorkAssistantMessageControlsModel
   let onCopyMessage: () -> Void
   let onShowMore: () -> Void
+  let onOpenFullOutput: () -> Void
 
   static func == (lhs: WorkAssistantMessageControlsView, rhs: WorkAssistantMessageControlsView) -> Bool {
     lhs.controls == rhs.controls
+  }
+
+  private var affordance: WorkTruncatedOutputAffordance {
+    workTruncatedOutputAffordance(
+      isTruncated: controls.canShowMore,
+      hasExpandedInPlace: controls.hasExpandedInPlace,
+      isClipped: false
+    )
   }
 
   var body: some View {
@@ -517,15 +544,32 @@ struct WorkAssistantMessageControlsView: View, Equatable {
         Label("Copy full", systemImage: "doc.on.doc")
           .labelStyle(.titleAndIcon)
           .font(.caption2.weight(.semibold))
+          .frame(minHeight: 44)
+          .contentShape(Rectangle())
       }
       .buttonStyle(.plain)
       .foregroundStyle(ADEColor.textSecondary)
 
-      if controls.canShowMore {
+      switch affordance {
+      case .none:
+        EmptyView()
+      case .showMore:
         Button(action: onShowMore) {
           Label("Show more", systemImage: "chevron.down")
             .labelStyle(.titleAndIcon)
             .font(.caption2.weight(.semibold))
+            .frame(minHeight: 44)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .foregroundStyle(ADEColor.accent)
+      case .openFullOutput:
+        Button(action: onOpenFullOutput) {
+          Label("Open full output", systemImage: "arrow.up.left.and.arrow.down.right")
+            .labelStyle(.titleAndIcon)
+            .font(.caption2.weight(.semibold))
+            .frame(minHeight: 44)
+            .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
         .foregroundStyle(ADEColor.accent)

--- a/apps/ios/ADE/Views/Work/WorkChatSessionView+Timeline.swift
+++ b/apps/ios/ADE/Views/Work/WorkChatSessionView+Timeline.swift
@@ -48,8 +48,6 @@ extension WorkChatSessionView {
           expandAssistantMessage(
             messageId: model.messageId,
             nextLineBudget: model.nextLineBudget,
-            controlsRowId: model.id,
-            proxy: proxy
           )
         },
         onOpenFullOutput: { openAssistantMessageFullOutput(messageId: model.messageId) }
@@ -68,22 +66,11 @@ extension WorkChatSessionView {
   @MainActor
   func expandAssistantMessage(
     messageId: String,
-    nextLineBudget: Int,
-    controlsRowId: String,
-    proxy: ScrollViewProxy
+    nextLineBudget: Int
   ) {
     assistantLineBudgets[messageId] = nextLineBudget
     assistantHeadAnchorOverrides.insert(messageId)
     refreshTimelinePresentation()
-    // Not animated: the expansion inserts a screenful of text, and animating
-    // the offset onto it reads as the transcript lurching.
-    var transaction = Transaction()
-    transaction.disablesAnimations = true
-    Task { @MainActor in
-      withTransaction(transaction) {
-        proxy.scrollTo(controlsRowId, anchor: .bottom)
-      }
-    }
   }
 
   /// Second rung of the message-level ladder: the whole answer, on its own
@@ -139,9 +126,7 @@ extension WorkChatSessionView {
               messageId: message.id,
               nextLineBudget: workAssistantMessageShowMoreLineBudget(
                 current: assistantLineBudgets[message.id] ?? assistantBudgetFloors[message.id]
-              ),
-              controlsRowId: entry.id,
-              proxy: proxy
+              )
             )
           }
           : nil,

--- a/apps/ios/ADE/Views/Work/WorkChatSessionView+Timeline.swift
+++ b/apps/ios/ADE/Views/Work/WorkChatSessionView+Timeline.swift
@@ -49,7 +49,7 @@ extension WorkChatSessionView {
             messageId: model.messageId,
             nextLineBudget: model.nextLineBudget,
             proxy: proxy,
-            restoreRowId: model.nextLineBudget < model.totalLineCount
+            restoreRowId: model.willRemainTruncatedAfterNextStep
               ? entry.id
               : entry.sourceEntryId,
           )

--- a/apps/ios/ADE/Views/Work/WorkChatSessionView+Timeline.swift
+++ b/apps/ios/ADE/Views/Work/WorkChatSessionView+Timeline.swift
@@ -6,7 +6,7 @@ extension WorkChatSessionView {
   /// Id of the assistant message still receiving streaming deltas, or nil
   /// when no turn is active. Only the LAST message qualifies, and only while
   /// the session is actively streaming — that message's bubble parses its
-  /// markdown through the tail-only streaming parser; every completed message
+  /// markdown through the bounded streaming parser; every completed message
   /// keeps the whole-text block cache path.
   var streamingAssistantMessageId: String? {
     guard shouldShowInterruptControl else { return nil }
@@ -48,6 +48,10 @@ extension WorkChatSessionView {
           expandAssistantMessage(
             messageId: model.messageId,
             nextLineBudget: model.nextLineBudget,
+            proxy: proxy,
+            restoreRowId: model.nextLineBudget < model.totalLineCount
+              ? entry.id
+              : entry.sourceEntryId,
           )
         },
         onOpenFullOutput: { openAssistantMessageFullOutput(messageId: model.messageId) }
@@ -66,11 +70,24 @@ extension WorkChatSessionView {
   @MainActor
   func expandAssistantMessage(
     messageId: String,
-    nextLineBudget: Int
+    nextLineBudget: Int,
+    proxy: ScrollViewProxy,
+    restoreRowId: String
   ) {
     assistantLineBudgets[messageId] = nextLineBudget
     assistantHeadAnchorOverrides.insert(messageId)
     refreshTimelinePresentation()
+
+    // The expansion changes a tail slice into a head slice. Keep the row the
+    // reader acted on at the same viewport edge instead of allowing SwiftUI to
+    // choose the newly-created first block and teleport to the beginning.
+    DispatchQueue.main.async {
+      var transaction = Transaction()
+      transaction.disablesAnimations = true
+      withTransaction(transaction) {
+        proxy.scrollTo(restoreRowId, anchor: .bottom)
+      }
+    }
   }
 
   /// Second rung of the message-level ladder: the whole answer, on its own
@@ -126,7 +143,9 @@ extension WorkChatSessionView {
               messageId: message.id,
               nextLineBudget: workAssistantMessageShowMoreLineBudget(
                 current: assistantLineBudgets[message.id] ?? assistantBudgetFloors[message.id]
-              )
+              ),
+              proxy: proxy,
+              restoreRowId: entry.id
             )
           }
           : nil,

--- a/apps/ios/ADE/Views/Work/WorkChatSessionView+Timeline.swift
+++ b/apps/ios/ADE/Views/Work/WorkChatSessionView+Timeline.swift
@@ -151,15 +151,18 @@ extension WorkChatSessionView {
       )
       .equatable()
     case .toolCard(let toolCard):
-      timelineToolCard(toolCard)
+      timelineToolCard(toolCard, entryId: entry.id)
     case .eventCard(let card):
-      timelineEventCard(card)
+      timelineEventCard(card, entryId: entry.id)
     case .adeCard(let card):
       if card.isHiddenAfterDismiss {
         EmptyView()
       } else {
         WorkAdeCardView(
           card: card,
+          // Live for its own turn, one line ("CI · PR #490  18✓ 3✕") after.
+          isExpanded: cardIsExpanded(card.id, entryId: entry.id, keepsOpenWhileLive: true),
+          onToggle: { toggleCard(card.id, entryId: entry.id, keepsOpenWhileLive: true) },
           onAction: card.variant == "claude_session_quota"
             ? { action in
               if action.id == "fork-local" {
@@ -177,21 +180,34 @@ extension WorkChatSessionView {
         modelLabel: chatSummaryContext.modelLabel
       )
     case .commandCard(let commandCard):
-      WorkCommandCardView(card: commandCard)
-        .equatable()
+      WorkCommandCardView(
+        card: commandCard,
+        isExpanded: cardIsExpanded(commandCard.id, entryId: entry.id),
+        onToggle: { toggleCard(commandCard.id, entryId: entry.id) }
+      )
+      .equatable()
     case .fileChangeCard(let fileChangeCard):
-      WorkFileChangeCardView(card: fileChangeCard)
-        .equatable()
+      WorkFileChangeCardView(
+        card: fileChangeCard,
+        isExpanded: cardIsExpanded(fileChangeCard.id, entryId: entry.id),
+        onToggle: { toggleCard(fileChangeCard.id, entryId: entry.id) }
+      )
+      .equatable()
     case .subagent(let row):
       WorkSubagentTimelineRowView(row: row, onOpen: onSelectSubagentRow)
     case .subagentStoppedGroup(let model):
-      WorkSubagentStoppedGroupCardView(model: model, onOpen: onSelectSubagentRow)
+      WorkSubagentStoppedGroupCardView(
+        model: model,
+        isExpanded: cardIsExpanded(model.id, entryId: entry.id),
+        onToggle: { toggleCard(model.id, entryId: entry.id) },
+        onOpen: onSelectSubagentRow
+      )
     case .toolGroup(let group):
-      timelineToolGroup(group)
+      timelineToolGroup(group, entryId: entry.id)
     case .changedFiles(let group):
-      timelineChangedFiles(group)
+      timelineChangedFiles(group, entryId: entry.id)
     case .artifact(let artifact):
-      timelineArtifact(artifact)
+      timelineArtifact(artifact, entryId: entry.id)
     case .turnSeparator(let separator):
       WorkTurnSeparatorView(separator: separator)
     case .turnEndMarker(let marker):
@@ -298,30 +314,34 @@ extension WorkChatSessionView {
   }
 
   @ViewBuilder
-  func timelineToolGroup(_ group: WorkToolGroupModel) -> some View {
+  func timelineToolGroup(_ group: WorkToolGroupModel, entryId: String) -> some View {
     WorkToolCallsPanelView(
       group: group,
-      isExpanded: expandedToolCardIds.contains(group.id),
-      onToggle: { toggleToolCard(group.id) }
+      isExpanded: cardIsExpanded(group.id, entryId: entryId),
+      onToggle: { toggleCard(group.id, entryId: entryId) },
+      expandedMemberIds: cardExpansion.expandedIds,
+      onToggleMember: { memberId in toggleNestedCard(memberId) }
     )
   }
 
   @ViewBuilder
-  func timelineChangedFiles(_ group: WorkChangedFilesGroupModel) -> some View {
+  func timelineChangedFiles(_ group: WorkChangedFilesGroupModel, entryId: String) -> some View {
     WorkChangedFilesPanelView(
       group: group,
-      isExpanded: expandedToolCardIds.contains(group.id),
-      onToggle: { toggleToolCard(group.id) },
+      isExpanded: cardIsExpanded(group.id, entryId: entryId),
+      onToggle: { toggleCard(group.id, entryId: entryId) },
+      expandedFileIds: cardExpansion.expandedIds,
+      onToggleFile: { fileId in toggleNestedCard(fileId) },
       onUndo: nil
     )
   }
 
   @ViewBuilder
-  func timelineToolCard(_ toolCard: WorkToolCardModel) -> some View {
+  func timelineToolCard(_ toolCard: WorkToolCardModel, entryId: String) -> some View {
     WorkToolCardView(
       toolCard: toolCard,
-      isExpanded: expandedToolCardIds.contains(toolCard.id),
-      onToggle: { toggleToolCard(toolCard.id) },
+      isExpanded: cardIsExpanded(toolCard.id, entryId: entryId),
+      onToggle: { toggleCard(toolCard.id, entryId: entryId) },
       onOpenFile: { path in
         Task { await onOpenFile(path) }
       },
@@ -333,14 +353,22 @@ extension WorkChatSessionView {
   }
 
   @ViewBuilder
-  func timelineEventCard(_ card: WorkEventCardModel) -> some View {
+  func timelineEventCard(_ card: WorkEventCardModel, entryId: String) -> some View {
     if card.kind == "reasoning" {
       WorkReasoningCard(
         card: card,
-        isLive: isReasoningLive(card)
+        isLive: isReasoningLive(card),
+        isExpanded: cardIsExpanded(card.id, entryId: entryId),
+        onToggle: { toggleCard(card.id, entryId: entryId) }
       )
     } else if card.kind == "plan" {
-      WorkProposedPlanCard(card: card)
+      WorkProposedPlanCard(
+        card: card,
+        // A plan being written is the one thing the reader is watching, so it
+        // stays open for its own turn and folds to `Plan · 4/7` after.
+        isExpanded: cardIsExpanded(card.id, entryId: entryId, keepsOpenWhileLive: true),
+        onToggle: { toggleCard(card.id, entryId: entryId, keepsOpenWhileLive: true) }
+      )
     } else if card.kind == "question" {
       WorkResolvedQuestionCard(card: card, fallbackProvider: chatSummaryContext.provider)
     } else if card.kind == "planApproval" {
@@ -355,7 +383,11 @@ extension WorkChatSessionView {
         onRecover: onRecoverCodexTurn
       )
     } else if card.kind == "turnDiagnostics" {
-      WorkTurnDiagnosticsDisclosureView(card: card)
+      WorkTurnDiagnosticsDisclosureView(
+        card: card,
+        isExpanded: cardIsExpanded(card.id, entryId: entryId),
+        onToggle: { toggleCard(card.id, entryId: entryId) }
+      )
     } else {
       WorkEventCardView(
         card: card,
@@ -375,10 +407,12 @@ extension WorkChatSessionView {
   }
 
   @ViewBuilder
-  func timelineArtifact(_ artifact: ComputerUseArtifactSummary) -> some View {
+  func timelineArtifact(_ artifact: ComputerUseArtifactSummary, entryId: String) -> some View {
     WorkArtifactView(
       artifact: artifact,
       content: artifactContent[artifact.id],
+      isExpanded: cardIsExpanded(artifact.id, entryId: entryId),
+      onToggle: { toggleCard(artifact.id, entryId: entryId) },
       onAppear: { Task { await onLoadArtifact(artifact) } },
       onOpenImage: { image in
         fullscreenImage = WorkFullscreenImage(title: artifact.title, image: image)

--- a/apps/ios/ADE/Views/Work/WorkChatSessionView.swift
+++ b/apps/ios/ADE/Views/Work/WorkChatSessionView.swift
@@ -71,6 +71,12 @@ func workChatTranscriptFailureMessage(_ message: String) -> String {
 /// it grows downward — the inverse of the geometry-probe `topY` this used to
 /// take, which was published from a per-frame `GeometryReader` riding the
 /// header row.
+///
+/// `hasError` scopes to the host page that failed, not to scroll-back as a
+/// whole. Buffered entries are already on the phone and cost no network, so a
+/// dropped history page must not strand the reader on top of history they
+/// already have — that combination is what turned one timed-out page into a
+/// transcript that would not scroll again.
 func workChatShouldRequestOlderHistory(
   distanceFromTop: CGFloat,
   triggerArmed: Bool,
@@ -79,13 +85,20 @@ func workChatShouldRequestOlderHistory(
   hasBufferedEntries: Bool,
   hasHostHistory: Bool
 ) -> Bool {
-  distanceFromTop <= workChatOlderHistoryTriggerDistance
-    && triggerArmed
-    && !loading
-    && !hasError
-    && (hasBufferedEntries || hasHostHistory)
+  guard distanceFromTop <= workChatOlderHistoryTriggerDistance,
+        triggerArmed,
+        !loading
+  else { return false }
+  if hasBufferedEntries { return true }
+  return !hasError && hasHostHistory
 }
 
+/// Keeps pulling while the transcript is still too short to scroll.
+///
+/// The buffered-entry bypass matters more here than at the scroll trigger: a
+/// transcript that fits the viewport cannot be scrolled, so the reader has no
+/// way to re-arm anything. Letting a failed host page block the local reveal
+/// there leaves buffered history unreachable by any gesture at all.
 func workChatShouldContinueAutomaticOlderHistory(
   distanceFromBottom: CGFloat,
   loading: Bool,
@@ -93,10 +106,9 @@ func workChatShouldContinueAutomaticOlderHistory(
   hasBufferedEntries: Bool,
   hasHostHistory: Bool
 ) -> Bool {
-  distanceFromBottom <= workChatOlderHistoryScrollableDistance
-    && !loading
-    && !hasError
-    && (hasBufferedEntries || hasHostHistory)
+  guard distanceFromBottom <= workChatOlderHistoryScrollableDistance, !loading else { return false }
+  if hasBufferedEntries { return true }
+  return !hasError && hasHostHistory
 }
 
 /// Scroll state a prepend has to preserve: which row led the list, where that
@@ -1727,6 +1739,16 @@ struct WorkChatSessionView: View {
     if distanceFromTop > workChatOlderHistoryRearmDistance {
       if !olderHistoryTriggerArmed {
         olderHistoryTriggerArmed = true
+      }
+      // Scrolling back down past the re-arm distance retires the previous
+      // failure. A dropped history page is almost always a transient host
+      // timeout, and latching it until someone finds the retry row means the
+      // next approach to the top does nothing at all — the transcript reads as
+      // frozen. Clearing it here keeps the retry gesture the same one the
+      // reader already makes, and cannot spin: a fresh attempt still costs a
+      // full round trip past `workChatOlderHistoryRearmDistance`.
+      if olderHistoryLoadError != nil {
+        olderHistoryLoadError = nil
       }
     }
     guard workChatShouldRequestOlderHistory(

--- a/apps/ios/ADE/Views/Work/WorkChatSessionView.swift
+++ b/apps/ios/ADE/Views/Work/WorkChatSessionView.swift
@@ -2406,6 +2406,7 @@ private func workTimelinePresentationSignature(
       // block, on every presentation refresh.
       hasher.combine(model.block.digest)
       hasher.combine(model.isStreamingTail)
+      hasher.combine(model.codeSource?.markdownIdentity)
     case .assistantMonospaced(let model):
       hasher.combine(model.id)
       hasher.combine(model.messageId)
@@ -2444,10 +2445,12 @@ private func workTimelineCombineMessageTextSignature(_ message: WorkChatMessage,
     return
   }
 
-  hasher.combine(message.markdown.utf8.count)
   if let digest = message.markdownDigest {
     hasher.combine(digest)
+    hasher.combine(message.markdownCharacterCount)
+    hasher.combine(message.markdownLineCount)
   } else {
+    hasher.combine(message.markdown.utf8.count)
     hasher.combine(message.markdown.hashValue)
   }
 }
@@ -2658,7 +2661,8 @@ func workTimelineRenderEntries(
             WorkCodeBlockSource(
               markdown: message.markdown,
               ordinal: ordinal,
-              countsFromEnd: preview.anchor == .tail
+              countsFromEnd: preview.anchor == .tail,
+              markdownIdentity: "\(message.markdownDigest ?? workStableDigest(message.markdown)):\(message.markdownRevision)"
             )
           }
         )

--- a/apps/ios/ADE/Views/Work/WorkChatSessionView.swift
+++ b/apps/ios/ADE/Views/Work/WorkChatSessionView.swift
@@ -2624,7 +2624,9 @@ func workTimelineRenderEntries(
     // flips into the tiny whole-message monospace renderer while paginating.
     if preview.usesMonospacedRendering {
       let model = WorkAssistantMonospacedRenderModel(
-        id: "\(entry.id)-assistant-monospace",
+        // Keep the first rendered row anchored to the source timeline entry so
+        // Show More can restore it after the preview changes anchor.
+        id: entry.id,
         messageId: message.id,
         turnId: message.turnId,
         itemId: message.itemId,
@@ -2651,7 +2653,7 @@ func workTimelineRenderEntries(
         : [:]
       for block in blocks {
         let model = WorkAssistantMarkdownBlockRenderModel(
-          id: "\(entry.id)-\(block.id)",
+          id: block.id == blocks.first?.id ? entry.id : "\(entry.id)-\(block.id)",
           messageId: message.id,
           turnId: message.turnId,
           itemId: message.itemId,

--- a/apps/ios/ADE/Views/Work/WorkChatSessionView.swift
+++ b/apps/ios/ADE/Views/Work/WorkChatSessionView.swift
@@ -19,6 +19,10 @@ let workChatInitialPinCancelDeadband: CGFloat = 16
 let workChatBottomAnchorSpacerHeight: CGFloat = 1
 let workChatContentBottomGutterHeight: CGFloat = 2
 let workChatSubagentActivePopupHeight: CGFloat = 34
+/// The composer chip strip. Its capsules declare `minHeight: 44` for the touch
+/// target, so the row that holds them has to be 44 too — pinning it to 34 was
+/// what squeezed the PR chip's label into an ellipsis.
+let workChatComposerChipRowHeight: CGFloat = 44
 let workChatOlderHistoryTriggerDistance: CGFloat = 240
 let workChatOlderHistoryRearmDistance: CGFloat = 420
 let workChatOlderHistoryScrollableDistance: CGFloat = 1
@@ -456,13 +460,13 @@ struct WorkChatSessionView: View {
   let optimisticPendingSteersRenderSignature: Int
   let localEchoMessages: [WorkLocalEchoMessage]
   let localEchoMessagesRenderSignature: Int
-  let expandedToolCardIdsSnapshot: Set<String>
-  let expandedToolCardIdsRenderSignature: Int
+  let cardExpansionSnapshot: WorkCardExpansionState
+  let cardExpansionRenderSignature: Int
   let artifactContentRenderSignature: Int
   let artifactDrawerPresentedSnapshot: Bool
   let sendingSnapshot: Bool
   let errorMessageSnapshot: String?
-  @Binding var expandedToolCardIds: Set<String>
+  @Binding var cardExpansion: WorkCardExpansionState
   @Binding var artifactContent: [String: WorkLoadedArtifactContent]
   @Binding var fullscreenImage: WorkFullscreenImage?
   @Binding var artifactDrawerPresented: Bool
@@ -579,7 +583,6 @@ struct WorkChatSessionView: View {
   var scheduledWorkSnapshotsRenderSignature: Int = 0
   var selectedSubagentTaskId: String? = nil
   var onOpenChatInfo: (() -> Void)? = nil
-  var onOpenSubagents: (() -> Void)? = nil
   /// Tapping a subagent spawn/result timeline row opens the same detail surface
   /// the Chat Info roster row opens (full transcript takeover or expanded row).
   var onSelectSubagentRow: (@MainActor (WorkSubagentSnapshot) async -> Void)? = nil
@@ -1358,36 +1361,31 @@ struct WorkChatSessionView: View {
         WorkClaudeGoalPill(goal: claudeGoal)
       }
 
-      let subagentCount = subagentSnapshots.count
-      let activeScheduledWorkCount = workScheduledWorkActiveCount(scheduledWorkSnapshots)
-      let showsChatInfoBadge = inputLockMessage == nil && activeScheduledWorkCount > 0 && onOpenChatInfo != nil
-      let showsSubagentBadge = inputLockMessage == nil
-        && subagentCount > 0
-        && onOpenSubagents != nil
+      // One chip per destination. Subagents used to get their own capsule that
+      // opened the very same sheet as Chat Info; the count now covers both.
+      let chatInfoCount = workChatInfoItemCount(
+        subagents: subagentSnapshots,
+        scheduledWork: scheduledWorkSnapshots
+      )
+      let showsChatInfoBadge = inputLockMessage == nil && chatInfoCount > 0 && onOpenChatInfo != nil
       let showsPrBadge = inputLockMessage == nil && prBadge != nil && onOpenPrDetails != nil
-      if showsChatInfoBadge || showsSubagentBadge || showsPrBadge {
-        HStack(spacing: 8) {
-          if showsChatInfoBadge, let onOpenChatInfo {
-            WorkChatInfoActivePopup(count: activeScheduledWorkCount, onOpen: onOpenChatInfo)
-          }
-          if showsSubagentBadge {
-            if subagentCount == 1,
-               let snapshot = subagentSnapshots.first,
-               let onSelectSubagentRow {
-              WorkSubagentActivePopup(count: subagentCount) {
-                Task { await onSelectSubagentRow(snapshot) }
-              }
-            } else if let onOpenSubagents {
-              WorkSubagentActivePopup(count: subagentCount, onOpen: onOpenSubagents)
+      if showsChatInfoBadge || showsPrBadge {
+        // Horizontally scrollable so a future chip can never truncate the ones
+        // beside it — it just scrolls out of reach instead.
+        ScrollView(.horizontal, showsIndicators: false) {
+          HStack(spacing: 8) {
+            if showsChatInfoBadge, let onOpenChatInfo {
+              WorkChatInfoActivePopup(count: chatInfoCount, onOpen: onOpenChatInfo)
+            }
+            if showsPrBadge, let prBadge, let onOpenPrDetails {
+              WorkChatPrActivePopup(badge: prBadge, onOpen: onOpenPrDetails)
             }
           }
-          if showsPrBadge, let prBadge, let onOpenPrDetails {
-            WorkChatPrActivePopup(badge: prBadge, onOpen: onOpenPrDetails)
-          }
-          Spacer(minLength: 0)
+          .padding(.trailing, 8)
         }
+        .scrollBounceBehavior(.basedOnSize, axes: .horizontal)
         .frame(maxWidth: .infinity, alignment: .leading)
-        .frame(height: workChatSubagentActivePopupHeight, alignment: .leading)
+        .frame(height: workChatComposerChipRowHeight, alignment: .leading)
       }
 
       if !pendingSteers.isEmpty {
@@ -1814,6 +1812,14 @@ struct WorkChatSessionView: View {
             unreadBelowCount = 0
           }
         }
+        // The turn ending is the single collapse trigger. Dropping every
+        // override here is what makes the finished turn fold to one line each,
+        // and what stops a "keep this shut while it runs" tap from outliving
+        // the run it was about.
+        .onChange(of: isStreamingTurn) { wasStreaming, isStreaming in
+          guard wasStreaming, !isStreaming else { return }
+          cardExpansion.clearForTurnEnd()
+        }
   }
 
   /// Session lifecycle + input-recovery handlers, split from `body` for type-checker budget.
@@ -2088,15 +2094,6 @@ func workLocalEchoMessagesRenderSignature(_ messages: [WorkLocalEchoMessage]) ->
       hasher.combine(attachment.type)
       hasher.combine(attachment.url)
     }
-  }
-  return hasher.finalize()
-}
-
-func workExpandedToolCardIdsRenderSignature(_ ids: Set<String>) -> Int {
-  var hasher = Hasher()
-  hasher.combine(ids.count)
-  for id in ids.sorted() {
-    hasher.combine(id)
   }
   return hasher.finalize()
 }

--- a/apps/ios/ADE/Views/Work/WorkChatSessionView.swift
+++ b/apps/ios/ADE/Views/Work/WorkChatSessionView.swift
@@ -185,6 +185,97 @@ struct WorkChatContentSizeSample: Equatable {
 /// Number of layout passes a prepend anchor stays armed for.
 let workChatPrependAnchorAttempts = 12
 
+/// What a presentation change does to the prepend anchor.
+enum WorkChatPrependArmDecision: Equatable {
+  case ignore
+  /// A second prepend landed while the first was still being corrected.
+  case extendExistingAnchorWindow
+  /// The anchored row is gone; nothing left to measure against.
+  case retireAnchor
+  case arm(rowId: String, rowY: CGFloat)
+}
+
+/// Decides how a presentation change affects the prepend anchor.
+///
+/// The overlapping-prepend case is the subtle one. The armed anchor rides a row
+/// that BOTH insertions pushed down, so the displacement measured on it already
+/// accumulates them. Re-arming on the new first row would measure only the
+/// second insertion and leave the first uncorrected — the "teleport up" that
+/// back-to-back page loads produced.
+func workChatPrependArmDecision(
+  previousFirstId: String?,
+  nextFirstId: String?,
+  previousVisibleCount: Int,
+  nextVisibleCount: Int,
+  existingAnchorRowId: String?,
+  anchorRowStillVisible: Bool,
+  previousFirstRowStillVisible: Bool,
+  probeRowId: String?,
+  probeRowY: CGFloat?
+) -> WorkChatPrependArmDecision {
+  guard nextVisibleCount > previousVisibleCount,
+        let previousFirstId,
+        nextFirstId != previousFirstId
+  else { return .ignore }
+
+  if existingAnchorRowId != nil {
+    return anchorRowStillVisible ? .extendExistingAnchorWindow : .retireAnchor
+  }
+
+  guard
+    // The probe has to already be measuring the row we are about to anchor on,
+    // or there is no "before" position to restore to.
+    probeRowId == previousFirstId,
+    let probeRowY,
+    // Only a genuine prepend: the row that used to lead the list has to still
+    // be in the list, just further down.
+    previousFirstRowStillVisible
+  else { return .ignore }
+
+  return .arm(rowId: previousFirstId, rowY: probeRowY)
+}
+
+/// What an armed anchor may do on this layout pass.
+enum WorkChatPrependCorrection: Equatable {
+  /// The reader owns the offset. Stay armed and spend no attempt.
+  case wait
+  /// No usable measurement yet. Spend an attempt.
+  case retry
+  /// Undo this much inserted height.
+  case apply(CGFloat)
+}
+
+/// Turns a probe sample into a correction.
+///
+/// The two `retry` cases are what keeps a correction honest. A probe describing
+/// some OTHER row carries no information about the anchored row, and treating a
+/// mismatch as a zero row shift reduces the correction to the reader's own
+/// scroll delta and applies it a second time — a teleport, not a correction.
+func workChatPrependCorrection(
+  anchor: WorkChatPrependAnchor,
+  probed: WorkChatPrependProbeSample?,
+  currentOffsetY: CGFloat,
+  mayWriteScrollOffset: Bool
+) -> WorkChatPrependCorrection {
+  // A correction is a scroll write, so it waits for the reader to let go. The
+  // anchor stays armed and spends no attempt meanwhile: the measurement below
+  // isolates the insertion from the reader's own scrolling, so applying it once
+  // the fling settles restores the same reading position it would have restored
+  // mid-fling — without fighting the fling for the offset.
+  guard mayWriteScrollOffset else { return .wait }
+  guard let probed, probed.rowId == anchor.rowId else { return .retry }
+
+  // The anchored row moves by the height inserted above it *minus* whatever the
+  // reader scrolled in the meantime, because scrolling moves the row up the
+  // screen too. Adding the offset change back isolates the insertion: with an
+  // inserted height H and a user scroll D, the row moves H - D and the offset
+  // moves D, so the sum is H either way — and a pure scroll with no prepend
+  // sums to zero and correctly restores nothing.
+  let insertedHeight = (probed.y - anchor.rowY) + (currentOffsetY - anchor.offsetY)
+  guard insertedHeight > 0.5 else { return .retry }
+  return .apply(insertedHeight)
+}
+
 /// Whether a scroll phase means the reader — not the app — owns the offset.
 ///
 /// `.animating` is deliberately not user-driven: it is the phase our own
@@ -917,44 +1008,37 @@ struct WorkChatSessionView: View {
   /// user was reading slides down by the height of the inserted page.
   @MainActor
   private func armPrependAnchorIfRowsInsertedAbove(_ nextPresentation: WorkTimelinePresentation) {
-    guard nextPresentation.visibleEntries.count > timelinePresentation.visibleEntries.count,
-          let previousFirstId = timelinePresentation.visibleEntries.first?.id,
-          nextPresentation.visibleEntries.first?.id != previousFirstId
-    else { return }
-
-    // Back-to-back prepends. The armed anchor rides a row that BOTH insertions
-    // pushed down, so the displacement it measures already accumulates them —
-    // re-arming on the new first row would instead measure only the second
-    // insertion and leave the first one uncorrected (the "teleport up"). Keep
-    // the existing anchor and only extend the window it may fire in.
-    if var anchor = scrollMetrics.prependAnchor {
-      guard nextPresentation.visibleEntries.contains(where: { $0.id == anchor.rowId }) else {
-        // The anchored row fell out of the list; nothing left to measure
-        // against, so retire it rather than restore to a row that is gone.
-        scrollMetrics.prependAnchor = nil
-        return
-      }
-      anchor.remainingAttempts = workChatPrependAnchorAttempts
-      scrollMetrics.prependAnchor = anchor
+    let previousFirstId = timelinePresentation.visibleEntries.first?.id
+    let existingAnchorRowId = scrollMetrics.prependAnchor?.rowId
+    switch workChatPrependArmDecision(
+      previousFirstId: previousFirstId,
+      nextFirstId: nextPresentation.visibleEntries.first?.id,
+      previousVisibleCount: timelinePresentation.visibleEntries.count,
+      nextVisibleCount: nextPresentation.visibleEntries.count,
+      existingAnchorRowId: existingAnchorRowId,
+      anchorRowStillVisible: existingAnchorRowId.map { rowId in
+        nextPresentation.visibleEntries.contains { $0.id == rowId }
+      } ?? false,
+      previousFirstRowStillVisible: previousFirstId.map { rowId in
+        nextPresentation.visibleEntries.contains { $0.id == rowId }
+      } ?? false,
+      probeRowId: scrollMetrics.probeRowId,
+      probeRowY: scrollMetrics.probeRowY
+    ) {
+    case .ignore:
       return
+    case .extendExistingAnchorWindow:
+      scrollMetrics.prependAnchor?.remainingAttempts = workChatPrependAnchorAttempts
+    case .retireAnchor:
+      scrollMetrics.prependAnchor = nil
+    case .arm(let rowId, let rowY):
+      scrollMetrics.prependAnchor = WorkChatPrependAnchor(
+        rowId: rowId,
+        rowY: rowY,
+        offsetY: scrollMetrics.offsetY,
+        remainingAttempts: workChatPrependAnchorAttempts
+      )
     }
-
-    guard
-      // The probe has to already be measuring the row we are about to anchor
-      // on, or there is no "before" position to restore to.
-      scrollMetrics.probeRowId == previousFirstId,
-      let previousFirstRowY = scrollMetrics.probeRowY
-    else { return }
-    // Only a genuine prepend: the row that used to lead the list has to still be
-    // in the list, just further down.
-    guard nextPresentation.visibleEntries.contains(where: { $0.id == previousFirstId }) else { return }
-
-    scrollMetrics.prependAnchor = WorkChatPrependAnchor(
-      rowId: previousFirstId,
-      rowY: previousFirstRowY,
-      offsetY: scrollMetrics.offsetY,
-      remainingAttempts: workChatPrependAnchorAttempts
-    )
   }
 
   /// Re-applies the reader's position once the prepended rows have laid out.
@@ -966,41 +1050,24 @@ struct WorkChatSessionView: View {
   func restorePrependAnchorIfNeeded(probed: WorkChatPrependProbeSample?) {
     guard var anchor = scrollMetrics.prependAnchor else { return }
 
-    // A correction is a scroll write, so it waits for the reader to let go.
-    // The anchor stays armed (and does not burn an attempt) meanwhile: the
-    // measurement below isolates the insertion from the reader's own scrolling,
-    // so applying it after the fling settles restores the same reading position
-    // it would have restored mid-fling — without fighting the fling for the
-    // offset, which is what double-applied the reader's own scroll.
-    guard workChatMayWriteScrollOffset(
-      dragActive: timelineDragActive,
-      scrollPhaseUserDriven: timelineScrollPhaseUserDriven
-    ) else { return }
-
-    // No usable measurement for THIS anchor: the probe is describing some other
-    // row (it moved with a recompose, or the anchored row was recycled out of
-    // the LazyVStack). Bail out rather than fall through with a zero row shift —
-    // that reduces the correction to the reader's own scroll delta and applies
-    // it a second time, which is a teleport, not a correction.
-    guard let probed, probed.rowId == anchor.rowId else {
+    let insertedHeight: CGFloat
+    switch workChatPrependCorrection(
+      anchor: anchor,
+      probed: probed,
+      currentOffsetY: scrollMetrics.offsetY,
+      mayWriteScrollOffset: workChatMayWriteScrollOffset(
+        dragActive: timelineDragActive,
+        scrollPhaseUserDriven: timelineScrollPhaseUserDriven
+      )
+    ) {
+    case .wait:
+      return
+    case .retry:
       anchor.remainingAttempts -= 1
       scrollMetrics.prependAnchor = anchor.remainingAttempts > 0 ? anchor : nil
       return
-    }
-
-    // The anchored row moves by the height inserted above it *minus* whatever
-    // the reader scrolled in the meantime, because scrolling moves the row up
-    // the screen too. Adding the offset change back isolates the insertion:
-    // with an inserted height H and a user scroll D, the row moves H - D and the
-    // offset moves D, so the sum is H either way — and a pure scroll with no
-    // prepend sums to zero and correctly restores nothing.
-    let rowShift = probed.y - anchor.rowY
-    let scrolled = scrollMetrics.offsetY - anchor.offsetY
-    let insertedHeight = rowShift + scrolled
-    guard insertedHeight > 0.5 else {
-      anchor.remainingAttempts -= 1
-      scrollMetrics.prependAnchor = anchor.remainingAttempts > 0 ? anchor : nil
-      return
+    case .apply(let height):
+      insertedHeight = height
     }
 
     scrollMetrics.prependAnchor = nil

--- a/apps/ios/ADE/Views/Work/WorkChatSessionView.swift
+++ b/apps/ios/ADE/Views/Work/WorkChatSessionView.swift
@@ -452,6 +452,8 @@ struct WorkChatSessionView: View {
   let chatSummaryContext: WorkChatSummaryRenderContext
   let transcript: [WorkChatEnvelope]
   let transcriptRenderSignature: Int
+  let allowsIncrementalTranscriptUpdate: Bool
+  @Binding var transcriptIncrementalDelta: [WorkChatEnvelope]
   let fallbackEntries: [AgentChatTranscriptEntry]
   let fallbackEntriesRenderSignature: Int
   let artifacts: [ComputerUseArtifactSummary]
@@ -942,9 +944,14 @@ struct WorkChatSessionView: View {
   }
 
   @MainActor
-  func refreshTimelinePresentation(sourceTimeline: [WorkTimelineEntry]? = nil) {
+  func refreshTimelinePresentation(
+    sourceTimeline: [WorkTimelineEntry]? = nil,
+    rebuildToolActivityIndex: Bool = true
+  ) {
     let timeline = sourceTimeline ?? timelineSnapshot.timeline
-    turnToolActivity = workTurnToolActivityIndex(from: timeline)
+    if rebuildToolActivityIndex {
+      turnToolActivity = workTurnToolActivityIndex(from: timeline)
+    }
     let presentedTimeline = workPresentedTimelineEntries(timeline)
     var budgetFloors = assistantBudgetFloors
     var nextPresentation = makeWorkTimelinePresentation(
@@ -2424,6 +2431,7 @@ private func workTimelinePresentationSignature(
       hasher.combine(model.totalLineCount)
       hasher.combine(model.canShowMore)
       hasher.combine(model.nextLineBudget)
+      hasher.combine(model.willRemainTruncatedAfterNextStep)
     }
   }
   return hasher.finalize()
@@ -2642,7 +2650,11 @@ func workTimelineRenderEntries(
       ))
     } else {
       let blocks = message.id == streamingAssistantMessageId
-        ? parseMarkdownBlocksForStreaming(preview.text, cacheKey: "\(message.id):preview")
+        ? parseMarkdownBlocksForStreaming(
+          preview.text,
+          cacheKey: "\(message.id):preview",
+          appendOnly: true
+        )
         : parseMarkdownBlocks(preview.text)
       rendered.reserveCapacity(rendered.count + blocks.count + (preview.isTruncated ? 1 : 0))
       let streamingTailBlockId = message.id == streamingAssistantMessageId ? blocks.last?.id : nil
@@ -2689,6 +2701,10 @@ func workTimelineRenderEntries(
         // message is rendered and this branch stops running.
         canShowMore: true,
         nextLineBudget: nextLineBudget,
+        willRemainTruncatedAfterNextStep: workAssistantMessageWillRemainTruncated(
+          preview,
+          nextLineBudget: nextLineBudget
+        ),
         // Only an explicit tap writes this map, so its presence *is* "the
         // reader already expanded this message once".
         hasExpandedInPlace: assistantLineBudgets[message.id] != nil

--- a/apps/ios/ADE/Views/Work/WorkChatSessionView.swift
+++ b/apps/ios/ADE/Views/Work/WorkChatSessionView.swift
@@ -1396,6 +1396,7 @@ struct WorkChatSessionView: View {
           drafts: $steerEditDrafts,
           busy: actionInFlight,
           isLive: isLive,
+          turnActive: sessionStatus == "active",
           onCancel: { steerId in
             await runSessionAction {
               await onCancelSteer(steerId)
@@ -2849,6 +2850,22 @@ private struct WorkChatComposerDraftInput: View {
     activeSendModesAvailable && activeSendCapability.modes.count > 1
   }
 
+  /// Where this chat's remembered send mode lives. Blank for the projectless
+  /// "new chat" composers, which have no session to remember against.
+  private var activeSendModeStorageKey: String {
+    WorkActiveSendModeStore.chatKey(sessionId: sessionId)
+  }
+
+  /// Restores the remembered mode for this chat, falling back to the provider
+  /// default when nothing is stored or the stored mode is one this provider
+  /// cannot honor.
+  private func restoreActiveSendMode() {
+    let remembered = WorkActiveSendModeStore.load(activeSendModeStorageKey)
+    activeSendMode = remembered.flatMap { mode in
+      activeSendCapability.modes.contains(mode) ? mode : nil
+    } ?? activeSendCapability.defaultMode
+  }
+
   private var activeSendAgentLabel: String { activeSendCapability.agentLabel }
 
   private var activeSendInterruptContinues: Bool { activeSendCapability.interruptContinues }
@@ -2972,7 +2989,7 @@ private struct WorkChatComposerDraftInput: View {
       stopMode = UserDefaults.standard.string(forKey: "\(draftPersistenceKey).stopMode") == AgentChatStopMode.stopOnly.rawValue
         ? .stopOnly
         : .stopAndClear
-      activeSendMode = activeSendCapability.defaultMode
+      restoreActiveSendMode()
       sendOptionsPresented = false
       stopOptionsPresented = false
       draftState.bind(persistenceKey: draftPersistenceKey)
@@ -2983,13 +3000,18 @@ private struct WorkChatComposerDraftInput: View {
     // The 400ms autosave debounce can't survive a navigation pop; flush here so
     // backing out of a chat mid-sentence keeps the sentence.
     .onDisappear { draftState.flushDraft() }
+    // A turn starting or ending is not a change of intent: the mode the user
+    // picked survives it, and only the transient popovers close.
     .onChange(of: showInterrupt) { _, _ in
-      activeSendMode = activeSendCapability.defaultMode
       sendOptionsPresented = false
       stopOptionsPresented = false
     }
+    // A provider change is: the new runtime may have no inline channel at all,
+    // so anything it cannot honor snaps back to that provider's default.
     .onChange(of: chatSummary.provider) { _, _ in
-      activeSendMode = activeSendCapability.defaultMode
+      if !activeSendCapability.modes.contains(activeSendMode) {
+        activeSendMode = activeSendCapability.defaultMode
+      }
       sendOptionsPresented = false
       stopOptionsPresented = false
       configureSuggestionController()
@@ -3134,6 +3156,7 @@ private struct WorkChatComposerDraftInput: View {
   private func activeSendOption(mode: WorkActiveSendMode, title: String, detail: String, systemImage: String) -> some View {
     Button {
       activeSendMode = mode
+      WorkActiveSendModeStore.save(mode, for: activeSendModeStorageKey)
       sendOptionsPresented = false
     } label: {
       HStack(alignment: .top, spacing: 10) {

--- a/apps/ios/ADE/Views/Work/WorkChatSessionView.swift
+++ b/apps/ios/ADE/Views/Work/WorkChatSessionView.swift
@@ -2431,6 +2431,19 @@ private func workTimelinePresentationSignature(
 /// Prefers the digest the snapshot fold stamped on the message; only messages
 /// built outside the fold pay to hash their text here.
 private func workTimelineCombineMessageTextSignature(_ message: WorkChatMessage, into hasher: inout Hasher) {
+  hasher.combine(message.markdownRevision)
+
+  // Live assistant deltas already carry a monotonic revision and exact
+  // character metadata. Do not count or hash the growing response here: this
+  // helper runs as part of the presentation signature on every streaming
+  // refresh. The revision is the authoritative invalidation token; the count
+  // only keeps the signature useful when a caller inspects it while a message
+  // is being assembled.
+  if message.markdownRevision > 0 {
+    hasher.combine(message.markdownCharacterCount)
+    return
+  }
+
   hasher.combine(message.markdown.utf8.count)
   if let digest = message.markdownDigest {
     hasher.combine(digest)
@@ -2614,7 +2627,7 @@ func workTimelineRenderEntries(
         itemId: message.itemId,
         text: preview.text,
         accessibilityLabel: accessibilityLabel,
-        sourceDigest: message.markdownDigest ?? ""
+        sourceDigest: "\(message.markdownDigest ?? ""):\(message.markdownRevision)",
       )
       rendered.append(WorkTimelineRenderEntry(
         id: model.id,

--- a/apps/ios/ADE/Views/Work/WorkChatSessionView.swift
+++ b/apps/ios/ADE/Views/Work/WorkChatSessionView.swift
@@ -945,10 +945,7 @@ struct WorkChatSessionView: View {
   func refreshTimelinePresentation(sourceTimeline: [WorkTimelineEntry]? = nil) {
     let timeline = sourceTimeline ?? timelineSnapshot.timeline
     turnToolActivity = workTurnToolActivityIndex(from: timeline)
-    let presentedTimeline = timeline.filter { entry in
-      if case .toolGroup = entry.payload { return false }
-      return true
-    }
+    let presentedTimeline = workPresentedTimelineEntries(timeline)
     var budgetFloors = assistantBudgetFloors
     var nextPresentation = makeWorkTimelinePresentation(
       timeline: presentedTimeline,

--- a/apps/ios/ADE/Views/Work/WorkChatSessionView.swift
+++ b/apps/ios/ADE/Views/Work/WorkChatSessionView.swift
@@ -2404,11 +2404,6 @@ private func workTimelinePresentationSignature(
   return hasher.finalize()
 }
 
-private func workTimelineCombineTextSignature(_ text: String, into hasher: inout Hasher) {
-  hasher.combine(text.utf8.count)
-  hasher.combine(text.hashValue)
-}
-
 /// Prefers the digest the snapshot fold stamped on the message; only messages
 /// built outside the fold pay to hash their text here.
 private func workTimelineCombineMessageTextSignature(_ message: WorkChatMessage, into hasher: inout Hasher) {

--- a/apps/ios/ADE/Views/Work/WorkChatSessionView.swift
+++ b/apps/ios/ADE/Views/Work/WorkChatSessionView.swift
@@ -399,6 +399,13 @@ struct WorkChatSessionView: View {
   @State var assistantPreviewCache = WorkAssistantPreviewCache()
   @State var contextUsageViewModelCache = WorkContextUsageViewModelCache()
   @State var assistantLineBudgets: [String: Int] = [:]
+  /// Largest budget each assistant message has already rendered under. A budget
+  /// may grow but never shrink, so "Show more" cannot appear on a message the
+  /// reader already read in full.
+  @State var assistantBudgetFloors: [String: Int] = [:]
+  /// Messages the reader expanded. They read from the top from then on, so a
+  /// tap does not swap the visible slice for the other end of the message.
+  @State var assistantHeadAnchorOverrides: Set<String> = []
   @State var composerSettingMutationInFlight = false
   @State var composerSettingMutationGeneration = 0
   @State var pendingCodexFastMode: Bool?
@@ -833,6 +840,7 @@ struct WorkChatSessionView: View {
       if case .toolGroup = entry.payload { return false }
       return true
     }
+    var budgetFloors = assistantBudgetFloors
     var nextPresentation = makeWorkTimelinePresentation(
       timeline: presentedTimeline,
       visibleCount: visibleTimelineCount,
@@ -840,6 +848,8 @@ struct WorkChatSessionView: View {
       transcript: transcript,
       assistantPreviewCache: assistantPreviewCache,
       assistantLineBudgets: assistantLineBudgets,
+      assistantBudgetFloors: &budgetFloors,
+      assistantHeadAnchorOverrides: assistantHeadAnchorOverrides,
       streamingAssistantMessageId: streamingAssistantMessageId
     )
     let timelineDelta = nextPresentation.timelineCount - timelinePresentation.timelineCount
@@ -862,8 +872,13 @@ struct WorkChatSessionView: View {
         transcript: transcript,
         assistantPreviewCache: assistantPreviewCache,
         assistantLineBudgets: assistantLineBudgets,
+        assistantBudgetFloors: &budgetFloors,
+        assistantHeadAnchorOverrides: assistantHeadAnchorOverrides,
         streamingAssistantMessageId: streamingAssistantMessageId
       )
+    }
+    if budgetFloors != assistantBudgetFloors {
+      assistantBudgetFloors = budgetFloors
     }
     guard nextPresentation != timelinePresentation else { return }
     armPrependAnchorIfRowsInsertedAbove(nextPresentation)
@@ -1751,6 +1766,8 @@ struct WorkChatSessionView: View {
           optimisticallyAnsweredInputIds.removeAll()
           collapsedPendingInputId = nil
           assistantLineBudgets.removeAll()
+          assistantBudgetFloors.removeAll()
+          assistantHeadAnchorOverrides.removeAll()
           composerSettingMutationInFlight = false
           composerSettingMutationGeneration &+= 1
           resetScrollStateForCurrentSession(reason: "session-change")
@@ -2185,6 +2202,8 @@ private func makeWorkTimelinePresentation(
   transcript: [WorkChatEnvelope],
   assistantPreviewCache: WorkAssistantPreviewCache,
   assistantLineBudgets: [String: Int],
+  assistantBudgetFloors: inout [String: Int],
+  assistantHeadAnchorOverrides: Set<String>,
   streamingAssistantMessageId: String?
 ) -> WorkTimelinePresentation {
   let rawVisibleEntries = visibleWorkTimelineEntries(from: timeline, visibleCount: visibleCount)
@@ -2195,17 +2214,22 @@ private func makeWorkTimelinePresentation(
     modelId: chatSummary.modelId,
     transcript: transcript
   )
+  var resolvedLineBudgets: [String: Int] = [:]
   let visibleEntries = workTimelineEntriesWithAssistantPreviews(
     visibleEntriesWithSeparators,
     cache: assistantPreviewCache,
     assistantLineBudgets: assistantLineBudgets,
+    assistantBudgetFloors: &assistantBudgetFloors,
+    assistantHeadAnchorOverrides: assistantHeadAnchorOverrides,
+    resolvedLineBudgets: &resolvedLineBudgets,
     tailAnchoredAssistantMessageId: workLatestAssistantMessageId(in: timeline)
   )
   let renderEntries = workTimelineRenderEntries(
     from: visibleEntries,
     streamingAssistantMessageId: streamingAssistantMessageId,
     splitAssistantMessageId: workLatestAssistantMessageId(in: timeline),
-    assistantLineBudgets: assistantLineBudgets
+    assistantLineBudgets: assistantLineBudgets,
+    resolvedAssistantLineBudgets: resolvedLineBudgets
   )
   let hiddenCount = max(timeline.count - rawVisibleEntries.count, 0)
   return WorkTimelinePresentation(
@@ -2268,24 +2292,38 @@ private func workTimelinePresentationSignature(
         hasher.combine(message.unprocessedResolution?.action)
         hasher.combine(message.unprocessedResolution?.state)
         hasher.combine(message.unprocessedResolution?.resolvedAt)
-        workTimelineCombineTextSignature(message.markdown, into: &hasher)
+        workTimelineCombineMessageTextSignature(message, into: &hasher)
         if let preview = message.assistantPreview {
-          workTimelineCombineTextSignature(preview.text, into: &hasher)
+          // A preview is a pure function of (message text, anchor, budget), and
+          // the text is already in this hash. Its shape is enough to separate
+          // two previews of the same message — no need to hash the slice, which
+          // is O(message) on every refresh.
           hasher.combine(preview.isTruncated)
+          hasher.combine(preview.anchor)
           hasher.combine(preview.visibleLineCount)
           hasher.combine(preview.totalLineCount)
+          hasher.combine(preview.visibleCharacterCount)
+          hasher.combine(preview.usesMonospacedRendering)
         }
       }
     case .assistantMarkdownBlock(let model):
       hasher.combine(model.id)
       hasher.combine(model.messageId)
       hasher.combine(model.block.id)
-      workTimelineCombineTextSignature(model.block.kind.cacheKey, into: &hasher)
+      // The block's own precomputed digest, not a rebuilt `kind.cacheKey`:
+      // building that key allocates a full copy of the block's text, once per
+      // block, on every presentation refresh.
+      hasher.combine(model.block.digest)
+      hasher.combine(model.isStreamingTail)
     case .assistantMonospaced(let model):
       hasher.combine(model.id)
       hasher.combine(model.messageId)
-      workTimelineCombineTextSignature(model.text, into: &hasher)
-      workTimelineCombineTextSignature(model.accessibilityLabel, into: &hasher)
+      // Digest of the source message plus the size of the slice taken from it:
+      // together these change whenever the rendered text does, without hashing
+      // the (potentially very long) slice itself.
+      hasher.combine(model.sourceDigest)
+      hasher.combine(model.text.utf8.count)
+      hasher.combine(model.accessibilityLabel)
     case .assistantControls(let model):
       hasher.combine(model.id)
       hasher.combine(model.messageId)
@@ -2304,10 +2342,63 @@ private func workTimelineCombineTextSignature(_ text: String, into hasher: inout
   hasher.combine(text.hashValue)
 }
 
+/// Prefers the digest the snapshot fold stamped on the message; only messages
+/// built outside the fold pay to hash their text here.
+private func workTimelineCombineMessageTextSignature(_ message: WorkChatMessage, into hasher: inout Hasher) {
+  hasher.combine(message.markdown.utf8.count)
+  if let digest = message.markdownDigest {
+    hasher.combine(digest)
+  } else {
+    hasher.combine(message.markdown.hashValue)
+  }
+}
+
+/// What a message renders under this pass: how much of it, and from which end.
+struct WorkAssistantRenderBudget: Equatable {
+  let lineBudget: Int
+  let anchor: WorkAssistantMessagePreviewAnchor
+}
+
+/// The budget rule, as one pure decision.
+///
+/// The contract it enforces is that a budget never shrinks. The newest assistant
+/// message renders tail-anchored under a generous budget so a finishing turn is
+/// readable in place; the moment a newer message arrives it becomes head-
+/// anchored, and *that* used to drop it back to the 48-line budget — so a
+/// message the reader had just read in full grew a "Show more" behind their
+/// back. The budget it already rendered under becomes its floor instead.
+///
+/// - Parameters:
+///   - userLineBudget: what "Show more" has asked for, nil if untouched.
+///   - floorLineBudget: the largest budget this message has already rendered under.
+///   - isTail: this is the newest assistant message in the timeline.
+///   - headAnchorOverride: the reader expanded this message, so it reads from
+///     the top from now on even while it is still the tail.
+///   - tailCanRenderFull: the whole message fits within the tail-full budgets.
+func workAssistantRenderBudget(
+  userLineBudget: Int?,
+  floorLineBudget: Int?,
+  isTail: Bool,
+  headAnchorOverride: Bool,
+  tailCanRenderFull: Bool
+) -> WorkAssistantRenderBudget {
+  var floor = max(floorLineBudget ?? 0, workAssistantMessageInitialLineBudget)
+  if isTail, tailCanRenderFull {
+    floor = max(floor, workAssistantMessageTailFullLineBudget)
+  }
+  return WorkAssistantRenderBudget(
+    lineBudget: max(userLineBudget ?? 0, floor),
+    anchor: (isTail && !headAnchorOverride) ? .tail : .head
+  )
+}
+
 private func workTimelineEntriesWithAssistantPreviews(
   _ entries: [WorkTimelineEntry],
   cache: WorkAssistantPreviewCache,
   assistantLineBudgets: [String: Int],
+  assistantBudgetFloors: inout [String: Int],
+  assistantHeadAnchorOverrides: Set<String>,
+  resolvedLineBudgets: inout [String: Int],
   tailAnchoredAssistantMessageId: String?
 ) -> [WorkTimelineEntry] {
   var visibleAssistantMessageIds = Set<String>()
@@ -2317,26 +2408,36 @@ private func workTimelineEntriesWithAssistantPreviews(
     else { return entry }
 
     visibleAssistantMessageIds.insert(message.id)
-    let previewAnchor: WorkAssistantMessagePreviewAnchor = message.id == tailAnchoredAssistantMessageId ? .tail : .head
-    let baselinePreview = cache.preview(for: message, anchor: previewAnchor)
-    let tailCanRenderFull = previewAnchor == .tail
+    let isTail = message.id == tailAnchoredAssistantMessageId
+    let headAnchorOverride = assistantHeadAnchorOverrides.contains(message.id)
+    let baselineAnchor: WorkAssistantMessagePreviewAnchor = (isTail && !headAnchorOverride) ? .tail : .head
+    let baselinePreview = cache.preview(for: message, anchor: baselineAnchor)
+    let tailCanRenderFull = baselineAnchor == .tail
       && !baselinePreview.usesMonospacedRendering
       && baselinePreview.totalLineCount <= workAssistantMessageTailFullLineBudget
       && baselinePreview.totalCharacterCount <= workAssistantMessageTailFullCharacterBudget
-    let lineBudget = assistantLineBudgets[message.id]
-      ?? (tailCanRenderFull ? workAssistantMessageTailFullLineBudget : workAssistantMessageInitialLineBudget)
-    let characterBudget = workAssistantMessageCharacterBudget(
-      forLineBudget: lineBudget,
-      tailCanRenderFull: tailCanRenderFull && assistantLineBudgets[message.id] == nil
+    let budget = workAssistantRenderBudget(
+      userLineBudget: assistantLineBudgets[message.id],
+      floorLineBudget: assistantBudgetFloors[message.id],
+      isTail: isTail,
+      headAnchorOverride: headAnchorOverride,
+      tailCanRenderFull: tailCanRenderFull
     )
-    if lineBudget == workAssistantMessageInitialLineBudget {
+    // Persist the floor so the flip to head-anchoring cannot take back what the
+    // reader could already see.
+    if budget.lineBudget > (assistantBudgetFloors[message.id] ?? 0) {
+      assistantBudgetFloors[message.id] = budget.lineBudget
+    }
+    resolvedLineBudgets[message.id] = budget.lineBudget
+
+    if budget.lineBudget == workAssistantMessageInitialLineBudget, budget.anchor == baselineAnchor {
       message.assistantPreview = baselinePreview
     } else {
-      message.assistantPreview = workAssistantMessagePreview(
-        message.markdown,
-        lineBudget: lineBudget,
-        characterBudget: characterBudget,
-        anchor: previewAnchor,
+      message.assistantPreview = cache.preview(
+        for: message,
+        anchor: budget.anchor,
+        lineBudget: budget.lineBudget,
+        characterBudget: workAssistantMessageCharacterBudget(forLineBudget: budget.lineBudget),
         classification: baselinePreview.usesMonospacedRendering
       )
     }
@@ -2348,6 +2449,10 @@ private func workTimelineEntriesWithAssistantPreviews(
     )
   }
   cache.prune(keeping: visibleAssistantMessageIds)
+  // Floors are deliberately NOT pruned with the preview cache. A message that
+  // leaves the paged window and is revealed again by scroll-back must come back
+  // rendered the way the reader last saw it. The map holds one small entry per
+  // assistant message seen in this session and is dropped on session change.
   return hydratedEntries
 }
 
@@ -2365,7 +2470,11 @@ func workTimelineRenderEntries(
   from entries: [WorkTimelineEntry],
   streamingAssistantMessageId: String?,
   splitAssistantMessageId: String? = nil,
-  assistantLineBudgets: [String: Int] = [:]
+  assistantLineBudgets: [String: Int] = [:],
+  /// Budget each message actually rendered under, after floors were applied.
+  /// "Show more" has to step from this, not from the raw request, or the first
+  /// tap on a message held at a floor would step backwards.
+  resolvedAssistantLineBudgets: [String: Int] = [:]
 ) -> [WorkTimelineRenderEntry] {
   var rendered: [WorkTimelineRenderEntry] = []
   rendered.reserveCapacity(entries.count)
@@ -2398,7 +2507,10 @@ func workTimelineRenderEntries(
       continue
     }
 
-    let requestedLineBudget = assistantLineBudgets[message.id] ?? workAssistantMessageInitialLineBudget
+    let requestedLineBudget = max(
+      resolvedAssistantLineBudgets[message.id] ?? 0,
+      assistantLineBudgets[message.id] ?? workAssistantMessageInitialLineBudget
+    )
     // One bounded step per tap, with no ceiling. A 1000-line answer is reached
     // by tapping "Show more" until it is all here; the reader is never left
     // with a truncated message and no way to see the rest.
@@ -2415,7 +2527,8 @@ func workTimelineRenderEntries(
         turnId: message.turnId,
         itemId: message.itemId,
         text: preview.text,
-        accessibilityLabel: accessibilityLabel
+        accessibilityLabel: accessibilityLabel,
+        sourceDigest: message.markdownDigest ?? ""
       )
       rendered.append(WorkTimelineRenderEntry(
         id: model.id,

--- a/apps/ios/ADE/Views/Work/WorkChatSessionView.swift
+++ b/apps/ios/ADE/Views/Work/WorkChatSessionView.swift
@@ -67,15 +67,19 @@ func workChatTranscriptFailureMessage(_ message: String) -> String {
   return trimmed
 }
 
+/// `distanceFromTop` is how far the reader has scrolled from the first row, so
+/// it grows downward — the inverse of the geometry-probe `topY` this used to
+/// take, which was published from a per-frame `GeometryReader` riding the
+/// header row.
 func workChatShouldRequestOlderHistory(
-  topY: CGFloat,
+  distanceFromTop: CGFloat,
   triggerArmed: Bool,
   loading: Bool,
   hasError: Bool,
   hasBufferedEntries: Bool,
   hasHostHistory: Bool
 ) -> Bool {
-  topY >= -workChatOlderHistoryTriggerDistance
+  distanceFromTop <= workChatOlderHistoryTriggerDistance
     && triggerArmed
     && !loading
     && !hasError
@@ -130,13 +134,48 @@ final class WorkChatScrollMetrics {
 
 /// The scroll geometry the transcript reacts to, rounded so sub-pixel jitter
 /// doesn't wake the observer.
+///
+/// Everything the transcript needs about its position is derived here, from the
+/// one sample the scroll view already produces. The content-top and
+/// content-bottom `GeometryReader` + `PreferenceKey` probes this replaced
+/// measured the same two numbers by laying out two extra views and running the
+/// preference reduce/observe machinery on every frame of every scroll.
 struct WorkChatScrollGeometrySample: Equatable {
   let offsetY: CGFloat
   /// Largest in-range content offset, used only to clamp a restore.
   let scrollableHeight: CGFloat
+  /// Distance scrolled past the first row. 0 at the very top.
+  let distanceFromTop: CGFloat
+  /// Distance still to scroll to reach the last row. 0 at the very bottom.
+  let distanceFromBottom: CGFloat
+  let containerHeight: CGFloat
 
   init(_ geometry: ScrollGeometry) {
     self.offsetY = (geometry.contentOffset.y * 2).rounded() / 2
+    let scrollable = geometry.contentSize.height - geometry.containerSize.height
+      + geometry.contentInsets.top + geometry.contentInsets.bottom
+    self.scrollableHeight = max(0, (scrollable * 2).rounded() / 2)
+    // Content insets shift `contentOffset` so that resting at the top reads as
+    // `-contentInsets.top`; adding it back puts both distances on the same
+    // inset-free 0…scrollableHeight range.
+    let position = geometry.contentOffset.y + geometry.contentInsets.top
+    self.distanceFromTop = max(0, (position * 2).rounded() / 2)
+    self.distanceFromBottom = max(0, self.scrollableHeight - self.distanceFromTop)
+    self.containerHeight = geometry.containerSize.height
+  }
+}
+
+/// The transcript's content size, sampled separately from the per-frame scroll
+/// position so layout-driven work (the opening pin, the short-transcript
+/// alignment) runs on content changes instead of on every scroll frame.
+struct WorkChatContentSizeSample: Equatable {
+  let contentHeight: CGFloat
+  let scrollableHeight: CGFloat
+
+  var contentFitsViewport: Bool { scrollableHeight <= 0.5 }
+
+  init(_ geometry: ScrollGeometry) {
+    self.contentHeight = (geometry.contentSize.height * 2).rounded() / 2
     let scrollable = geometry.contentSize.height - geometry.containerSize.height
       + geometry.contentInsets.top + geometry.contentInsets.bottom
     self.scrollableHeight = max(0, (scrollable * 2).rounded() / 2)
@@ -1092,14 +1131,6 @@ struct WorkChatSessionView: View {
         }
       }
       .font(.footnote.weight(.semibold))
-      .background(
-        GeometryReader { geometry in
-          Color.clear.preference(
-            key: WorkChatContentTopPreferenceKey.self,
-            value: geometry.frame(in: .named(workChatScrollCoordinateSpace)).minY
-          )
-        }
-      )
     }
 
     if timeline.isEmpty {
@@ -1430,14 +1461,6 @@ struct WorkChatSessionView: View {
               .transaction { transaction in
                 transaction.animation = nil
               }
-              .background(
-                GeometryReader { geometry in
-                  Color.clear.preference(
-                    key: WorkChatContentBottomPreferenceKey.self,
-                    value: geometry.frame(in: .named(workChatScrollCoordinateSpace)).maxY
-                  )
-                }
-              )
           }
           .padding(16)
           .frame(
@@ -1479,10 +1502,26 @@ struct WorkChatSessionView: View {
           .onScrollGeometryChange(for: WorkChatScrollGeometrySample.self) { geometry in
             WorkChatScrollGeometrySample(geometry)
           } action: { _, sample in
-            // Recorded into a reference box, not @State: this fires per scroll
-            // frame and must not invalidate the transcript.
+            // Fires per scroll frame. Everything here is O(1) and writes to a
+            // reference box or to state that only changes at a threshold — no
+            // list scans, and nothing that invalidates the transcript per frame.
             scrollMetrics.offsetY = sample.offsetY
             scrollMetrics.scrollableHeight = sample.scrollableHeight
+            guard sample.containerHeight > 1 else { return }
+            updateBottomStickiness(distanceFromBottom: sample.distanceFromBottom, proxy: proxy)
+            continueAutomaticOlderHistoryIfNeeded()
+            requestOlderHistoryIfScrolledNearTop(distanceFromTop: sample.distanceFromTop)
+          }
+          // Content SIZE changes only — this observer never fires while the
+          // reader is merely scrolling, which is what keeps the tail scan in
+          // `resolvePendingInitialBottomPinAfterLayout` off the scroll path.
+          .onScrollGeometryChange(for: WorkChatContentSizeSample.self) { geometry in
+            WorkChatContentSizeSample(geometry)
+          } action: { _, sample in
+            if transcriptContentFitsViewport != sample.contentFitsViewport {
+              transcriptContentFitsViewport = sample.contentFitsViewport
+            }
+            resolvePendingInitialBottomPinAfterLayout(proxy, reason: "content-size")
           }
           .coordinateSpace(name: workChatScrollCoordinateSpace)
           .background(
@@ -1595,30 +1634,26 @@ struct WorkChatSessionView: View {
           guard isNearBottom else { return }
           pinToLatestAfterLayout(proxy, reason: "composer-height")
         }
-        .onPreferenceChange(WorkChatContentBottomPreferenceKey.self) { bottomY in
-          guard scrollViewportHeight > 1 else { return }
-          updateBottomStickiness(
-            distanceFromBottom: max(0, bottomY - scrollViewportHeight),
-            proxy: proxy
-          )
-          continueAutomaticOlderHistoryIfNeeded()
-          resolvePendingInitialBottomPinAfterLayout(proxy, reason: "content-bottom")
-        }
-        .onPreferenceChange(WorkChatContentTopPreferenceKey.self) { topY in
-          if topY < -workChatOlderHistoryRearmDistance {
-            olderHistoryTriggerArmed = true
-          }
-          guard workChatShouldRequestOlderHistory(
-            topY: topY,
-            triggerArmed: olderHistoryTriggerArmed,
-            loading: olderHistoryLoadInFlight,
-            hasError: olderHistoryLoadError != nil,
-            hasBufferedEntries: hiddenTimelineCount > 0,
-            hasHostHistory: canRequestOlderTranscriptHistory
-          ) else { return }
-          olderHistoryTriggerArmed = false
-          requestEarlierTimelineEntries(automatically: true)
-        }
+  }
+
+  /// Older-history scroll-back trigger, driven by the shared scroll sample.
+  @MainActor
+  private func requestOlderHistoryIfScrolledNearTop(distanceFromTop: CGFloat) {
+    if distanceFromTop > workChatOlderHistoryRearmDistance {
+      if !olderHistoryTriggerArmed {
+        olderHistoryTriggerArmed = true
+      }
+    }
+    guard workChatShouldRequestOlderHistory(
+      distanceFromTop: distanceFromTop,
+      triggerArmed: olderHistoryTriggerArmed,
+      loading: olderHistoryLoadInFlight,
+      hasError: olderHistoryLoadError != nil,
+      hasBufferedEntries: hiddenTimelineCount > 0,
+      hasHostHistory: canRequestOlderTranscriptHistory
+    ) else { return }
+    olderHistoryTriggerArmed = false
+    requestEarlierTimelineEntries(automatically: true)
   }
 
   /// Timeline/scroll change handlers, split from `body` for type-checker budget.
@@ -2074,22 +2109,6 @@ private struct WorkChatComposerLayoutHeightPreferenceKey: PreferenceKey {
   static func reduce(value: inout CGFloat, nextValue: () -> CGFloat) {
     let next = nextValue()
     if next > 0 { value = next }
-  }
-}
-
-private struct WorkChatContentBottomPreferenceKey: PreferenceKey {
-  static var defaultValue: CGFloat = 0
-
-  static func reduce(value: inout CGFloat, nextValue: () -> CGFloat) {
-    value = nextValue()
-  }
-}
-
-private struct WorkChatContentTopPreferenceKey: PreferenceKey {
-  static var defaultValue: CGFloat = -CGFloat.greatestFiniteMagnitude
-
-  static func reduce(value: inout CGFloat, nextValue: () -> CGFloat) {
-    value = max(value, nextValue())
   }
 }
 

--- a/apps/ios/ADE/Views/Work/WorkChatSessionView.swift
+++ b/apps/ios/ADE/Views/Work/WorkChatSessionView.swift
@@ -497,6 +497,9 @@ struct WorkChatSessionView: View {
   /// Messages the reader expanded. They read from the top from then on, so a
   /// tap does not swap the visible slice for the other end of the message.
   @State var assistantHeadAnchorOverrides: Set<String> = []
+  /// One presentation host for every box in this transcript. Boxes reach it
+  /// through `\.workOutputViewer` rather than each carrying its own cover.
+  @StateObject var outputViewer = WorkOutputViewerModel()
   @State var composerSettingMutationInFlight = false
   @State var composerSettingMutationGeneration = 0
   @State var pendingCodexFastMode: Bool?
@@ -1887,6 +1890,10 @@ struct WorkChatSessionView: View {
     content
         .sensoryFeedback(.impact(weight: .light), trigger: blockingPendingHapticToken)
         .sensoryFeedback(.impact(weight: .light), trigger: quotaCardHapticToken)
+        .environment(\.workOutputViewer, outputViewer)
+        .fullScreenCover(item: $outputViewer.request) { request in
+          WorkOutputViewerScreen(request: request)
+        }
         .sheet(isPresented: $artifactDrawerPresented) {
           WorkArtifactDrawerSheet(
             artifacts: artifacts,
@@ -2604,6 +2611,11 @@ func workTimelineRenderEntries(
         : parseMarkdownBlocks(preview.text)
       rendered.reserveCapacity(rendered.count + blocks.count + (preview.isTruncated ? 1 : 0))
       let streamingTailBlockId = message.id == streamingAssistantMessageId ? blocks.last?.id : nil
+      // Only a bounded slice needs resolving; a whole message already holds its
+      // own blocks, and numbering them would be work for nothing.
+      let codeOrdinals = preview.isTruncated
+        ? workCodeBlockOrdinals(blocks, countsFromEnd: preview.anchor == .tail)
+        : [:]
       for block in blocks {
         let model = WorkAssistantMarkdownBlockRenderModel(
           id: "\(entry.id)-\(block.id)",
@@ -2611,7 +2623,14 @@ func workTimelineRenderEntries(
           turnId: message.turnId,
           itemId: message.itemId,
           block: block,
-          isStreamingTail: block.id == streamingTailBlockId
+          isStreamingTail: block.id == streamingTailBlockId,
+          codeSource: codeOrdinals[block.id].map { ordinal in
+            WorkCodeBlockSource(
+              markdown: message.markdown,
+              ordinal: ordinal,
+              countsFromEnd: preview.anchor == .tail
+            )
+          }
         )
         rendered.append(WorkTimelineRenderEntry(
           id: model.id,
@@ -2633,7 +2652,10 @@ func workTimelineRenderEntries(
         // step that shows it — the control only disappears once the whole
         // message is rendered and this branch stops running.
         canShowMore: true,
-        nextLineBudget: nextLineBudget
+        nextLineBudget: nextLineBudget,
+        // Only an explicit tap writes this map, so its presence *is* "the
+        // reader already expanded this message once".
+        hasExpandedInPlace: assistantLineBudgets[message.id] != nil
       )
       rendered.append(WorkTimelineRenderEntry(
         id: controls.id,

--- a/apps/ios/ADE/Views/Work/WorkChatSessionView.swift
+++ b/apps/ios/ADE/Views/Work/WorkChatSessionView.swift
@@ -6,12 +6,25 @@ let workChatScrollCoordinateSpace = "WorkChatScrollCoordinateSpace"
 let workChatStickThreshold: CGFloat = 160
 let workChatStickResumeThreshold: CGFloat = 48
 let workChatTouchScrollDeadband: CGFloat = 2
+/// How far a drag has to travel before it counts as the reader taking over from
+/// the initial bottom pin.
+///
+/// Deliberately larger than `workChatTouchScrollDeadband`: 2pt is the right
+/// sensitivity for releasing bottom-stickiness during a streaming turn (a nudge
+/// upward means "stop following"), but it is well inside the finger jitter of a
+/// tap on a freshly-opened chat, and cancelling the pin there is what left
+/// transcripts parked at a random offset while hydration was still growing the
+/// content underneath.
+let workChatInitialPinCancelDeadband: CGFloat = 16
 let workChatBottomAnchorSpacerHeight: CGFloat = 1
 let workChatContentBottomGutterHeight: CGFloat = 2
 let workChatSubagentActivePopupHeight: CGFloat = 34
 let workChatOlderHistoryTriggerDistance: CGFloat = 240
 let workChatOlderHistoryRearmDistance: CGFloat = 420
 let workChatOlderHistoryScrollableDistance: CGFloat = 1
+/// How long the transcript's content size has to stay unchanged before the
+/// opening bottom pin is considered settled.
+let workChatInitialPinQuiescenceMilliseconds = 600
 
 struct WorkChatOlderHistoryLoadResult {
   let succeeded: Bool
@@ -132,6 +145,38 @@ struct WorkChatScrollGeometrySample: Equatable {
 
 /// Number of layout passes a prepend anchor stays armed for.
 let workChatPrependAnchorAttempts = 12
+
+/// Whether a scroll phase means the reader — not the app — owns the offset.
+///
+/// `.animating` is deliberately not user-driven: it is the phase our own
+/// `scrollTo` animations run in, and treating it as the reader's would let one
+/// programmatic scroll suppress the next one.
+func workChatScrollPhaseIsUserDriven(_ phase: ScrollPhase) -> Bool {
+  switch phase {
+  case .tracking, .interacting, .decelerating:
+    return true
+  default:
+    return false
+  }
+}
+
+/// Whether the transcript may write the scroll offset right now.
+///
+/// Every programmatic scroll — bottom-follow pins, the initial pin, the prepend
+/// correction — goes through this. Writing an offset while the reader's finger
+/// is down or a fling is still decelerating kills the fling and lands the
+/// content somewhere neither the app nor the reader chose.
+func workChatMayWriteScrollOffset(dragActive: Bool, scrollPhaseUserDriven: Bool) -> Bool {
+  !dragActive && !scrollPhaseUserDriven
+}
+
+/// Where the transcript's content sits inside a viewport it does not fill.
+///
+/// Only meaningful while the content is shorter than the viewport: past that the
+/// content frame is sized by the content and the alignment is inert.
+func workChatTranscriptContentAlignment(contentFitsViewport: Bool) -> Alignment {
+  contentFitsViewport ? .topLeading : .bottomLeading
+}
 
 /// Position of the single probed row, published from the row itself so a
 /// prepend's displacement can be measured without a geometry reader per row.
@@ -296,6 +341,10 @@ struct WorkChatSessionView: View {
   /// follow and the jump-to-latest pill keep using `ScrollViewProxy.scrollTo`.
   @State var scrollPosition = ScrollPosition()
   @State var timelineDragActive = false
+  /// True from the moment the reader touches the transcript until the fling it
+  /// launched has come to rest. The drag gesture alone ends at finger-up, which
+  /// is the middle of the interaction, not the end of it.
+  @State var timelineScrollPhaseUserDriven = false
   @State var bottomStickinessReleasedByUser = false
   @State var timelineSnapshot = WorkChatTimelineSnapshot.empty
   @State var timelinePresentation = WorkTimelinePresentation.empty
@@ -316,6 +365,10 @@ struct WorkChatSessionView: View {
   @State var pendingCodexFastMode: Bool?
   @State var scrollStateSessionId: String?
   @State var pendingInitialBottomPinSessionId: String?
+  @State var initialBottomPinQuiescenceGeneration = 0
+  /// Whether the whole transcript fits on screen. Flips rarely, so it is safe as
+  /// `@State` even though the sample that produces it arrives per scroll frame.
+  @State var transcriptContentFitsViewport = true
   @State var timelineLayoutPinToken = 0
   @State var olderHistoryLoadInFlight = false
   @State var olderHistoryLoadError: String?
@@ -785,6 +838,24 @@ struct WorkChatSessionView: View {
     scrollMetrics.prependAnchor?.rowId ?? timelinePresentation.visibleEntries.first?.id
   }
 
+  /// The last real probe measurement, replayed when a correction had to wait for
+  /// the reader's fling to settle (no new preference change arrives once layout
+  /// is quiet).
+  var lastPrependProbeSample: WorkChatPrependProbeSample? {
+    guard let rowId = scrollMetrics.probeRowId, let y = scrollMetrics.probeRowY else { return nil }
+    return WorkChatPrependProbeSample(rowId: rowId, y: y)
+  }
+
+  /// Where a transcript shorter than the viewport sits.
+  ///
+  /// The alignment only has an effect while the content is shorter than the
+  /// viewport (past that the frame is content-sized), and there desktop renders
+  /// the first prompt at the TOP — a one-message chat pinned to the bottom of an
+  /// otherwise empty screen reads like the transcript failed to load.
+  var transcriptContentAlignment: Alignment {
+    workChatTranscriptContentAlignment(contentFitsViewport: transcriptContentFitsViewport)
+  }
+
   /// Records where the reader is whenever the next presentation inserts rows
   /// above the ones already on screen — whether that came from revealing locally
   /// buffered entries or from an older page landing from the host. Without this
@@ -792,14 +863,33 @@ struct WorkChatSessionView: View {
   /// user was reading slides down by the height of the inserted page.
   @MainActor
   private func armPrependAnchorIfRowsInsertedAbove(_ nextPresentation: WorkTimelinePresentation) {
-    guard scrollMetrics.prependAnchor == nil,
-          nextPresentation.visibleEntries.count > timelinePresentation.visibleEntries.count,
+    guard nextPresentation.visibleEntries.count > timelinePresentation.visibleEntries.count,
           let previousFirstId = timelinePresentation.visibleEntries.first?.id,
-          nextPresentation.visibleEntries.first?.id != previousFirstId,
-          // The probe has to already be measuring the row we are about to anchor
-          // on, or there is no "before" position to restore to.
-          scrollMetrics.probeRowId == previousFirstId,
-          let previousFirstRowY = scrollMetrics.probeRowY
+          nextPresentation.visibleEntries.first?.id != previousFirstId
+    else { return }
+
+    // Back-to-back prepends. The armed anchor rides a row that BOTH insertions
+    // pushed down, so the displacement it measures already accumulates them —
+    // re-arming on the new first row would instead measure only the second
+    // insertion and leave the first one uncorrected (the "teleport up"). Keep
+    // the existing anchor and only extend the window it may fire in.
+    if var anchor = scrollMetrics.prependAnchor {
+      guard nextPresentation.visibleEntries.contains(where: { $0.id == anchor.rowId }) else {
+        // The anchored row fell out of the list; nothing left to measure
+        // against, so retire it rather than restore to a row that is gone.
+        scrollMetrics.prependAnchor = nil
+        return
+      }
+      anchor.remainingAttempts = workChatPrependAnchorAttempts
+      scrollMetrics.prependAnchor = anchor
+      return
+    }
+
+    guard
+      // The probe has to already be measuring the row we are about to anchor
+      // on, or there is no "before" position to restore to.
+      scrollMetrics.probeRowId == previousFirstId,
+      let previousFirstRowY = scrollMetrics.probeRowY
     else { return }
     // Only a genuine prepend: the row that used to lead the list has to still be
     // in the list, just further down.
@@ -822,13 +912,35 @@ struct WorkChatSessionView: View {
   func restorePrependAnchorIfNeeded(probed: WorkChatPrependProbeSample?) {
     guard var anchor = scrollMetrics.prependAnchor else { return }
 
+    // A correction is a scroll write, so it waits for the reader to let go.
+    // The anchor stays armed (and does not burn an attempt) meanwhile: the
+    // measurement below isolates the insertion from the reader's own scrolling,
+    // so applying it after the fling settles restores the same reading position
+    // it would have restored mid-fling — without fighting the fling for the
+    // offset, which is what double-applied the reader's own scroll.
+    guard workChatMayWriteScrollOffset(
+      dragActive: timelineDragActive,
+      scrollPhaseUserDriven: timelineScrollPhaseUserDriven
+    ) else { return }
+
+    // No usable measurement for THIS anchor: the probe is describing some other
+    // row (it moved with a recompose, or the anchored row was recycled out of
+    // the LazyVStack). Bail out rather than fall through with a zero row shift —
+    // that reduces the correction to the reader's own scroll delta and applies
+    // it a second time, which is a teleport, not a correction.
+    guard let probed, probed.rowId == anchor.rowId else {
+      anchor.remainingAttempts -= 1
+      scrollMetrics.prependAnchor = anchor.remainingAttempts > 0 ? anchor : nil
+      return
+    }
+
     // The anchored row moves by the height inserted above it *minus* whatever
     // the reader scrolled in the meantime, because scrolling moves the row up
     // the screen too. Adding the offset change back isolates the insertion:
     // with an inserted height H and a user scroll D, the row moves H - D and the
     // offset moves D, so the sum is H either way — and a pure scroll with no
     // prepend sums to zero and correctly restores nothing.
-    let rowShift = probed?.rowId == anchor.rowId ? (probed?.y ?? anchor.rowY) - anchor.rowY : 0
+    let rowShift = probed.y - anchor.rowY
     let scrolled = scrollMetrics.offsetY - anchor.offsetY
     let insertedHeight = rowShift + scrolled
     guard insertedHeight > 0.5 else {
@@ -1331,7 +1443,7 @@ struct WorkChatSessionView: View {
           .frame(
             maxWidth: .infinity,
             minHeight: max(scrollViewportHeight, 0),
-            alignment: .bottomLeading
+            alignment: transcriptContentAlignment
           )
           .modifier(
             WorkChatTranscriptEnvironmentModifier(
@@ -1349,7 +1461,21 @@ struct WorkChatSessionView: View {
           .clipped()
           .scrollIndicators(.hidden)
           .scrollDismissesKeyboard(.interactively)
+          // Open at the tail without waiting for a layout pass. Scoped to
+          // `.initialOffset` on purpose: the `.sizeChanges` anchor would keep
+          // the bottom pinned as content grows, which is exactly the total-height
+          // correction the prepend machinery exists to avoid. The retry pin
+          // stays as belt-and-braces for the hydration that lands afterwards.
+          .defaultScrollAnchor(.bottom, for: .initialOffset)
           .scrollPosition($scrollPosition)
+          .onScrollPhaseChange { _, phase in
+            let userDriven = workChatScrollPhaseIsUserDriven(phase)
+            guard timelineScrollPhaseUserDriven != userDriven else { return }
+            timelineScrollPhaseUserDriven = userDriven
+            guard !userDriven else { return }
+            // A fling that ended may have left a prepend correction waiting.
+            restorePrependAnchorIfNeeded(probed: lastPrependProbeSample)
+          }
           .onScrollGeometryChange(for: WorkChatScrollGeometrySample.self) { geometry in
             WorkChatScrollGeometrySample(geometry)
           } action: { _, sample in
@@ -1377,6 +1503,9 @@ struct WorkChatSessionView: View {
               .onChanged { value in
                 if !timelineDragActive {
                   timelineDragActive = true
+                }
+                if abs(value.translation.height) > workChatInitialPinCancelDeadband {
+                  cancelPendingInitialBottomPinForUserScroll()
                 }
                 if value.translation.height > workChatTouchScrollDeadband {
                   releaseBottomStickinessForUserScroll(reason: "drag")

--- a/apps/ios/ADE/Views/Work/WorkDraftPersistence.swift
+++ b/apps/ios/ADE/Views/Work/WorkDraftPersistence.swift
@@ -131,6 +131,60 @@ enum WorkComposerDraftStore {
   }
 }
 
+/// Which active-turn send mode a chat was last sent with, remembered per chat so
+/// a user who works one way ("interrupt, always") doesn't re-pick it on every
+/// turn — and doesn't lose it by backgrounding the app. Same storage shape as
+/// `WorkComposerDraftStore`: one bounded JSON dictionary under a versioned key.
+///
+/// Stored as the raw mode string rather than the enum so an unknown value from a
+/// future build decodes to "no preference" instead of failing the whole map.
+enum WorkActiveSendModeStore {
+  struct Entry: Codable, Equatable {
+    var mode: String
+    var updatedAt: Double
+  }
+
+  private static let storageKey = "ade.work.activeSendMode.v1"
+  /// A send-mode preference is worth far less than a draft, so the cap is
+  /// smaller; falling off it just restores the provider default.
+  private static let maxEntries = 40
+
+  /// Per-chat key. Blank session ids yield a blank key so a composer that
+  /// renders before its session resolves can't write every chat's preference
+  /// into one bucket.
+  static func chatKey(sessionId: String) -> String {
+    let trimmed = sessionId.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard !trimmed.isEmpty else { return "" }
+    return "chat:\(trimmed)"
+  }
+
+  /// The remembered mode, or nil when the key is blank, absent, or no longer a
+  /// mode this build knows — the caller then falls back to the provider default.
+  static func load(_ key: String) -> WorkActiveSendMode? {
+    guard !key.isEmpty else { return nil }
+    let map: [String: Entry] = WorkDefaultsJSONMap.load(storageKey)
+    guard let raw = map[key]?.mode else { return nil }
+    return WorkActiveSendMode(rawValue: raw)
+  }
+
+  static func save(_ mode: WorkActiveSendMode, for key: String) {
+    guard !key.isEmpty else { return }
+    var map: [String: Entry] = WorkDefaultsJSONMap.load(storageKey)
+    if map[key]?.mode == mode.rawValue { return }
+    map[key] = Entry(mode: mode.rawValue, updatedAt: Date().timeIntervalSince1970)
+    map = WorkDefaultsJSONMap.evictingOldest(map, keeping: maxEntries, updatedAt: \.updatedAt)
+    WorkDefaultsJSONMap.persist(map, under: storageKey)
+  }
+
+  /// Forgets one chat's preference, so it falls back to the provider default.
+  static func clear(_ key: String) {
+    guard !key.isEmpty else { return }
+    var map: [String: Entry] = WorkDefaultsJSONMap.load(storageKey)
+    guard map.removeValue(forKey: key) != nil else { return }
+    WorkDefaultsJSONMap.persist(map, under: storageKey)
+  }
+}
+
 /// In-progress answers for a still-open question request, persisted per request
 /// id. The card's selections and freeform text were plain `@State`, so backing
 /// out of a chat to check something in the transcript — the exact reason a user

--- a/apps/ios/ADE/Views/Work/WorkErrorAndMessageHelpers.swift
+++ b/apps/ios/ADE/Views/Work/WorkErrorAndMessageHelpers.swift
@@ -287,14 +287,14 @@ private func duplicateAssistantFragmentIndex(
 }
 
 private func assistantTurnIdsAreCompatible(_ lhs: String?, _ rhs: String?) -> Bool {
-  let left = lhs?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
-  let right = rhs?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+  let left = lhs.map(workStreamingTrimmedView) ?? ""
+  let right = rhs.map(workStreamingTrimmedView) ?? ""
   return !left.isEmpty && left == right
 }
 
 private func mergedDuplicateAssistantText(existing: String, incoming: String) -> String? {
-  let normalizedExisting = existing.trimmingCharacters(in: .whitespacesAndNewlines)
-  let normalizedIncoming = incoming.trimmingCharacters(in: .whitespacesAndNewlines)
+  let normalizedExisting = workStreamingTrimmedView(existing)
+  let normalizedIncoming = workStreamingTrimmedView(incoming)
   guard !normalizedExisting.isEmpty, !normalizedIncoming.isEmpty else { return nil }
   if normalizedExisting == normalizedIncoming || normalizedExisting.hasSuffix(normalizedIncoming) {
     return existing
@@ -307,50 +307,163 @@ private func mergedDuplicateAssistantText(existing: String, incoming: String) ->
   return merged == existing + incoming ? nil : merged
 }
 
-func mergeWorkStreamingText(_ existing: String, _ incoming: String) -> String {
-  if existing.isEmpty { return incoming }
-  if incoming.isEmpty { return existing }
-  if existing == incoming { return existing }
-  if incoming.hasPrefix(existing) { return incoming }
+private enum WorkStreamingMergeResult {
+  case unchanged
+  case appended(String)
+  case replaced(String)
+}
+
+private func workStreamingMergeResult(_ existing: String, _ incoming: String) -> WorkStreamingMergeResult {
+  if existing.isEmpty { return .appended(incoming) }
+  if incoming.isEmpty { return .unchanged }
+  if existing == incoming { return .unchanged }
+  if incoming.hasPrefix(existing) {
+    return .appended(String(incoming.dropFirst(existing.count)))
+  }
   if existing.hasPrefix(incoming),
      workStreamingExistingOnlyAddsRepeatedIncomingTail(existing: existing, incoming: incoming) {
-    return incoming
+    return .replaced(incoming)
   }
-  if existing.hasPrefix(incoming) { return existing }
-  let normalizedExisting = existing.trimmingCharacters(in: .whitespacesAndNewlines)
-  let normalizedIncoming = incoming.trimmingCharacters(in: .whitespacesAndNewlines)
+  if existing.hasPrefix(incoming) { return .unchanged }
+  // Keep these as views. `trimmingCharacters` creates a second String copy of
+  // the complete assistant response even when only its edges are whitespace.
+  // The replay checks below only need the trimmed bounds.
+  let normalizedExisting = workStreamingTrimmedView(existing)
+  let normalizedIncoming = workStreamingTrimmedView(incoming)
   if !normalizedIncoming.isEmpty,
      normalizedExisting.hasSuffix(normalizedIncoming) {
-    return existing
+    return .unchanged
   }
   if !normalizedExisting.isEmpty,
      normalizedIncoming.hasPrefix(normalizedExisting) {
-    return incoming
+    return .replaced(incoming)
   }
   if workStreamingTextHasMultiwordReplayShape(incoming),
      existing.hasSuffix(incoming) {
-    return existing
+    return .unchanged
   }
   if let mergedReplay = mergeWorkStreamingReplayText(existing: existing, incoming: incoming) {
-    return workStreamingTextByCollapsingRepeatedTail(mergedReplay)
+    let collapsed = workStreamingTextByCollapsingRepeatedTail(mergedReplay)
+    if collapsed == existing { return .unchanged }
+    return .replaced(collapsed)
   }
 
-  let maxOverlap = min(min(existing.count, incoming.count), workStreamingMergeMaxScanCharacters)
+  let existingOverlapWindow = existing.suffix(workStreamingMergeMaxScanCharacters)
+  let maxOverlap = min(existingOverlapWindow.count, incoming.count)
   guard maxOverlap > 0 else {
-    return existing + incoming
+    return .appended(incoming)
   }
 
   // The hasPrefix checks above handle the common streaming-duplication cases, so this
   // overlap scan is capped to keep long transcript rebuilds bounded.
   for length in stride(from: maxOverlap, through: 1, by: -1) {
-    let existingSuffix = existing.suffix(length)
+    let existingSuffix = existingOverlapWindow.suffix(length)
     let incomingPrefix = incoming.prefix(length)
     if existingSuffix == incomingPrefix {
-      return existing + incoming.dropFirst(length)
+      let suffix = String(incoming.dropFirst(length))
+      return suffix.isEmpty ? .unchanged : .appended(suffix)
     }
   }
 
-  return existing + incoming
+  return .appended(incoming)
+}
+
+private func workStreamingTrimmedView(_ text: String) -> Substring {
+  var start = text.startIndex
+  while start < text.endIndex, text[start].isWhitespace {
+    start = text.index(after: start)
+  }
+
+  var end = text.endIndex
+  while end > start {
+    let previous = text.index(before: end)
+    guard text[previous].isWhitespace else { break }
+    end = previous
+  }
+  return text[start..<end]
+}
+
+func mergeWorkStreamingText(_ existing: String, _ incoming: String) -> String {
+  switch workStreamingMergeResult(existing, incoming) {
+  case .unchanged:
+    return existing
+  case .appended(let suffix):
+    return existing + suffix
+  case .replaced(let text):
+    return text
+  }
+}
+
+/// Applies one live assistant delta while keeping the preview identity cheap.
+/// The canonical snapshot fold replaces the revision with a full digest on
+/// its next pass; until then, the revision is enough to invalidate the cache
+/// without rescanning the whole response on every token batch.
+@discardableResult
+func workApplyStreamingAssistantText(_ incoming: String, to message: inout WorkChatMessage) -> Bool {
+  // Keep the source string scoped to the merge decision. Once the result is
+  // known, the append case can mutate `message.markdown` in place instead of
+  // retaining an alias and forcing `existing + suffix` to copy the entire
+  // response for every token batch.
+  let (
+    existingCharacterCount,
+    existingLineCount,
+    existingHasCarriageReturn,
+    existingContainsFence,
+    mergeResult
+  ): (Int, Int, Bool, Bool, WorkStreamingMergeResult) = {
+    let existing = message.markdown
+    return (
+      message.markdownCharacterCount ?? existing.count,
+      message.markdownLineCount ?? workAssistantMessageLineCount(existing),
+      message.markdownHasCarriageReturn ?? existing.contains("\r"),
+      message.markdownContainsFence ?? existing.contains("```"),
+      workStreamingMergeResult(existing, incoming)
+    )
+  }()
+
+  switch mergeResult {
+  case .unchanged:
+    return false
+  case .appended(let suffix):
+    message.markdown.append(contentsOf: suffix)
+  case .replaced(let replacement):
+    message.markdown = replacement
+  }
+  message.markdownRevision &+= 1
+  let mergedHasCarriageReturn = existingHasCarriageReturn || incoming.contains("\r")
+  message.markdownHasCarriageReturn = mergedHasCarriageReturn
+  message.markdownContainsFence = switch mergeResult {
+  case .appended:
+    existingContainsFence || incoming.contains("```")
+  case .replaced:
+    message.markdown.contains("```")
+  case .unchanged:
+    existingContainsFence
+  }
+  if !mergedHasCarriageReturn, case .appended(let appended) = mergeResult {
+    message.markdownCharacterCount = existingCharacterCount + appended.count
+    message.markdownLineCount = existingLineCount + appended.reduce(into: 0) { count, character in
+      if character == "\n" { count += 1 }
+    }
+    if var classifier = message.markdownMonospacedClassifier {
+      classifier.append(appended)
+      message.markdownMonospacedClassifier = classifier
+    } else {
+      message.markdownMonospacedClassifier = WorkStreamingMonospacedClassifierState(text: message.markdown)
+    }
+  } else {
+    // Dedup/replay can rewrite rather than append. That path is uncommon, but
+    // keeping its counts authoritative is more important than preserving the
+    // fast path's assumption.
+    let normalized = mergedHasCarriageReturn
+      ? message.markdown.replacingOccurrences(of: "\r\n", with: "\n")
+      : message.markdown
+    message.markdownCharacterCount = normalized.count
+    message.markdownLineCount = workAssistantMessageLineCount(normalized)
+    message.markdownMonospacedClassifier = WorkStreamingMonospacedClassifierState(text: normalized)
+  }
+  message.assistantPreview = nil
+  return true
 }
 
 private func workStreamingExistingOnlyAddsRepeatedIncomingTail(existing: String, incoming: String) -> Bool {
@@ -397,16 +510,12 @@ private func workStreamingNormalizedWords(_ text: String) -> [String] {
 }
 
 private func mergeWorkStreamingReplayText(existing: String, incoming: String) -> String? {
-  let existingCount = existing.count
   let incomingCount = incoming.count
-  guard existingCount >= workStreamingMergeMinimumReplayAnchorLength,
-        incomingCount >= workStreamingMergeMinimumReplayAnchorLength else {
+  guard incomingCount >= workStreamingMergeMinimumReplayAnchorLength else {
     return nil
   }
 
-  let searchWindowLength = min(existingCount, workStreamingMergeReplaySearchWindowCharacters)
-  let searchStart = existing.index(existing.endIndex, offsetBy: -searchWindowLength)
-  let searchableExisting = existing[searchStart...]
+  let searchableExisting = existing.suffix(workStreamingMergeReplaySearchWindowCharacters)
   let maxAnchorLength = min(
     min(incomingCount, searchableExisting.count),
     workStreamingMergeMaxScanCharacters

--- a/apps/ios/ADE/Views/Work/WorkErrorAndMessageHelpers.swift
+++ b/apps/ios/ADE/Views/Work/WorkErrorAndMessageHelpers.swift
@@ -438,23 +438,29 @@ func workApplyStreamingAssistantText(_ incoming: String, to message: inout WorkC
   // response for every token batch.
   let (
     existingCharacterCount,
+    existingUTF8Length,
     existingLineCount,
     existingHasCarriageReturn,
     existingContainsFence,
     existingTrailingBacktickRun,
+    existingTrailingRegionalIndicatorRun,
+    existingLastCharacter,
     mergeResult
-  ): (Int, Int, Bool, Bool, Int, WorkStreamingMergeResult) = {
+  ): (Int, Int, Int, Bool, Bool, Int, Int, Character?, WorkStreamingMergeResult) = {
     let existing = message.markdown
     return (
       message.markdownCharacterCount ?? existing.count,
+      message.markdownUTF8Count ?? existing.utf8.count,
       message.markdownLineCount ?? workAssistantMessageLineCount(existing),
       message.markdownHasCarriageReturn ?? existing.contains("\r"),
       message.markdownContainsFence ?? existing.contains("```"),
       message.markdownTrailingBacktickRun ?? workMarkdownTrailingBacktickRun(existing),
+      workTrailingRegionalIndicatorRun(existing),
+      existing.last,
       workStreamingMergeResult(
         existing,
         incoming,
-        existingUTF8Length: existing.utf8.count,
+        existingUTF8Length: message.markdownUTF8Count ?? existing.utf8.count,
         existingTrailingBacktickRun: message.markdownTrailingBacktickRun
           ?? workMarkdownTrailingBacktickRun(existing)
       )
@@ -484,7 +490,13 @@ func workApplyStreamingAssistantText(_ incoming: String, to message: inout WorkC
     existingContainsFence
   }
   if !mergedHasCarriageReturn, case .appended(let appended) = mergeResult {
-    message.markdownCharacterCount = existingCharacterCount + appended.count
+    message.markdownUTF8Count = existingUTF8Length + appended.utf8.count
+    message.markdownCharacterCount = workStreamingMergedCharacterCount(
+      existingLastCharacter: existingLastCharacter,
+      existingTrailingRegionalIndicatorRun: existingTrailingRegionalIndicatorRun,
+      appended: appended,
+      existingCharacterCount: existingCharacterCount
+    )
     message.markdownLineCount = existingLineCount + appended.reduce(into: 0) { count, character in
       if character == "\n" { count += 1 }
     }
@@ -508,6 +520,7 @@ func workApplyStreamingAssistantText(_ incoming: String, to message: inout WorkC
     let normalized = mergedHasCarriageReturn
       ? message.markdown.replacingOccurrences(of: "\r\n", with: "\n")
       : message.markdown
+    message.markdownUTF8Count = message.markdown.utf8.count
     message.markdownCharacterCount = normalized.count
     message.markdownLineCount = workAssistantMessageLineCount(normalized)
     let classifier = WorkStreamingMonospacedClassifierState(text: normalized)
@@ -517,6 +530,80 @@ func workApplyStreamingAssistantText(_ incoming: String, to message: inout WorkC
   }
   message.assistantPreview = nil
   return true
+}
+
+/// Appending a delta normally makes the grapheme count additive. The only
+/// exception is when the first grapheme of that delta joins the previous tail
+/// (combining marks, regional-indicator flags, emoji modifiers, or a similar
+/// Unicode boundary). Detect that boundary with a tiny string, and pay for a
+/// full count only on that uncommon path; the ordinary ASCII stream remains
+/// O(delta) with no full-response scan.
+private func workStreamingMergedCharacterCount(
+  existingLastCharacter: Character?,
+  existingTrailingRegionalIndicatorRun: Int,
+  appended: String,
+  existingCharacterCount: Int
+) -> Int {
+  guard let existingLast = existingLastCharacter,
+        let appendedFirst = appended.first
+  else {
+    return existingCharacterCount + appended.count
+  }
+
+  let existingTail = String(existingLast)
+  // `String.first` is a grapheme, not a scalar. A delta beginning with an
+  // odd run of regional indicators can therefore start with a paired
+  // `Character` even though its first scalar still needs to pair with the
+  // previous message tail. Handle that boundary explicitly before the
+  // general combining-mark/emoji check below.
+  if existingTrailingRegionalIndicatorRun % 2 == 1,
+     let appendedFirstScalar = appended.unicodeScalars.first,
+     workIsRegionalIndicator(appendedFirstScalar) {
+    // Swift groups regional indicators in pairs. When the existing run is
+    // odd, the incoming run only reduces the grapheme delta by one when it is
+    // odd too; an even incoming run simply pairs with the existing singleton
+    // and leaves the incoming grapheme count additive.
+    let incomingRegionalIndicatorRun = workLeadingRegionalIndicatorRun(in: appended)
+    if incomingRegionalIndicatorRun % 2 == 1 {
+      return existingCharacterCount + appended.count - 1
+    }
+  }
+
+  let appendedHead = String(appendedFirst)
+  let detachedBoundaryCount = existingTail.count + appendedHead.count
+  let mergedBoundaryCount = (existingTail + appendedHead).count
+  guard mergedBoundaryCount < detachedBoundaryCount else {
+    return existingCharacterCount + appended.count
+  }
+
+  // The prefix is the only part whose grapheme segmentation can change when
+  // it is joined to the existing message tail. Preserve the already-counted
+  // prefix and replace that one boundary cluster with its authoritative count.
+  return existingCharacterCount - 1
+    + (existingTail + appended).count
+}
+
+private func workTrailingRegionalIndicatorRun(_ text: String) -> Int {
+  var count = 0
+  for scalar in text.unicodeScalars.reversed() {
+    guard workIsRegionalIndicator(scalar) else { break }
+    count += 1
+  }
+  return count
+}
+
+private func workLeadingRegionalIndicatorRun(in text: String) -> Int {
+  var count = 0
+  for scalar in text.unicodeScalars {
+    guard workIsRegionalIndicator(scalar) else { break }
+    count += 1
+  }
+  return count
+}
+
+private func workIsRegionalIndicator(_ scalar: UnicodeScalar?) -> Bool {
+  guard let scalar else { return false }
+  return (0x1F1E6...0x1F1FF).contains(scalar.value)
 }
 
 private func workMarkdownTrailingBacktickRunAfterAppending(_ appended: String, precedingRun: Int) -> Int {

--- a/apps/ios/ADE/Views/Work/WorkErrorAndMessageHelpers.swift
+++ b/apps/ios/ADE/Views/Work/WorkErrorAndMessageHelpers.swift
@@ -313,18 +313,35 @@ private enum WorkStreamingMergeResult {
   case replaced(String)
 }
 
-private func workStreamingMergeResult(_ existing: String, _ incoming: String) -> WorkStreamingMergeResult {
+private func workStreamingMergeResult(
+  _ existing: String,
+  _ incoming: String,
+  existingUTF8Length: Int? = nil
+) -> WorkStreamingMergeResult {
   if existing.isEmpty { return .appended(incoming) }
   if incoming.isEmpty { return .unchanged }
-  if existing == incoming { return .unchanged }
-  if incoming.hasPrefix(existing) {
+
+  // Live events are append fragments. Compare byte lengths before asking
+  // `hasPrefix` to inspect either string so the ordinary delta path does not
+  // rescan the entire accumulated response. Cumulative snapshots and replay
+  // recovery still take the bounded fallback paths below.
+  let existingByteCount = existingUTF8Length ?? existing.utf8.count
+  let incomingByteCount = incoming.utf8.count
+  if existingByteCount == incomingByteCount {
+    if existing == incoming { return .unchanged }
+  } else if incomingByteCount > existingByteCount, incoming.hasPrefix(existing) {
     return .appended(String(incoming.dropFirst(existing.count)))
   }
-  if existing.hasPrefix(incoming),
-     workStreamingExistingOnlyAddsRepeatedIncomingTail(existing: existing, incoming: incoming) {
-    return .replaced(incoming)
+  if existingByteCount > incomingByteCount {
+    // This is bounded by the incoming delta in the normal path. Reuse the
+    // result so replay handling does not perform this scan twice.
+    let existingStartsWithIncoming = existing.hasPrefix(incoming)
+    if existingStartsWithIncoming,
+       workStreamingExistingOnlyAddsRepeatedIncomingTail(existing: existing, incoming: incoming) {
+      return .replaced(incoming)
+    }
+    if existingStartsWithIncoming { return .unchanged }
   }
-  if existing.hasPrefix(incoming) { return .unchanged }
   // Keep these as views. `trimmingCharacters` creates a second String copy of
   // the complete assistant response even when only its edges are whitespace.
   // The replay checks below only need the trimmed bounds.
@@ -409,15 +426,17 @@ func workApplyStreamingAssistantText(_ incoming: String, to message: inout WorkC
     existingLineCount,
     existingHasCarriageReturn,
     existingContainsFence,
+    existingTrailingBacktickRun,
     mergeResult
-  ): (Int, Int, Bool, Bool, WorkStreamingMergeResult) = {
+  ): (Int, Int, Bool, Bool, Int, WorkStreamingMergeResult) = {
     let existing = message.markdown
     return (
       message.markdownCharacterCount ?? existing.count,
       message.markdownLineCount ?? workAssistantMessageLineCount(existing),
       message.markdownHasCarriageReturn ?? existing.contains("\r"),
       message.markdownContainsFence ?? existing.contains("```"),
-      workStreamingMergeResult(existing, incoming)
+      message.markdownTrailingBacktickRun ?? workMarkdownTrailingBacktickRun(existing),
+      workStreamingMergeResult(existing, incoming, existingUTF8Length: existing.utf8.count)
     )
   }()
 
@@ -434,7 +453,10 @@ func workApplyStreamingAssistantText(_ incoming: String, to message: inout WorkC
   message.markdownHasCarriageReturn = mergedHasCarriageReturn
   message.markdownContainsFence = switch mergeResult {
   case .appended:
-    existingContainsFence || incoming.contains("```")
+    existingContainsFence || workStreamingDeltaContainsFence(
+      incoming,
+      precedingBacktickRun: existingTrailingBacktickRun
+    )
   case .replaced:
     message.markdown.contains("```")
   case .unchanged:
@@ -448,9 +470,16 @@ func workApplyStreamingAssistantText(_ incoming: String, to message: inout WorkC
     if var classifier = message.markdownMonospacedClassifier {
       classifier.append(appended)
       message.markdownMonospacedClassifier = classifier
+      message.markdownOpenFenceMarker = classifier.openFenceMarker
     } else {
-      message.markdownMonospacedClassifier = WorkStreamingMonospacedClassifierState(text: message.markdown)
+      let classifier = WorkStreamingMonospacedClassifierState(text: message.markdown)
+      message.markdownMonospacedClassifier = classifier
+      message.markdownOpenFenceMarker = classifier.openFenceMarker
     }
+    message.markdownTrailingBacktickRun = workMarkdownTrailingBacktickRunAfterAppending(
+      appended,
+      precedingRun: existingTrailingBacktickRun
+    )
   } else {
     // Dedup/replay can rewrite rather than append. That path is uncommon, but
     // keeping its counts authoritative is more important than preserving the
@@ -460,10 +489,38 @@ func workApplyStreamingAssistantText(_ incoming: String, to message: inout WorkC
       : message.markdown
     message.markdownCharacterCount = normalized.count
     message.markdownLineCount = workAssistantMessageLineCount(normalized)
-    message.markdownMonospacedClassifier = WorkStreamingMonospacedClassifierState(text: normalized)
+    let classifier = WorkStreamingMonospacedClassifierState(text: normalized)
+    message.markdownMonospacedClassifier = classifier
+    message.markdownOpenFenceMarker = classifier.openFenceMarker
+    message.markdownTrailingBacktickRun = workMarkdownTrailingBacktickRun(normalized)
   }
   message.assistantPreview = nil
   return true
+}
+
+private func workMarkdownTrailingBacktickRunAfterAppending(_ appended: String, precedingRun: Int) -> Int {
+  var count = precedingRun
+  for character in appended {
+    if character == "`" {
+      count += 1
+    } else {
+      count = 0
+    }
+  }
+  return count
+}
+
+private func workStreamingDeltaContainsFence(_ incoming: String, precedingBacktickRun: Int) -> Bool {
+  var run = precedingBacktickRun
+  for character in incoming {
+    if character == "`" {
+      run += 1
+      if run >= 3 { return true }
+    } else {
+      run = 0
+    }
+  }
+  return false
 }
 
 private func workStreamingExistingOnlyAddsRepeatedIncomingTail(existing: String, incoming: String) -> Bool {

--- a/apps/ios/ADE/Views/Work/WorkErrorAndMessageHelpers.swift
+++ b/apps/ios/ADE/Views/Work/WorkErrorAndMessageHelpers.swift
@@ -316,7 +316,8 @@ private enum WorkStreamingMergeResult {
 private func workStreamingMergeResult(
   _ existing: String,
   _ incoming: String,
-  existingUTF8Length: Int? = nil
+  existingUTF8Length: Int? = nil,
+  existingTrailingBacktickRun: Int = 0
 ) -> WorkStreamingMergeResult {
   if existing.isEmpty { return .appended(incoming) }
   if incoming.isEmpty { return .unchanged }
@@ -354,6 +355,20 @@ private func workStreamingMergeResult(
   if !normalizedExisting.isEmpty,
      normalizedIncoming.hasPrefix(normalizedExisting) {
     return .replaced(incoming)
+  }
+
+  // A provider may split an opening fence between deltas (` `` ` then
+  // `` `swift``). The bounded overlap fallback would otherwise treat the
+  // shared backtick as replay and drop it, turning a valid fence into prose.
+  // Preserve the incoming fragment whenever its leading backticks complete
+  // the existing run; cumulative snapshots have already taken the fast
+  // prefix path above.
+  let incomingLeadingBacktickRun = workMarkdownLeadingBacktickRun(incoming)
+  if existingTrailingBacktickRun > 0,
+     incomingLeadingBacktickRun > 0,
+     existingTrailingBacktickRun + incomingLeadingBacktickRun >= 3,
+     incomingLeadingBacktickRun < 3 {
+    return .appended(incoming)
   }
   if workStreamingTextHasMultiwordReplayShape(incoming),
      existing.hasSuffix(incoming) {
@@ -436,7 +451,13 @@ func workApplyStreamingAssistantText(_ incoming: String, to message: inout WorkC
       message.markdownHasCarriageReturn ?? existing.contains("\r"),
       message.markdownContainsFence ?? existing.contains("```"),
       message.markdownTrailingBacktickRun ?? workMarkdownTrailingBacktickRun(existing),
-      workStreamingMergeResult(existing, incoming, existingUTF8Length: existing.utf8.count)
+      workStreamingMergeResult(
+        existing,
+        incoming,
+        existingUTF8Length: existing.utf8.count,
+        existingTrailingBacktickRun: message.markdownTrailingBacktickRun
+          ?? workMarkdownTrailingBacktickRun(existing)
+      )
     )
   }()
 
@@ -506,6 +527,15 @@ private func workMarkdownTrailingBacktickRunAfterAppending(_ appended: String, p
     } else {
       count = 0
     }
+  }
+  return count
+}
+
+private func workMarkdownLeadingBacktickRun(_ text: String) -> Int {
+  var count = 0
+  for character in text {
+    guard character == "`" else { break }
+    count += 1
   }
   return count
 }

--- a/apps/ios/ADE/Views/Work/WorkMarkdownParsing.swift
+++ b/apps/ios/ADE/Views/Work/WorkMarkdownParsing.swift
@@ -348,18 +348,183 @@ func parseMarkdownBlocks(_ markdown: String) -> [WorkMarkdownBlock] {
 /// tiny per-message cache for repeated SwiftUI evaluations, and let the normal
 /// parser remain the single source of truth for block identities.
 func parseMarkdownBlocksForStreaming(_ markdown: String, cacheKey: String) -> [WorkMarkdownBlock] {
+  parseMarkdownBlocksForStreaming(markdown, cacheKey: cacheKey, appendOnly: true)
+}
+
+/// Append-only variant used by the live assistant tail. The cache records the
+/// UTF-16 boundary where the next delta starts, so the successful path touches
+/// only the new suffix. The prefix guard is required because transport
+/// de-duplication can rewrite a message under the same cache key; such a
+/// rewrite must fall back to the authoritative parser instead of being treated
+/// as an append.
+func parseMarkdownBlocksForStreaming(
+  _ markdown: String,
+  cacheKey: String,
+  appendOnly: Bool
+) -> [WorkMarkdownBlock] {
   let key = cacheKey as NSString
   let cached = workStreamingMarkdownCache.object(forKey: key)
-  if let cached, cached.fullText == markdown {
-    return cached.blocks
+  if let cached {
+    if appendOnly {
+      if cached.appendBoundaryUTF16Count == markdown.utf16.count,
+         cached.fullText == markdown
+      {
+        return cached.blocks
+      }
+    } else if cached.fullText == markdown {
+      return cached.blocks
+    }
+  }
+
+  if let cached,
+     cached.isPlainProse,
+     appendOnly,
+     markdown.hasPrefix(cached.fullText),
+     let appended = workStreamingAppendText(from: markdown, after: cached)
+  {
+    let blocks = workAppendPlainProse(
+      cached.blocks,
+      replacingTrailingWhitespace: cached.trailingWhitespace,
+      appendedText: cached.trailingWhitespace + appended
+    )
+    workStreamingMarkdownCache.setObject(
+      WorkStreamingMarkdownCacheBox(
+        fullText: markdown,
+        blocks: blocks,
+        isPlainProse: true,
+        trailingWhitespace: workTrailingWhitespace(in: markdown)
+      ),
+      forKey: key
+    )
+    return blocks
   }
 
   let blocks = parseMarkdownBlocksInternal(markdown)
   workStreamingMarkdownCache.setObject(
-    WorkStreamingMarkdownCacheBox(fullText: markdown, blocks: blocks),
+    WorkStreamingMarkdownCacheBox(
+      fullText: markdown,
+      blocks: blocks,
+      isPlainProse: workIsPlainProse(markdown, blocks: blocks),
+      trailingWhitespace: workTrailingWhitespace(in: markdown)
+    ),
     forKey: key
   )
   return blocks
+}
+
+/// The append-only fast path is deliberately narrower than Markdown parsing:
+/// one paragraph, no line breaks, and no punctuation that can change block or
+/// inline interpretation. A cache hit is therefore safe to update by replacing
+/// only the last bounded prose row; headings, lists, links, tables, and fences
+/// all use `parseMarkdownBlocksInternal` instead.
+private let workPlainProseMarkdownPunctuation: Set<Character> = [
+  "#", "*", "_", "`", "[", "]", "|", ">", "~", "\\", "<",
+]
+
+private func workIsPlainProse(_ text: String, blocks: [WorkMarkdownBlock]) -> Bool {
+  guard !text.isEmpty,
+        !text.contains(where: { $0 == "\n" || $0 == "\r" }),
+        !blocks.isEmpty,
+        blocks.allSatisfy({
+          if case .paragraph = $0.kind { return true }
+          return false
+        })
+  else { return false }
+
+  return workHasPlainProseCharacters(text)
+}
+
+private func workHasPlainProseCharacters(_ text: String) -> Bool {
+  let markerText = text.drop { $0.isWhitespace }
+  if markerText.hasPrefix("#") || markerText.hasPrefix(">") || markerText.hasPrefix("-") || markerText.hasPrefix("+") {
+    return false
+  }
+  if markerText.first?.isNumber == true {
+    var index = markerText.startIndex
+    while index < markerText.endIndex, markerText[index].isNumber {
+      index = markerText.index(after: index)
+    }
+    // A streaming delta can leave an ordered-list marker split across
+    // updates: `"1"` then `". item"`, or `"1."` then `" item"`. Do not
+    // cache either partial marker as settled prose, otherwise the append
+    // fast path cannot recover the ordered-list block that the full parser
+    // would produce.
+    if index == markerText.endIndex {
+      return false
+    }
+    if index < markerText.endIndex, markerText[index] == "." {
+      let afterDot = markerText.index(after: index)
+      if afterDot == markerText.endIndex || markerText[afterDot].isWhitespace {
+        return false
+      }
+    }
+  }
+
+  // These characters are enough to enter a Markdown construct in the parser
+  // or in AttributedString's inline parser. Being conservative is important:
+  // a false negative only takes the existing safe path, while a false positive
+  // could change a block's kind or text.
+  return !text.contains(where: { workPlainProseMarkdownPunctuation.contains($0) })
+}
+
+private func workTrailingWhitespace(in text: String) -> String {
+  var start = text.endIndex
+  while start > text.startIndex {
+    let previous = text.index(before: start)
+    guard text[previous].isWhitespace else { break }
+    start = previous
+  }
+  return String(text[start...])
+}
+
+private func workStreamingAppendText(
+  from markdown: String,
+  after cached: WorkStreamingMarkdownCacheBox
+) -> String? {
+  guard markdown.utf16.count > cached.appendBoundaryUTF16Count else { return nil }
+  let start = String.Index(utf16Offset: cached.appendBoundaryUTF16Count, in: markdown)
+  let appended = String(markdown[start...])
+  guard workHasPlainProseCharacters(appended),
+        !appended.contains(where: { $0 == "\n" || $0 == "\r" }) else { return nil }
+  return appended
+}
+
+private func workAppendPlainProse(
+  _ blocks: [WorkMarkdownBlock],
+  replacingTrailingWhitespace: String,
+  appendedText: String
+) -> [WorkMarkdownBlock] {
+  guard !appendedText.isEmpty,
+        let last = blocks.last,
+        case .paragraph(let lastText) = last.kind
+  else { return blocks }
+
+  let baseCount = blocks.count - 1
+  let settledLastText: String
+  if !replacingTrailingWhitespace.isEmpty,
+     lastText.hasSuffix(replacingTrailingWhitespace) {
+    settledLastText = String(lastText.dropLast(replacingTrailingWhitespace.count))
+  } else {
+    settledLastText = lastText
+  }
+  // The canonical parser trims paragraph-edge whitespace. Keep source
+  // whitespace in the cache as the next token's append boundary, but do not
+  // render it while it is still trailing. Interior spaces remain lossless.
+  let candidate = settledLastText + appendedText
+  let trailingWhitespace = workTrailingWhitespace(in: candidate)
+  let renderedCandidate = trailingWhitespace.isEmpty
+    ? candidate
+    : String(candidate.dropLast(trailingWhitespace.count))
+  let replacement = workBoundedProseChunks(renderedCandidate)
+  var result = Array(blocks.dropLast())
+  result.reserveCapacity(baseCount + replacement.count)
+  for (offset, chunk) in replacement.enumerated() {
+    result.append(WorkMarkdownBlock(
+      id: "markdown-block-\(baseCount + offset)",
+      kind: .paragraph(chunk)
+    ))
+  }
+  return result
 }
 
 /// Most characters a single rendered prose row may carry.
@@ -452,9 +617,10 @@ func workBoundedProseChunks(
 /// the text is inside a span that has not closed yet, so the scan keeps going
 /// past the budget and takes the FIRST balanced boundary after it: appends can
 /// only add boundaries later than that one, so the cut settles the moment it is
-/// chosen. A chunk that runs over budget for a few deltas is the price of never
-/// moving a cut backwards. If the text ends first the remainder stays whole,
-/// which is no worse than the single tall row it would otherwise have been.
+/// chosen. An incomplete link destination is the exception: if input ends
+/// while that destination is still open, the hard edge bounds the malformed
+/// row rather than allowing it to grow without limit. A valid long destination
+/// still waits for its closing boundary.
 private func workProseChunkCut(
   in text: String,
   from start: String.Index,
@@ -466,6 +632,7 @@ private func workProseChunkCut(
   var wordGap: String.Index?
   var budgetEdge: String.Index?
   var overflow: String.Index?
+  var hardLinkDestinationEdge: String.Index?
 
   var index = start
   var previous: Character?
@@ -479,6 +646,9 @@ private func workProseChunkCut(
       if boundary == ceiling, markup.isBalanced {
         budgetEdge = boundary
       }
+      if boundary == ceiling, markup.hasOpenLinkDestination {
+        hardLinkDestinationEdge = boundary
+      }
       if character == " " || character == "\n", markup.isBalanced, boundary >= floor {
         wordGap = boundary
         if character == "\n" || previous == "." || previous == "!" || previous == "?" {
@@ -486,6 +656,13 @@ private func workProseChunkCut(
         }
       }
     } else {
+      if markup.hasOpenLinkDestination, hardLinkDestinationEdge == nil {
+        // The link destination may begin just after the frozen budget edge
+        // (for example, `[` is inside the window but `](` is not). Remember
+        // the edge as soon as that malformed destination becomes observable;
+        // otherwise an unfinished link can grow without a bounded row.
+        hardLinkDestinationEdge = ceiling
+      }
       // Everything past the budget is a last resort, and reading any of it
       // would tie this cut to text that has not finished arriving. Stop as soon
       // as the frozen window has answered.
@@ -499,7 +676,8 @@ private func workProseChunkCut(
     previous = character
     index = boundary
   }
-  return sentenceEnd ?? wordGap ?? budgetEdge ?? overflow
+  let hardCut = markup.hasOpenLinkDestination ? hardLinkDestinationEdge : nil
+  return sentenceEnd ?? wordGap ?? budgetEdge ?? overflow ?? hardCut
 }
 
 /// Running parity of the inline delimiters a cut must not land between.
@@ -518,6 +696,9 @@ private struct WorkInlineMarkupBalance {
   private var brackets = 0
   private var linkDestinationDepth = 0
   private var linkDestinationPending = false
+  private var linkDestinationAngleDelimited = false
+  private var linkDestinationFirstCharacter = false
+  private var linkDestinationEscapePending = false
   private var beforeEmphasisRun: Character?
 
   var isBalanced: Bool {
@@ -528,8 +709,34 @@ private struct WorkInlineMarkupBalance {
       && !linkDestinationPending
   }
 
+  var hasOpenLinkDestination: Bool {
+    linkDestinationDepth > 0
+  }
+
   mutating func consume(_ character: Character, previous: Character?, next: Character?) {
     if linkDestinationDepth > 0 {
+      if linkDestinationEscapePending {
+        linkDestinationEscapePending = false
+        return
+      }
+      if character == "\\" {
+        linkDestinationEscapePending = true
+        return
+      }
+      if linkDestinationFirstCharacter {
+        linkDestinationFirstCharacter = false
+        if character == "<" {
+          linkDestinationAngleDelimited = true
+          return
+        }
+      }
+      if linkDestinationAngleDelimited {
+        if character == ">" {
+          linkDestinationDepth = 0
+          linkDestinationAngleDelimited = false
+        }
+        return
+      }
       if character == "(" {
         linkDestinationDepth += 1
       } else if character == ")" {
@@ -541,6 +748,8 @@ private struct WorkInlineMarkupBalance {
       if character == "(" {
         linkDestinationDepth = 1
         linkDestinationPending = false
+        linkDestinationAngleDelimited = false
+        linkDestinationFirstCharacter = true
         return
       }
       linkDestinationPending = false
@@ -857,10 +1066,21 @@ private let workStreamingInlineMarkdownCache: NSCache<NSString, WorkMarkdownCach
 private final class WorkStreamingMarkdownCacheBox: NSObject {
   let fullText: String
   let blocks: [WorkMarkdownBlock]
+  let isPlainProse: Bool
+  let trailingWhitespace: String
+  let appendBoundaryUTF16Count: Int
 
-  init(fullText: String, blocks: [WorkMarkdownBlock]) {
+  init(
+    fullText: String,
+    blocks: [WorkMarkdownBlock],
+    isPlainProse: Bool = false,
+    trailingWhitespace: String = ""
+  ) {
     self.fullText = fullText
     self.blocks = blocks
+    self.isPlainProse = isPlainProse
+    self.trailingWhitespace = trailingWhitespace
+    self.appendBoundaryUTF16Count = fullText.utf16.count
   }
 }
 

--- a/apps/ios/ADE/Views/Work/WorkMarkdownParsing.swift
+++ b/apps/ios/ADE/Views/Work/WorkMarkdownParsing.swift
@@ -37,6 +37,10 @@ func workLineHasAlignedColumnGap<S: StringProtocol>(_ line: S) -> Bool {
 /// cheap and exact without rescanning the growing response.
 struct WorkStreamingMonospacedClassifierState: Equatable {
   private(set) var insideFence = false
+  /// The opening marker for the currently unclosed fence, when the streamed
+  /// text ends inside one. Tail previews can reuse this bounded piece of
+  /// metadata instead of rescanning the entire response to reconstruct it.
+  private(set) var openFenceMarker: String? = nil
   private(set) var proseLineCount = 0
   private(set) var alignedColumnLineCount = 0
   private(set) var hasWireframeGlyph = false
@@ -51,6 +55,7 @@ struct WorkStreamingMonospacedClassifierState: Equatable {
   private var pendingHasPipe = false
   private var pendingFencePrefixLength = 0
   private var pendingFenceCandidate = true
+  private var pendingFenceMarker = ""
 
   init(text: String = "") {
     append(text)
@@ -93,14 +98,23 @@ struct WorkStreamingMonospacedClassifierState: Equatable {
       pendingHasNonWhitespace = true
       if character == "`" {
         pendingFencePrefixLength = 1
+        pendingFenceMarker = "`"
       } else {
         pendingFenceCandidate = false
       }
-    } else if pendingFenceCandidate, pendingFencePrefixLength < 3 {
-      if character == "`" {
-        pendingFencePrefixLength += 1
+    } else if pendingFenceCandidate {
+      if pendingFencePrefixLength < 3 {
+        if character == "`" {
+          pendingFencePrefixLength += 1
+          pendingFenceMarker.append(character)
+        } else {
+          pendingFenceCandidate = false
+          pendingFenceMarker = ""
+        }
       } else {
-        pendingFenceCandidate = false
+        // The parser treats any trimmed line beginning with three backticks as
+        // a fence, so retain the (usually tiny) language suffix as well.
+        pendingFenceMarker.append(character)
       }
     }
 
@@ -124,7 +138,13 @@ struct WorkStreamingMonospacedClassifierState: Equatable {
   private mutating func processCompleteLine() {
     let isFence = pendingFenceCandidate && pendingFencePrefixLength >= 3
     if isFence {
-      insideFence.toggle()
+      if insideFence {
+        insideFence = false
+        openFenceMarker = nil
+      } else {
+        insideFence = true
+        openFenceMarker = pendingFenceMarker.trimmingCharacters(in: .whitespaces)
+      }
       resetPendingLine()
       return
     }
@@ -151,11 +171,21 @@ struct WorkStreamingMonospacedClassifierState: Equatable {
     pendingHasPipe = false
     pendingFencePrefixLength = 0
     pendingFenceCandidate = true
+    pendingFenceMarker = ""
   }
 }
 
 func workAssistantMessageUsesMonospacedPreview(_ text: String) -> Bool {
   WorkStreamingMonospacedClassifierState(text: text).usesMonospacedRendering
+}
+
+func workMarkdownTrailingBacktickRun(_ text: String) -> Int {
+  var count = 0
+  for character in text.reversed() {
+    guard character == "`" else { break }
+    count += 1
+  }
+  return count
 }
 
 enum WorkMarkdownBlockKind: Equatable {
@@ -228,6 +258,19 @@ struct WorkCodeBlockSource {
   let markdown: String
   let ordinal: Int
   let countsFromEnd: Bool
+  let markdownIdentity: String
+
+  init(
+    markdown: String,
+    ordinal: Int,
+    countsFromEnd: Bool,
+    markdownIdentity: String? = nil
+  ) {
+    self.markdown = markdown
+    self.ordinal = ordinal
+    self.countsFromEnd = countsFromEnd
+    self.markdownIdentity = markdownIdentity ?? workStableDigest(markdown)
+  }
 
   /// The whole block, or `fallback` when the slice cannot be located (a message
   /// edited between render and tap, or a slice that parsed to more code blocks
@@ -243,13 +286,10 @@ struct WorkCodeBlockSource {
 }
 
 extension WorkCodeBlockSource: Equatable {
-  /// `markdown` is compared by length, not content. It only feeds tap-time
-  /// resolution, and every edit that can reach a rendered block also changes
-  /// the block itself — which the owning row already compares.
   static func == (lhs: WorkCodeBlockSource, rhs: WorkCodeBlockSource) -> Bool {
     lhs.ordinal == rhs.ordinal
       && lhs.countsFromEnd == rhs.countsFromEnd
-      && lhs.markdown.utf8.count == rhs.markdown.utf8.count
+      && lhs.markdownIdentity == rhs.markdownIdentity
   }
 }
 

--- a/apps/ios/ADE/Views/Work/WorkMarkdownParsing.swift
+++ b/apps/ios/ADE/Views/Work/WorkMarkdownParsing.swift
@@ -30,27 +30,132 @@ func workLineHasAlignedColumnGap<S: StringProtocol>(_ line: S) -> Bool {
 /// Whether an assistant answer should render as one fixed-column block rather
 /// than parsed Markdown. Fenced code and Markdown table rows are deliberately
 /// ignored: their dedicated block renderers already preserve alignment.
-func workAssistantMessageUsesMonospacedPreview(_ text: String) -> Bool {
-  var insideFence = false
-  var proseLineCount = 0
-  var alignedColumnLineCount = 0
-  for line in text.split(separator: "\n", omittingEmptySubsequences: false) {
-    let trimmed = line.trimmingCharacters(in: .whitespaces)
-    if trimmed.hasPrefix("```") {
-      insideFence.toggle()
-      continue
-    }
-    if insideFence || trimmed.isEmpty { continue }
-    if trimmed.contains(where: { workWireframeGlyphs.contains($0) }) {
-      return true
-    }
-    proseLineCount += 1
-    if trimmed.contains("|") { continue }
-    if workLineHasAlignedColumnGap(trimmed) {
-      alignedColumnLineCount += 1
+/// Incremental state for the fixed-column classifier used by a live assistant
+/// response. A cached `false` classification is not safe by itself: a later
+/// delta can complete a second aligned row, or add a wireframe glyph outside a
+/// fence. Keeping the line scanner's state on the message makes both cases
+/// cheap and exact without rescanning the growing response.
+struct WorkStreamingMonospacedClassifierState: Equatable {
+  private(set) var insideFence = false
+  private(set) var proseLineCount = 0
+  private(set) var alignedColumnLineCount = 0
+  private(set) var hasWireframeGlyph = false
+  // Keep only the facts needed to classify the unfinished line. Retaining the
+  // whole line here made `usesMonospacedRendering` copy and rescan an ever
+  // growing one-line response on every token batch — exactly the O(n) loop the
+  // streaming path is meant to remove.
+  private var pendingHasNonWhitespace = false
+  private var pendingWhitespaceRun = 0
+  private var pendingHasAlignedColumnGap = false
+  private var pendingHasWireframeGlyph = false
+  private var pendingHasPipe = false
+  private var pendingFencePrefixLength = 0
+  private var pendingFenceCandidate = true
+
+  init(text: String = "") {
+    append(text)
+  }
+
+  mutating func append(_ text: String) {
+    guard !text.isEmpty else { return }
+
+    for character in text {
+      if character == "\n" {
+        processCompleteLine()
+      } else {
+        processCharacter(character)
+      }
     }
   }
-  return alignedColumnLineCount >= 2 && alignedColumnLineCount * 2 >= proseLineCount
+
+  var usesMonospacedRendering: Bool {
+    guard !insideFence, pendingHasNonWhitespace else {
+      return hasWireframeGlyph
+    }
+    let pendingIsFence = pendingFenceCandidate && pendingFencePrefixLength >= 3
+    guard !pendingIsFence else { return hasWireframeGlyph }
+
+    let pendingProseLineCount = proseLineCount + 1
+    let pendingAlignedColumnLineCount = alignedColumnLineCount
+      + (!pendingHasPipe && pendingHasAlignedColumnGap ? 1 : 0)
+    return hasWireframeGlyph
+      || pendingHasWireframeGlyph
+      || (pendingAlignedColumnLineCount >= 2
+        && pendingAlignedColumnLineCount * 2 >= pendingProseLineCount)
+  }
+
+  private mutating func processCharacter(_ character: Character) {
+    let isHorizontalWhitespace = character == " " || character == "\t"
+    let isWhitespace = character.isWhitespace
+
+    if !pendingHasNonWhitespace {
+      guard !isWhitespace else { return }
+      pendingHasNonWhitespace = true
+      if character == "`" {
+        pendingFencePrefixLength = 1
+      } else {
+        pendingFenceCandidate = false
+      }
+    } else if pendingFenceCandidate, pendingFencePrefixLength < 3 {
+      if character == "`" {
+        pendingFencePrefixLength += 1
+      } else {
+        pendingFenceCandidate = false
+      }
+    }
+
+    if character == "|" {
+      pendingHasPipe = true
+    }
+    if workWireframeGlyphs.contains(character) {
+      pendingHasWireframeGlyph = true
+    }
+
+    if isHorizontalWhitespace {
+      pendingWhitespaceRun += 1
+    } else {
+      if pendingWhitespaceRun >= 3 {
+        pendingHasAlignedColumnGap = true
+      }
+      pendingWhitespaceRun = 0
+    }
+  }
+
+  private mutating func processCompleteLine() {
+    let isFence = pendingFenceCandidate && pendingFencePrefixLength >= 3
+    if isFence {
+      insideFence.toggle()
+      resetPendingLine()
+      return
+    }
+    guard !insideFence, pendingHasNonWhitespace else {
+      resetPendingLine()
+      return
+    }
+
+    if pendingHasWireframeGlyph {
+      hasWireframeGlyph = true
+    }
+    proseLineCount += 1
+    if !pendingHasPipe, pendingHasAlignedColumnGap {
+      alignedColumnLineCount += 1
+    }
+    resetPendingLine()
+  }
+
+  private mutating func resetPendingLine() {
+    pendingHasNonWhitespace = false
+    pendingWhitespaceRun = 0
+    pendingHasAlignedColumnGap = false
+    pendingHasWireframeGlyph = false
+    pendingHasPipe = false
+    pendingFencePrefixLength = 0
+    pendingFenceCandidate = true
+  }
+}
+
+func workAssistantMessageUsesMonospacedPreview(_ text: String) -> Bool {
+  WorkStreamingMonospacedClassifierState(text: text).usesMonospacedRendering
 }
 
 enum WorkMarkdownBlockKind: Equatable {
@@ -281,6 +386,193 @@ private func workStreamingStableBoundaryIndex(in normalized: String) -> String.I
   return boundary
 }
 
+/// Most characters a single rendered prose row may carry.
+///
+/// This is a layout budget, not a reading one. The transcript is a `LazyVStack`,
+/// which estimates the height of every row it has not realized from the ones it
+/// has. A row that is many screens tall poisons that estimate: placing the
+/// stack with it realizes a different set of rows, the new set has a different
+/// average height, the new average moves the estimate, and the moved estimate
+/// changes the placement again. With one ordinary-sized row among giants the
+/// two never agree, so the view graph re-runs on every run-loop pass forever —
+/// the main thread pinned at 100%, the transcript frozen mid-turn, and no way
+/// out except leaving the chat.
+///
+/// An agent that formats its prose normally never reaches this: blank lines
+/// already end a paragraph. It is the unbroken wall of text — a long numbered
+/// answer written as one paragraph — that produces the outlier, and that is
+/// exactly the shape a streaming turn grows into.
+///
+/// 1,600 characters is roughly a screenful of prose on an iPhone, so a split
+/// reads as the paragraph break the text was missing. The budget is counted in
+/// characters, not bytes, because row height follows glyphs.
+let workMarkdownProseRowCharacterLimit = 1_600
+
+/// Splits one oversized paragraph into rows of comparable height.
+///
+/// Every cut is decided from the front, out of text that is already present, so
+/// a paragraph that is still streaming keeps every chunk but its last
+/// byte-identical from delta to delta: same text, same digest, same
+/// `markdown-block-<n>` id, and a hit in `markdownAttributedString`'s cache
+/// instead of a fresh `AttributedString(markdown:)` per row per delta. Only the
+/// last chunk changes, and the number of chunks only ever grows.
+///
+/// A cut never lands inside an inline span, because a row that renders a stray
+/// `**` is worse than a row that is too tall. That rule is applied to each cut
+/// on its own rather than to the split as a whole — an unclosed `` ` `` in the
+/// tail the agent is still typing must not retract cuts already made ahead of
+/// it. Retracting them collapses the paragraph back to a single block and
+/// restores it a few tokens later, renumbering every block in the message
+/// twice, which is the churn this split exists to remove.
+func workBoundedProseChunks(
+  _ text: String,
+  limit: Int = workMarkdownProseRowCharacterLimit
+) -> [String] {
+  // A string's UTF-8 count is never below its character count, so this lets
+  // through everything that could exceed the budget and nothing that cannot,
+  // without paying for grapheme breaking on the short paragraphs that are the
+  // overwhelming majority.
+  guard limit > 1, text.utf8.count > limit else { return [text] }
+
+  var chunks: [String] = []
+  var start = text.startIndex
+  while let ceiling = text.index(start, offsetBy: limit, limitedBy: text.endIndex) {
+    // Never cut in the first half of the budget: a paragraph made of one
+    // enormous unbroken token would otherwise be shredded into slivers.
+    let floor = text.index(start, offsetBy: limit / 2, limitedBy: ceiling) ?? ceiling
+    guard let cut = workProseChunkCut(in: text, from: start, floor: floor, ceiling: ceiling) else {
+      break
+    }
+    // Keep the delimiter in the chunk that owns it. `appendParagraph` has
+    // already trimmed the paragraph's outer whitespace; trimming each piece
+    // here would silently drop the separator between two rendered rows and
+    // would make this helper impossible to reason about as a lossless split.
+    let chunk = String(text[start..<cut])
+    if !chunk.isEmpty { chunks.append(chunk) }
+    start = cut
+  }
+
+  guard !chunks.isEmpty else { return [text] }
+  let remainder = String(text[start...])
+  if !remainder.isEmpty { chunks.append(remainder) }
+  return chunks.count > 1 ? chunks : [text]
+}
+
+/// Where the chunk beginning at `start` ends, or nil when the rest of the text
+/// has to stay in one piece.
+///
+/// One forward pass carries the inline-markup state, so asking whether a
+/// candidate boundary is balanced costs nothing per candidate. Preference
+/// inside the budget window matches a reader's: end of a line, then end of a
+/// sentence, then any word gap — the last one that fits, so rows stay full.
+///
+/// Failing all three, the cut goes at the budget's own edge. Prose with no word
+/// gap in an entire 800-character window is either a script that does not
+/// separate words — Japanese, Chinese, Thai — or a pasted blob, and both break
+/// between characters anyway. Without this the budget would apply to English
+/// and to nothing else.
+///
+/// The edge is only usable while the markup there is balanced. When it is not,
+/// the text is inside a span that has not closed yet, so the scan keeps going
+/// past the budget and takes the FIRST balanced boundary after it: appends can
+/// only add boundaries later than that one, so the cut settles the moment it is
+/// chosen. A chunk that runs over budget for a few deltas is the price of never
+/// moving a cut backwards. If the text ends first the remainder stays whole,
+/// which is no worse than the single tall row it would otherwise have been.
+private func workProseChunkCut(
+  in text: String,
+  from start: String.Index,
+  floor: String.Index,
+  ceiling: String.Index
+) -> String.Index? {
+  var markup = WorkInlineMarkupBalance()
+  var sentenceEnd: String.Index?
+  var wordGap: String.Index?
+  var budgetEdge: String.Index?
+  var overflow: String.Index?
+
+  var index = start
+  var previous: Character?
+  while index < text.endIndex {
+    let character = text[index]
+    let boundary = text.index(after: index)
+    let next = boundary < text.endIndex ? text[boundary] : nil
+    markup.consume(character, previous: previous, next: next)
+
+    if boundary <= ceiling {
+      if boundary == ceiling, markup.isBalanced {
+        budgetEdge = boundary
+      }
+      if character == " " || character == "\n", markup.isBalanced, boundary >= floor {
+        wordGap = boundary
+        if character == "\n" || previous == "." || previous == "!" || previous == "?" {
+          sentenceEnd = boundary
+        }
+      }
+    } else {
+      // Everything past the budget is a last resort, and reading any of it
+      // would tie this cut to text that has not finished arriving. Stop as soon
+      // as the frozen window has answered.
+      if sentenceEnd != nil || wordGap != nil || budgetEdge != nil { break }
+      if character == " " || character == "\n", markup.isBalanced {
+        overflow = boundary
+        break
+      }
+    }
+
+    previous = character
+    index = boundary
+  }
+  return sentenceEnd ?? wordGap ?? budgetEdge ?? overflow
+}
+
+/// Running parity of the inline delimiters a cut must not land between.
+///
+/// Deliberately counting rather than parsing: the only question is "could this
+/// position be inside a span", and an odd number of open delimiter runs answers
+/// yes. Runs, not characters — `**bold**` is two delimiters, not four, and a
+/// chunk carrying only the opening `**` has to read as odd.
+///
+/// Underscores are left out: they sit inside ordinary identifiers far more
+/// often than they open emphasis, and counting them would refuse nearly every
+/// cut.
+private struct WorkInlineMarkupBalance {
+  private var backtickRuns = 0
+  private var emphasisRuns = 0
+  private var brackets = 0
+  private var beforeEmphasisRun: Character?
+
+  var isBalanced: Bool {
+    backtickRuns.isMultiple(of: 2) && emphasisRuns.isMultiple(of: 2) && brackets == 0
+  }
+
+  mutating func consume(_ character: Character, previous: Character?, next: Character?) {
+    switch character {
+    case "`":
+      if previous != "`" { backtickRuns += 1 }
+    case "*":
+      if previous != "*" { beforeEmphasisRun = previous }
+      guard next != "*" else { break }
+      // CommonMark's flanking rule, reduced to the part that matters here: a
+      // run padded by whitespace on both sides opens nothing — "2 * 3" is
+      // arithmetic. Counting it would leave the parity wrong for the entire
+      // rest of the paragraph, and one stray asterisk would cost every later
+      // cut, handing the transcript back the giant row.
+      let opens = !(next?.isWhitespace ?? true)
+      let closes = !(beforeEmphasisRun?.isWhitespace ?? true)
+      if opens || closes { emphasisRuns += 1 }
+    case "[":
+      brackets += 1
+    case "]":
+      // A close with no open is malformed text, not a span. Clamping stops one
+      // stray "]" from making every later boundary read as unbalanced.
+      brackets = max(0, brackets - 1)
+    default:
+      break
+    }
+  }
+}
+
 private func parseMarkdownBlocksInternal(_ markdown: String) -> [WorkMarkdownBlock] {
   let lines = markdown.replacingOccurrences(of: "\r\n", with: "\n").split(separator: "\n", omittingEmptySubsequences: false).map(String.init)
   var index = 0
@@ -293,7 +585,12 @@ private func parseMarkdownBlocksInternal(_ markdown: String) -> [WorkMarkdownBlo
   func appendParagraph(_ lines: [String]) {
     let text = lines.joined(separator: "\n").trimmingCharacters(in: .whitespacesAndNewlines)
     if !text.isEmpty {
-      appendBlock(.paragraph(text))
+      // One paragraph can still become several rows: see
+      // `workBoundedProseChunks` for why a single multi-screen row is not
+      // something the transcript's `LazyVStack` can survive.
+      for chunk in workBoundedProseChunks(text) {
+        appendBlock(.paragraph(chunk))
+      }
     }
   }
 
@@ -364,7 +661,16 @@ private func parseMarkdownBlocksInternal(_ markdown: String) -> [WorkMarkdownBlo
     }
 
     if let ordered = parseList(startingAt: index, in: lines, ordered: true) {
-      appendBlock(.orderedList(start: ordered.startNumber ?? 1, items: ordered.items))
+      if ordered.items.count == 1, workLooksLikeInlineNumberedProse(trimmed) {
+        // A model sometimes emits a numbered narrative on one physical line:
+        // `1. First sentence. 2. Second sentence.` Markdown sees that as one
+        // ordered-list item, but rendering it as one item recreates the giant
+        // LazyVStack row this parser bounds for prose. Preserve the source
+        // markers and let the prose splitter turn it into stable rows.
+        appendParagraph([trimmed])
+      } else {
+        appendBlock(.orderedList(start: ordered.startNumber ?? 1, items: ordered.items))
+      }
       index = ordered.nextIndex
       continue
     }
@@ -388,6 +694,43 @@ private func parseMarkdownBlocksInternal(_ markdown: String) -> [WorkMarkdownBlo
   }
 
   return blocks
+}
+
+/// Detects the common malformed-but-readable form of a numbered narrative.
+/// Markdown's line-oriented list grammar treats the whole line as one item;
+/// the extra number markers show that the author meant sentence numbers, not a
+/// single list item containing an unbounded wall of text.
+func workLooksLikeInlineNumberedProse(_ line: String) -> Bool {
+  guard line.count > workMarkdownProseRowCharacterLimit else { return false }
+
+  func marker(at start: String.Index) -> (number: Int, next: String.Index)? {
+    var cursor = start
+    guard cursor < line.endIndex, line[cursor].isNumber else { return nil }
+    while cursor < line.endIndex, line[cursor].isNumber {
+      cursor = line.index(after: cursor)
+    }
+    guard cursor < line.endIndex, line[cursor] == "." else { return nil }
+    guard let number = Int(line[start..<cursor]) else { return nil }
+    cursor = line.index(after: cursor)
+    guard cursor < line.endIndex, line[cursor].isWhitespace else { return nil }
+    return (number, line.index(after: cursor))
+  }
+
+  guard let first = marker(at: line.startIndex) else { return false }
+  let expectedNextNumber = first.number.addingReportingOverflow(1)
+  guard !expectedNextNumber.overflow else { return false }
+
+  var index = first.next
+  while index < line.endIndex {
+    if line[index].isWhitespace {
+      let candidate = line.index(after: index)
+      if let next = marker(at: candidate), next.number == expectedNextNumber.partialValue {
+        return true
+      }
+    }
+    index = line.index(after: index)
+  }
+  return false
 }
 
 func parseList(startingAt index: Int, in lines: [String], ordered: Bool) -> (items: [String], nextIndex: Int, startNumber: Int?)? {

--- a/apps/ios/ADE/Views/Work/WorkMarkdownParsing.swift
+++ b/apps/ios/ADE/Views/Work/WorkMarkdownParsing.swift
@@ -338,92 +338,28 @@ func parseMarkdownBlocks(_ markdown: String) -> [WorkMarkdownBlock] {
   return parsed
 }
 
-/// Tail-only block parsing for the actively-streaming assistant message.
+/// Block parsing for the actively-streaming assistant preview.
 ///
-/// While a turn streams, the message text grows with every delta, so the
-/// whole-text cache in `parseMarkdownBlocks` misses on every rebuild and the
-/// entire (ever longer) message re-parses each frame. This entry point splits
-/// the text at the last "stable boundary" — the last empty line that is not
-/// inside an unclosed ``` fence. Everything before that boundary can never be
-/// re-interpreted by text that arrives later (every non-code construct in the
-/// parser terminates at a blank line and never looks past one), so the prefix
-/// is parsed once and cached under `cacheKey` (the message id); only the small
-/// growing tail re-parses per delta.
-///
-/// The combined output is exactly `parseMarkdownBlocks(fullText)` — same
-/// kinds, same ids — so views can switch between the streaming and completed
-/// paths without any visual or identity churn.
+/// The caller deliberately supplies only the bounded head/tail slice that can
+/// be rendered in the transcript. Re-scanning that slice is predictable and
+/// safe; attempting to find a stable boundary in the growing authoritative
+/// response added a second full-text scan and copied a prefix on every delta,
+/// while tail slices can change their boundary as the response grows. Keep a
+/// tiny per-message cache for repeated SwiftUI evaluations, and let the normal
+/// parser remain the single source of truth for block identities.
 func parseMarkdownBlocksForStreaming(_ markdown: String, cacheKey: String) -> [WorkMarkdownBlock] {
-  let normalized = markdown.replacingOccurrences(of: "\r\n", with: "\n")
   let key = cacheKey as NSString
   let cached = workStreamingMarkdownCache.object(forKey: key)
-  if let cached, cached.fullText == normalized {
+  if let cached, cached.fullText == markdown {
     return cached.blocks
   }
 
-  guard let boundary = workStreamingStableBoundaryIndex(in: normalized) else {
-    // No stable prefix yet (still inside the first block, or everything sits
-    // in one unclosed leading fence) — parse the whole text fresh.
-    let blocks = parseMarkdownBlocksInternal(normalized)
-    workStreamingMarkdownCache.setObject(
-      WorkStreamingMarkdownCacheBox(prefixText: "", prefixBlocks: [], fullText: normalized, blocks: blocks),
-      forKey: key
-    )
-    return blocks
-  }
-
-  let prefixText = String(normalized[..<boundary])
-  let prefixBlocks: [WorkMarkdownBlock]
-  if let cached, cached.prefixText == prefixText {
-    prefixBlocks = cached.prefixBlocks
-  } else {
-    prefixBlocks = parseMarkdownBlocksInternal(prefixText)
-  }
-
-  let tailBlocks = parseMarkdownBlocksInternal(String(normalized[boundary...]))
-  var blocks = prefixBlocks
-  blocks.reserveCapacity(prefixBlocks.count + tailBlocks.count)
-  for tailBlock in tailBlocks {
-    // Re-id the tail blocks so indices continue from the prefix — the parser
-    // bakes the running block index into each id, and ids must match the
-    // whole-text parse exactly.
-    blocks.append(WorkMarkdownBlock(
-      id: "markdown-block-\(blocks.count)",
-      kind: tailBlock.kind,
-      digest: tailBlock.digest
-    ))
-  }
+  let blocks = parseMarkdownBlocksInternal(markdown)
   workStreamingMarkdownCache.setObject(
-    WorkStreamingMarkdownCacheBox(prefixText: prefixText, prefixBlocks: prefixBlocks, fullText: normalized, blocks: blocks),
+    WorkStreamingMarkdownCacheBox(fullText: markdown, blocks: blocks),
     forKey: key
   )
   return blocks
-}
-
-/// Finds the position just past the last empty line that is NOT inside an
-/// unclosed ``` fence (fence state is tracked by toggling on every line whose
-/// trimmed text starts with "```", mirroring the parser's open/close rule).
-/// Splitting there is safe because blank lines terminate every non-code
-/// construct in `parseMarkdownBlocksInternal`, and the parser's only lookahead
-/// (the table-header check) never crosses a blank line.
-private func workStreamingStableBoundaryIndex(in normalized: String) -> String.Index? {
-  var boundary: String.Index?
-  var insideFence = false
-  var lineStart = normalized.startIndex
-  while lineStart < normalized.endIndex {
-    let newlineIndex = normalized[lineStart...].firstIndex(of: "\n")
-    let lineEnd = newlineIndex ?? normalized.endIndex
-    if lineStart == lineEnd {
-      if !insideFence {
-        boundary = newlineIndex.map { normalized.index(after: $0) } ?? lineEnd
-      }
-    } else if normalized[lineStart..<lineEnd].trimmingCharacters(in: .whitespaces).hasPrefix("```") {
-      insideFence.toggle()
-    }
-    guard let newlineIndex else { break }
-    lineStart = normalized.index(after: newlineIndex)
-  }
-  return boundary
 }
 
 /// Most characters a single rendered prose row may carry.
@@ -580,13 +516,36 @@ private struct WorkInlineMarkupBalance {
   private var backtickRuns = 0
   private var emphasisRuns = 0
   private var brackets = 0
+  private var linkDestinationDepth = 0
+  private var linkDestinationPending = false
   private var beforeEmphasisRun: Character?
 
   var isBalanced: Bool {
-    backtickRuns.isMultiple(of: 2) && emphasisRuns.isMultiple(of: 2) && brackets == 0
+    backtickRuns.isMultiple(of: 2)
+      && emphasisRuns.isMultiple(of: 2)
+      && brackets == 0
+      && linkDestinationDepth == 0
+      && !linkDestinationPending
   }
 
   mutating func consume(_ character: Character, previous: Character?, next: Character?) {
+    if linkDestinationDepth > 0 {
+      if character == "(" {
+        linkDestinationDepth += 1
+      } else if character == ")" {
+        linkDestinationDepth = max(0, linkDestinationDepth - 1)
+      }
+      return
+    }
+    if linkDestinationPending {
+      if character == "(" {
+        linkDestinationDepth = 1
+        linkDestinationPending = false
+        return
+      }
+      linkDestinationPending = false
+    }
+
     switch character {
     case "`":
       if previous != "`" { backtickRuns += 1 }
@@ -606,7 +565,15 @@ private struct WorkInlineMarkupBalance {
     case "]":
       // A close with no open is malformed text, not a span. Clamping stops one
       // stray "]" from making every later boundary read as unbalanced.
-      brackets = max(0, brackets - 1)
+      if brackets > 0 {
+        brackets -= 1
+        if brackets == 0 {
+          // A link destination starts only when the next character is `(`;
+          // keep this pending so nested parentheses in the URL cannot become
+          // an accidental prose cut.
+          linkDestinationPending = true
+        }
+      }
     default:
       break
     }
@@ -888,14 +855,10 @@ private let workStreamingInlineMarkdownCache: NSCache<NSString, WorkMarkdownCach
 /// readers never observe a half-updated entry. Only one message streams at a
 /// time per session, so the limit stays tiny.
 private final class WorkStreamingMarkdownCacheBox: NSObject {
-  let prefixText: String
-  let prefixBlocks: [WorkMarkdownBlock]
   let fullText: String
   let blocks: [WorkMarkdownBlock]
 
-  init(prefixText: String, prefixBlocks: [WorkMarkdownBlock], fullText: String, blocks: [WorkMarkdownBlock]) {
-    self.prefixText = prefixText
-    self.prefixBlocks = prefixBlocks
+  init(fullText: String, blocks: [WorkMarkdownBlock]) {
     self.fullText = fullText
     self.blocks = blocks
   }

--- a/apps/ios/ADE/Views/Work/WorkMarkdownParsing.swift
+++ b/apps/ios/ADE/Views/Work/WorkMarkdownParsing.swift
@@ -108,6 +108,80 @@ struct WorkMarkdownBlock: Identifiable, Equatable {
   }
 }
 
+/// Where a rendered fenced code block sits inside the message it was sliced
+/// from, so Copy and the full-screen viewer can reach the whole block.
+///
+/// The transcript renders a *bounded slice* of a long message, so the code a
+/// block view holds may be a prefix (head-anchored preview) or a suffix
+/// (tail-anchored preview, which also gets a synthetic opening fence so the
+/// slice parses at all) of the real thing. The slice's code blocks are matched
+/// to the full message's by ordinal — from the front for a head slice, from the
+/// back for a tail slice. Every block on the anchored side of the cut parses
+/// identically in both texts, so those ordinals line up; the only partial block
+/// is the one the cut runs through, which is the last (head) or first (tail).
+struct WorkCodeBlockSource {
+  let markdown: String
+  let ordinal: Int
+  let countsFromEnd: Bool
+
+  /// The whole block, or `fallback` when the slice cannot be located (a message
+  /// edited between render and tap, or a slice that parsed to more code blocks
+  /// than the source has).
+  func resolvedCode(fallback: String) -> String {
+    workFullCodeBlockText(
+      in: markdown,
+      ordinal: ordinal,
+      countsFromEnd: countsFromEnd,
+      fallback: fallback
+    )
+  }
+}
+
+extension WorkCodeBlockSource: Equatable {
+  /// `markdown` is compared by length, not content. It only feeds tap-time
+  /// resolution, and every edit that can reach a rendered block also changes
+  /// the block itself — which the owning row already compares.
+  static func == (lhs: WorkCodeBlockSource, rhs: WorkCodeBlockSource) -> Bool {
+    lhs.ordinal == rhs.ordinal
+      && lhs.countsFromEnd == rhs.countsFromEnd
+      && lhs.markdown.utf8.count == rhs.markdown.utf8.count
+  }
+}
+
+/// The authoritative text of the `ordinal`-th fenced code block of `markdown`.
+func workFullCodeBlockText(
+  in markdown: String,
+  ordinal: Int,
+  countsFromEnd: Bool,
+  fallback: String
+) -> String {
+  guard ordinal >= 0 else { return fallback }
+  var codeBlocks: [String] = []
+  for block in parseMarkdownBlocks(markdown) {
+    guard case .code(_, let code) = block.kind else { continue }
+    codeBlocks.append(code)
+  }
+  let index = countsFromEnd ? codeBlocks.count - 1 - ordinal : ordinal
+  guard codeBlocks.indices.contains(index) else { return fallback }
+  return codeBlocks[index]
+}
+
+/// Code-block ordinals for the blocks of one rendered slice, keyed by block id.
+/// A tail-anchored slice numbers from the end so its ordinals match the full
+/// message's.
+func workCodeBlockOrdinals(_ blocks: [WorkMarkdownBlock], countsFromEnd: Bool) -> [String: Int] {
+  var ordinals: [String: Int] = [:]
+  var forward = 0
+  for block in blocks {
+    guard case .code = block.kind else { continue }
+    ordinals[block.id] = forward
+    forward += 1
+  }
+  guard countsFromEnd else { return ordinals }
+  let total = forward
+  return ordinals.mapValues { total - 1 - $0 }
+}
+
 func parseMarkdownBlocks(_ markdown: String) -> [WorkMarkdownBlock] {
   let key = workStableDigest(markdown) as NSString
   if let cached = workMarkdownBlocksCache.object(forKey: key) {

--- a/apps/ios/ADE/Views/Work/WorkMarkdownParsing.swift
+++ b/apps/ios/ADE/Views/Work/WorkMarkdownParsing.swift
@@ -87,8 +87,25 @@ enum WorkMarkdownBlockKind: Equatable {
 }
 
 struct WorkMarkdownBlock: Identifiable, Equatable {
+  /// Position-stable within its message: `markdown-block-<index>`.
+  ///
+  /// Deliberately NOT content-derived. The id used to carry a digest of the
+  /// block's text, so every streaming delta and every "Show more" step handed
+  /// the `LazyVStack` a brand-new identity for a row that was still the same
+  /// row — destroying reuse and re-creating the whole subtree instead of
+  /// updating it. Content changes are detected through `digest` / `kind`.
   let id: String
   let kind: WorkMarkdownBlockKind
+  /// Digest of `kind.cacheKey`, computed once at parse time. Change detection
+  /// (Equatable, presentation signatures) reads this instead of rebuilding and
+  /// re-hashing the block's full text on every refresh.
+  let digest: String
+
+  init(id: String, kind: WorkMarkdownBlockKind, digest: String? = nil) {
+    self.id = id
+    self.kind = kind
+    self.digest = digest ?? workStableDigest(kind.cacheKey)
+  }
 }
 
 func parseMarkdownBlocks(_ markdown: String) -> [WorkMarkdownBlock] {
@@ -152,8 +169,9 @@ func parseMarkdownBlocksForStreaming(_ markdown: String, cacheKey: String) -> [W
     // bakes the running block index into each id, and ids must match the
     // whole-text parse exactly.
     blocks.append(WorkMarkdownBlock(
-      id: "markdown-block-\(blocks.count)-\(workStableDigest(tailBlock.kind.cacheKey))",
-      kind: tailBlock.kind
+      id: "markdown-block-\(blocks.count)",
+      kind: tailBlock.kind,
+      digest: tailBlock.digest
     ))
   }
   workStreamingMarkdownCache.setObject(
@@ -195,8 +213,7 @@ private func parseMarkdownBlocksInternal(_ markdown: String) -> [WorkMarkdownBlo
   var blocks: [WorkMarkdownBlock] = []
 
   func appendBlock(_ kind: WorkMarkdownBlockKind) {
-    let blockID = "markdown-block-\(blocks.count)-\(workStableDigest(kind.cacheKey))"
-    blocks.append(WorkMarkdownBlock(id: blockID, kind: kind))
+    blocks.append(WorkMarkdownBlock(id: "markdown-block-\(blocks.count)", kind: kind))
   }
 
   func appendParagraph(_ lines: [String]) {

--- a/apps/ios/ADE/Views/Work/WorkMarkdownViews.swift
+++ b/apps/ios/ADE/Views/Work/WorkMarkdownViews.swift
@@ -25,6 +25,13 @@ struct WorkMarkdownRenderer: View {
   /// cache, which misses on every delta because the text keeps growing.
   /// Completed messages keep the default whole-text cache path.
   var streamingCacheKey: String? = nil
+  /// The whole message this markdown was sliced from, when `markdown` is a
+  /// bounded preview of it. Copying a fenced block resolves against this, so a
+  /// truncated block still copies whole.
+  var fullMarkdown: String? = nil
+  /// Which end of `fullMarkdown` the slice was taken from. Decides whether code
+  /// blocks are numbered from the front or the back.
+  var previewAnchor: WorkAssistantMessagePreviewAnchor = .head
 
   private var blocks: [WorkMarkdownBlock] {
     if let streamingCacheKey {
@@ -38,17 +45,38 @@ struct WorkMarkdownRenderer: View {
     // Only the last block of a streaming message is still growing; everything
     // above it is final and belongs in the shared caches.
     let streamingTailId = streamingCacheKey == nil ? nil : blocks.last?.id
+    let ordinals = fullMarkdown == nil
+      ? [:]
+      : workCodeBlockOrdinals(blocks, countsFromEnd: previewAnchor == .tail)
     VStack(alignment: .leading, spacing: 10) {
       ForEach(blocks) { block in
-        WorkMarkdownBlockView(block: block, isStreamingTail: block.id == streamingTailId)
+        WorkMarkdownBlockView(
+          block: block,
+          isStreamingTail: block.id == streamingTailId,
+          codeSource: codeSource(for: block, ordinals: ordinals)
+        )
       }
     }
+  }
+
+  private func codeSource(
+    for block: WorkMarkdownBlock,
+    ordinals: [String: Int]
+  ) -> WorkCodeBlockSource? {
+    guard let fullMarkdown, let ordinal = ordinals[block.id] else { return nil }
+    return WorkCodeBlockSource(
+      markdown: fullMarkdown,
+      ordinal: ordinal,
+      countsFromEnd: previewAnchor == .tail
+    )
   }
 }
 
 struct WorkMarkdownBlockView: View {
   let block: WorkMarkdownBlock
   var isStreamingTail = false
+  /// Set when this block was parsed from a bounded slice of a longer message.
+  var codeSource: WorkCodeBlockSource? = nil
 
   var body: some View {
     switch block.kind {
@@ -93,7 +121,7 @@ struct WorkMarkdownBlockView: View {
     case .table(let headers, let rows):
       WorkMarkdownTable(headers: headers, rows: rows, isStreamingTail: isStreamingTail)
     case .code(let language, let code):
-      WorkCodeBlockView(language: language, code: code)
+      WorkCodeBlockView(language: language, code: code, source: codeSource)
     case .rule:
       Divider()
     }
@@ -148,22 +176,53 @@ struct WorkMarkdownTable: View {
 struct WorkCodeBlockView: View {
   let language: String?
   let code: String
+  /// Non-nil when `code` is the slice of a block from a longer message. Copy
+  /// and the viewer resolve the whole block through it, at tap time — resolving
+  /// on every render pass would reparse the message behind every frame.
+  var source: WorkCodeBlockSource? = nil
+
+  @State private var copied = false
 
   var detectedLanguage: FilesLanguage {
     FilesLanguage.detect(languageId: language, filePath: "snippet.\(language ?? "txt")")
   }
 
+  private var label: String {
+    (language?.isEmpty == false ? language : detectedLanguage.displayName)
+      .map { $0.uppercased() } ?? detectedLanguage.displayName.uppercased()
+  }
+
   var body: some View {
     VStack(alignment: .leading, spacing: 8) {
       HStack(spacing: 8) {
-        Text((language?.isEmpty == false ? language : detectedLanguage.displayName).map { $0.uppercased() } ?? detectedLanguage.displayName.uppercased())
+        Text(label)
           .font(.caption2.weight(.semibold))
           .foregroundStyle(ADEColor.textMuted)
         Spacer()
-        Button("Copy") {
-          UIPasteboard.general.string = code
+        WorkOpenFullOutputButton(
+          title: "Code · \(label.lowercased())",
+          text: code,
+          kind: .code,
+          languageId: language,
+          codeSource: source
+        )
+        Button {
+          // The rendered block can be a slice; the clipboard never is.
+          UIPasteboard.general.string = source?.resolvedCode(fallback: code) ?? code
+          copied = true
+          Task { @MainActor in
+            try? await Task.sleep(nanoseconds: 1_400_000_000)
+            copied = false
+          }
+        } label: {
+          Text(copied ? "Copied" : "Copy")
+            .font(.caption2.weight(.semibold))
+            .foregroundStyle(copied ? ADEColor.success : ADEColor.accent)
+            .frame(minHeight: 44)
+            .contentShape(Rectangle())
         }
-        .font(.caption2.weight(.semibold))
+        .buttonStyle(.plain)
+        .accessibilityLabel(copied ? "Copied to clipboard" : "Copy code")
       }
       ScrollView(.horizontal, showsIndicators: false) {
         Text(SyntaxHighlighter.highlightedAttributedString(code, as: detectedLanguage))

--- a/apps/ios/ADE/Views/Work/WorkMarkdownViews.swift
+++ b/apps/ios/ADE/Views/Work/WorkMarkdownViews.swift
@@ -32,6 +32,9 @@ struct WorkMarkdownRenderer: View {
   /// Which end of `fullMarkdown` the slice was taken from. Decides whether code
   /// blocks are numbered from the front or the back.
   var previewAnchor: WorkAssistantMessagePreviewAnchor = .head
+  /// Stable identity for the authoritative source. The chat timeline passes
+  /// its stamped digest/revision so source equality never relies on length.
+  var fullMarkdownIdentity: String? = nil
 
   private var blocks: [WorkMarkdownBlock] {
     if let streamingCacheKey {
@@ -67,7 +70,8 @@ struct WorkMarkdownRenderer: View {
     return WorkCodeBlockSource(
       markdown: fullMarkdown,
       ordinal: ordinal,
-      countsFromEnd: previewAnchor == .tail
+      countsFromEnd: previewAnchor == .tail,
+      markdownIdentity: fullMarkdownIdentity
     )
   }
 }

--- a/apps/ios/ADE/Views/Work/WorkMarkdownViews.swift
+++ b/apps/ios/ADE/Views/Work/WorkMarkdownViews.swift
@@ -20,10 +20,10 @@ struct WorkInlineMarkdownText: View {
 struct WorkMarkdownRenderer: View {
   let markdown: String
   /// Non-nil while this markdown is still receiving streaming deltas. Routes
-  /// block parsing through the tail-only streaming parser (stable prefix
-  /// cached under this key — the message id) instead of the whole-text block
-  /// cache, which misses on every delta because the text keeps growing.
-  /// Completed messages keep the default whole-text cache path.
+  /// block parsing through the bounded streaming parser, which caches the
+  /// latest preview under this key instead of asking the whole-text cache to
+  /// retain throwaway revisions. Completed messages keep the default
+  /// whole-text cache path.
   var streamingCacheKey: String? = nil
   /// The whole message this markdown was sliced from, when `markdown` is a
   /// bounded preview of it. Copying a fenced block resolves against this, so a

--- a/apps/ios/ADE/Views/Work/WorkModels.swift
+++ b/apps/ios/ADE/Views/Work/WorkModels.swift
@@ -876,6 +876,26 @@ func workLatestTurnEndTurnId(in timeline: [WorkTimelineEntry]) -> String? {
   return nil
 }
 
+/// Entries that arrived after the most recent turn-end marker — i.e. the rows
+/// belonging to the turn currently in flight.
+///
+/// Position, not `turnId`, is the attribution rule: not every payload carries a
+/// turn id, and the marker is itself a timeline row, so "after the last marker"
+/// is both cheaper and total. Combined with `isStreamingTurn` it answers the one
+/// question every collapsible card asks — "is my turn still going?" — and it
+/// answers "no" for the whole transcript when nothing is streaming, which is
+/// what makes a reopened chat render entirely collapsed.
+func workEntryIdsAfterLatestTurnEnd(in timeline: [WorkTimelineEntry]) -> Set<String> {
+  var ids = Set<String>()
+  for entry in timeline.reversed() {
+    if case .turnEndMarker = entry.payload {
+      return ids
+    }
+    ids.insert(entry.id)
+  }
+  return ids
+}
+
 struct WorkTimelineEntry: Identifiable, Equatable {
   let id: String
   let timestamp: String
@@ -1032,6 +1052,8 @@ struct WorkChatTimelineSnapshot: Equatable {
   var latestTranscriptTimestamp: String?
   var latestMessageAssistantId: String?
   var latestTurnEndTurnId: String?
+  /// Rows belonging to the turn in flight. Empty once every turn has ended.
+  var liveTurnEntryIds: Set<String>
   var timeline: [WorkTimelineEntry]
 
   static let empty = WorkChatTimelineSnapshot(
@@ -1050,6 +1072,7 @@ struct WorkChatTimelineSnapshot: Equatable {
     latestTranscriptTimestamp: nil,
     latestMessageAssistantId: nil,
     latestTurnEndTurnId: nil,
+    liveTurnEntryIds: [],
     timeline: []
   )
 

--- a/apps/ios/ADE/Views/Work/WorkModels.swift
+++ b/apps/ios/ADE/Views/Work/WorkModels.swift
@@ -145,6 +145,13 @@ struct WorkChatMessage: Identifiable, Equatable {
   var markdownLineCount: Int? = nil
   var markdownHasCarriageReturn: Bool? = nil
   var markdownContainsFence: Bool? = nil
+  /// Number of backticks at the authoritative text's end. This lets a fence
+  /// split across two live deltas be recognized without rescanning the full
+  /// response.
+  var markdownTrailingBacktickRun: Int? = nil
+  /// Opening marker for the currently unclosed fence, if the response ends
+  /// inside one. Tail previews use it to avoid a full-prefix fence scan.
+  var markdownOpenFenceMarker: String? = nil
   /// Incremental fixed-column classification state for the append-only live
   /// path. Completed snapshot messages leave this nil and classify normally.
   var markdownMonospacedClassifier: WorkStreamingMonospacedClassifierState? = nil

--- a/apps/ios/ADE/Views/Work/WorkModels.swift
+++ b/apps/ios/ADE/Views/Work/WorkModels.swift
@@ -142,6 +142,10 @@ struct WorkChatMessage: Identifiable, Equatable {
   /// on every token batch. Completed snapshot messages leave these nil and
   /// continue to derive their values from the authoritative markdown.
   var markdownCharacterCount: Int? = nil
+  /// Exact UTF-8 byte count for the authoritative markdown. The streaming
+  /// merger uses this to avoid rescanning the entire growing response before
+  /// deciding whether an incoming provider payload is a fragment or replay.
+  var markdownUTF8Count: Int? = nil
   var markdownLineCount: Int? = nil
   var markdownHasCarriageReturn: Bool? = nil
   var markdownContainsFence: Bool? = nil
@@ -776,6 +780,7 @@ struct WorkAssistantMessageControlsModel: Identifiable, Equatable {
   let totalLineCount: Int
   let canShowMore: Bool
   let nextLineBudget: Int
+  let willRemainTruncatedAfterNextStep: Bool
   /// The reader has already taken one "Show more" step on this message, so the
   /// ladder's next rung is the full-screen viewer rather than another step.
   var hasExpandedInPlace = false
@@ -788,6 +793,7 @@ struct WorkAssistantMessageControlsModel: Identifiable, Equatable {
       && lhs.totalLineCount == rhs.totalLineCount
       && lhs.canShowMore == rhs.canShowMore
       && lhs.nextLineBudget == rhs.nextLineBudget
+      && lhs.willRemainTruncatedAfterNextStep == rhs.willRemainTruncatedAfterNextStep
       && lhs.hasExpandedInPlace == rhs.hasExpandedInPlace
   }
 }
@@ -1074,6 +1080,7 @@ struct WorkChatTimelineSnapshot: Equatable {
   var transcriptHasInterruptibleActivity: Bool
   var latestTranscriptTimestamp: String?
   var latestMessageAssistantId: String?
+  var latestMessageAssistantItemId: String?
   var latestTurnEndTurnId: String?
   /// Rows belonging to the turn in flight. Empty once every turn has ended.
   var liveTurnEntryIds: Set<String>
@@ -1094,6 +1101,7 @@ struct WorkChatTimelineSnapshot: Equatable {
     transcriptHasInterruptibleActivity: false,
     latestTranscriptTimestamp: nil,
     latestMessageAssistantId: nil,
+    latestMessageAssistantItemId: nil,
     latestTurnEndTurnId: nil,
     liveTurnEntryIds: [],
     timeline: []

--- a/apps/ios/ADE/Views/Work/WorkModels.swift
+++ b/apps/ios/ADE/Views/Work/WorkModels.swift
@@ -113,6 +113,14 @@ struct WorkChatMessage: Identifiable, Equatable {
   let id: String
   let role: String
   var markdown: String
+  /// Digest of `markdown`, stamped once by the (off-main) snapshot fold.
+  ///
+  /// Change detection used to hash the full text of every visible message on
+  /// every presentation refresh — main-thread work proportional to the whole
+  /// visible transcript, several times a second during a streaming turn. Nil
+  /// only for messages built outside the fold, where the callers below fall
+  /// back to hashing the text.
+  var markdownDigest: String? = nil
   var assistantPreview: WorkAssistantMessagePreview? = nil
   let timestamp: String
   let turnId: String?
@@ -718,12 +726,16 @@ struct WorkAssistantMonospacedRenderModel: Identifiable, Equatable {
   let itemId: String?
   let text: String
   let accessibilityLabel: String
+  /// Digest of the source message. Lets change detection separate two slices of
+  /// two different messages without hashing either slice.
+  var sourceDigest: String = ""
 
   static func == (lhs: WorkAssistantMonospacedRenderModel, rhs: WorkAssistantMonospacedRenderModel) -> Bool {
     lhs.id == rhs.id
       && lhs.messageId == rhs.messageId
       && lhs.turnId == rhs.turnId
       && lhs.itemId == rhs.itemId
+      && lhs.sourceDigest == rhs.sourceDigest
       && lhs.text == rhs.text
       && lhs.accessibilityLabel == rhs.accessibilityLabel
   }

--- a/apps/ios/ADE/Views/Work/WorkModels.swift
+++ b/apps/ios/ADE/Views/Work/WorkModels.swift
@@ -708,6 +708,9 @@ struct WorkAssistantMarkdownBlockRenderModel: Identifiable, Equatable {
   /// The one block still receiving deltas. Its renders are throwaway, so they
   /// are kept out of the shared inline-markdown cache.
   var isStreamingTail = false
+  /// Set on fenced code blocks of a message the transcript is only rendering a
+  /// slice of, so Copy and the viewer reach the whole block.
+  var codeSource: WorkCodeBlockSource? = nil
 
   static func == (lhs: WorkAssistantMarkdownBlockRenderModel, rhs: WorkAssistantMarkdownBlockRenderModel) -> Bool {
     lhs.id == rhs.id
@@ -715,6 +718,7 @@ struct WorkAssistantMarkdownBlockRenderModel: Identifiable, Equatable {
       && lhs.turnId == rhs.turnId
       && lhs.itemId == rhs.itemId
       && lhs.isStreamingTail == rhs.isStreamingTail
+      && lhs.codeSource == rhs.codeSource
       && lhs.block == rhs.block
   }
 }
@@ -749,6 +753,9 @@ struct WorkAssistantMessageControlsModel: Identifiable, Equatable {
   let totalLineCount: Int
   let canShowMore: Bool
   let nextLineBudget: Int
+  /// The reader has already taken one "Show more" step on this message, so the
+  /// ladder's next rung is the full-screen viewer rather than another step.
+  var hasExpandedInPlace = false
 
   static func == (lhs: WorkAssistantMessageControlsModel, rhs: WorkAssistantMessageControlsModel) -> Bool {
     lhs.id == rhs.id
@@ -758,6 +765,7 @@ struct WorkAssistantMessageControlsModel: Identifiable, Equatable {
       && lhs.totalLineCount == rhs.totalLineCount
       && lhs.canShowMore == rhs.canShowMore
       && lhs.nextLineBudget == rhs.nextLineBudget
+      && lhs.hasExpandedInPlace == rhs.hasExpandedInPlace
   }
 }
 

--- a/apps/ios/ADE/Views/Work/WorkModels.swift
+++ b/apps/ios/ADE/Views/Work/WorkModels.swift
@@ -132,6 +132,22 @@ struct WorkChatMessage: Identifiable, Equatable {
   var processed: Bool? = nil
   var attachments: [AgentChatFileRef]? = nil
   var unprocessedResolution: WorkUserMessageResolution? = nil
+  /// Monotonic content revision for the incremental streaming path. The
+  /// off-main snapshot fold stamps `markdownDigest` once, but live deltas
+  /// mutate the same message on the main actor and must invalidate preview
+  /// caches without hashing the entire growing response again.
+  var markdownRevision: UInt64 = 0
+  /// Exact counts for the append-only streaming path. They are updated from
+  /// the incoming delta, so preview summaries do not recount the whole answer
+  /// on every token batch. Completed snapshot messages leave these nil and
+  /// continue to derive their values from the authoritative markdown.
+  var markdownCharacterCount: Int? = nil
+  var markdownLineCount: Int? = nil
+  var markdownHasCarriageReturn: Bool? = nil
+  var markdownContainsFence: Bool? = nil
+  /// Incremental fixed-column classification state for the append-only live
+  /// path. Completed snapshot messages leave this nil and classify normally.
+  var markdownMonospacedClassifier: WorkStreamingMonospacedClassifierState? = nil
 }
 
 struct WorkLocalEchoMessage: Identifiable, Equatable {

--- a/apps/ios/ADE/Views/Work/WorkOutputViewerScreen.swift
+++ b/apps/ios/ADE/Views/Work/WorkOutputViewerScreen.swift
@@ -1,0 +1,568 @@
+import SwiftUI
+import UIKit
+
+/// One request to read a box's whole contents on its own screen.
+///
+/// The transcript shows boxed output — tool results, command output, fenced
+/// code, diffs, monospace reports — at a fixed height with no inner scroller,
+/// so anything past that height is unreachable in place. This is how a box
+/// hands the full, authoritative text over to the reader.
+struct WorkOutputViewerRequest: Identifiable {
+  enum Kind {
+    case text
+    case code
+    case diff
+  }
+
+  /// Fresh per request: presenting the same content twice must re-present.
+  let id = UUID()
+  let title: String
+  var subtitle: String? = nil
+  let text: String
+  var kind: Kind = .text
+  /// Language hint for `.code`, e.g. "swift".
+  var languageId: String? = nil
+}
+
+/// Owner of the full-screen viewer for one chat surface.
+///
+/// Boxes ask for the viewer through the environment instead of each carrying
+/// its own `fullScreenCover`: a presentation host per transcript row would cost
+/// the `LazyVStack` a modifier that almost never fires. The surface holds one
+/// of these and presents from it.
+final class WorkOutputViewerModel: ObservableObject {
+  @Published var request: WorkOutputViewerRequest?
+
+  func present(_ request: WorkOutputViewerRequest) {
+    self.request = request
+  }
+}
+
+private struct WorkOutputViewerEnvironmentKey: EnvironmentKey {
+  static let defaultValue: WorkOutputViewerModel? = nil
+}
+
+extension EnvironmentValues {
+  /// Nil on surfaces that render boxes without a viewer (previews, the PR
+  /// wizard). Affordances that need it hide themselves rather than dead-end.
+  var workOutputViewer: WorkOutputViewerModel? {
+    get { self[WorkOutputViewerEnvironmentKey.self] }
+    set { self[WorkOutputViewerEnvironmentKey.self] = newValue }
+  }
+}
+
+// MARK: - Clipping
+
+/// A `WorkStructuredOutputBlock` clips at 180pt. Caption monospaced lines lay
+/// out at ~15pt, and a phone-width box fits ~46 of those characters per line.
+let workStructuredOutputBoxLineCapacity = 11
+let workStructuredOutputBoxColumnCapacity = 46
+/// `WorkDiffOutputBlock` clips at 220pt, with 4pt of padding per diff line.
+let workDiffOutputBoxLineCapacity = 11
+/// `WorkInlineDiffPreview` clips at 320pt with no per-line padding.
+let workInlineDiffPreviewLineCapacity = 19
+
+/// Whether `text` overflows a box that clips at a fixed height.
+///
+/// Phase 1 de-nested the transcript's inner scrollers, so these boxes clip
+/// instead of scrolling. This is what decides whether the reader is looking at
+/// a partial view and should be offered the full-screen viewer.
+///
+/// - Parameters:
+///   - lineCapacity: laid-out lines the box shows before it clips.
+///   - columnCapacity: characters per line before wrapping, or nil for a box
+///     that scrolls horizontally instead of wrapping (the diffs).
+func workOutputBoxOverflows(_ text: String, lineCapacity: Int, columnCapacity: Int?) -> Bool {
+  guard lineCapacity > 0 else { return !text.isEmpty }
+
+  guard let columnCapacity, columnCapacity > 0 else {
+    // Non-wrapping box: only hard line breaks push content down, and the scan
+    // stops at the first line past the cap, so a huge diff pays for ~12 lines.
+    var renderedLines = 1
+    for byte in text.utf8 where byte == 0x0A {
+      renderedLines += 1
+      if renderedLines > lineCapacity { return true }
+    }
+    return false
+  }
+
+  // O(1) upper bound: text that cannot fill the box even packed as one dense
+  // run of bytes cannot overflow it, so a long result never pays for a scan.
+  if text.utf8.count > lineCapacity * columnCapacity { return true }
+
+  var renderedLines = 1
+  var column = 0
+  for character in text {
+    if character == "\n" {
+      renderedLines += 1
+      column = 0
+    } else {
+      column += 1
+      if column > columnCapacity {
+        renderedLines += 1
+        column = 1
+      }
+    }
+    if renderedLines > lineCapacity { return true }
+  }
+  return false
+}
+
+// MARK: - Hybrid expand ladder
+
+/// The one affordance a bounded box offers next.
+enum WorkTruncatedOutputAffordance: Equatable {
+  case none
+  case showMore
+  case openFullOutput
+}
+
+/// The hybrid expand ladder, as one decision.
+///
+/// The first tap expands downward in place. Anything still bounded after that
+/// step goes to the full-screen viewer instead of stepping again — a box that
+/// clips at a fixed height cannot show what another step would add, and a
+/// reader paginating a 2000-line answer four lines at a time is not being
+/// helped.
+func workTruncatedOutputAffordance(
+  isTruncated: Bool,
+  hasExpandedInPlace: Bool,
+  isClipped: Bool
+) -> WorkTruncatedOutputAffordance {
+  if isTruncated {
+    return hasExpandedInPlace ? .openFullOutput : .showMore
+  }
+  return isClipped ? .openFullOutput : .none
+}
+
+// MARK: - Affordances
+
+/// Shared "read this box full screen" control.
+struct WorkOpenFullOutputButton: View {
+  let title: String
+  var subtitle: String? = nil
+  /// What the box is displaying. Also the fallback text when `codeSource`
+  /// cannot resolve.
+  let text: String
+  var kind: WorkOutputViewerRequest.Kind = .text
+  var languageId: String? = nil
+  /// Set when `text` is a slice of a larger message; the whole block is
+  /// resolved at tap time rather than on every render pass.
+  var codeSource: WorkCodeBlockSource? = nil
+  /// Box headers use the compact "Open"; the transcript's ladder spells it out.
+  var label: String = "Open"
+  var prominent = false
+
+  @Environment(\.workOutputViewer) private var viewer
+
+  var body: some View {
+    if let viewer {
+      Button {
+        viewer.present(
+          WorkOutputViewerRequest(
+            title: title,
+            subtitle: subtitle,
+            text: codeSource?.resolvedCode(fallback: text) ?? text,
+            kind: kind,
+            languageId: languageId
+          )
+        )
+      } label: {
+        Label(label, systemImage: "arrow.up.left.and.arrow.down.right")
+          .labelStyle(.titleAndIcon)
+          .font(.caption2.weight(.semibold))
+          .frame(minHeight: 44)
+          .contentShape(Rectangle())
+      }
+      .buttonStyle(.plain)
+      .foregroundStyle(prominent ? ADEColor.accent : ADEColor.textSecondary)
+      .accessibilityLabel("Open \(title.lowercased()) full screen")
+    }
+  }
+}
+
+/// Makes a clipping box's content open the viewer when tapped, so the reader
+/// does not have to find the header control to reach what is cut off.
+struct WorkOpenFullOutputTapModifier: ViewModifier {
+  let title: String
+  var subtitle: String? = nil
+  let text: String
+  var kind: WorkOutputViewerRequest.Kind = .text
+  var languageId: String? = nil
+
+  @Environment(\.workOutputViewer) private var viewer
+
+  private func present() {
+    viewer?.present(
+      WorkOutputViewerRequest(
+        title: title,
+        subtitle: subtitle,
+        text: text,
+        kind: kind,
+        languageId: languageId
+      )
+    )
+  }
+
+  func body(content: Content) -> some View {
+    content
+      .contentShape(Rectangle())
+      .onTapGesture { present() }
+      .accessibilityAction(named: "Open full output") { present() }
+  }
+}
+
+extension View {
+  /// Applied to the clipped region of a box. A no-op when nothing is cut off.
+  @ViewBuilder
+  func workOpensFullOutput(
+    _ isClipped: Bool,
+    title: String,
+    subtitle: String? = nil,
+    text: String,
+    kind: WorkOutputViewerRequest.Kind = .text,
+    languageId: String? = nil
+  ) -> some View {
+    if isClipped {
+      modifier(
+        WorkOpenFullOutputTapModifier(
+          title: title,
+          subtitle: subtitle,
+          text: text,
+          kind: kind,
+          languageId: languageId
+        )
+      )
+    } else {
+      self
+    }
+  }
+}
+
+// MARK: - Search
+
+/// Line index of every case-insensitive occurrence of `query`. A line with
+/// three hits contributes three entries, so "3 of 12" counts matches and not
+/// lines, and stepping walks hits in reading order.
+func workOutputViewerMatchLines(_ lines: [String], query: String) -> [Int] {
+  let needle = query.trimmingCharacters(in: .whitespacesAndNewlines)
+  guard !needle.isEmpty else { return [] }
+  var result: [Int] = []
+  for (index, line) in lines.enumerated() {
+    var cursor = line.startIndex
+    while cursor < line.endIndex,
+          let found = line.range(of: needle, options: [.caseInsensitive], range: cursor..<line.endIndex) {
+      result.append(index)
+      cursor = found.upperBound > found.lowerBound
+        ? found.upperBound
+        : line.index(after: found.lowerBound)
+    }
+  }
+  return result
+}
+
+/// Wraps around at both ends: the reader stepping past the last hit expects the
+/// first one, not a dead button.
+func workOutputViewerSteppedMatchIndex(current: Int, delta: Int, count: Int) -> Int {
+  guard count > 0 else { return 0 }
+  let stepped = (current + delta) % count
+  return stepped < 0 ? stepped + count : stepped
+}
+
+// MARK: - Screen
+
+/// Full-screen reader for any boxed output in a chat.
+///
+/// Line-based and lazy on purpose: the text can be a 100k-character tool
+/// result, and one `Text` that long with a line-number gutter would lay the
+/// whole thing out before drawing a single row.
+struct WorkOutputViewerScreen: View {
+  let request: WorkOutputViewerRequest
+
+  /// Split once, at init. Recomputing this in `body` would rescan the whole
+  /// text on every keystroke in the search field.
+  private let lines: [String]
+
+  @Environment(\.dismiss) private var dismiss
+  @State private var wrapsLines = false
+  @State private var searchVisible = false
+  @State private var query = ""
+  @State private var matches: [Int] = []
+  /// Same hits as `matches`, as a set. Rows ask "am I a match?" once each, so
+  /// this is built with the results rather than rebuilt per row.
+  @State private var matchedLines: Set<Int> = []
+  @State private var matchIndex = 0
+  /// Bumped whenever the current match moves, including when a fresh search
+  /// lands back on index 0 — watching `matchIndex` alone would not scroll to
+  /// the first hit of the reader's second query.
+  @State private var matchScrollToken = 0
+  @State private var copied = false
+  @FocusState private var searchFocused: Bool
+
+  init(request: WorkOutputViewerRequest) {
+    self.request = request
+    let split = splitPreservingEmptyLines(request.text)
+    self.lines = split.isEmpty ? [""] : split
+  }
+
+  private var trimmedQuery: String {
+    query.trimmingCharacters(in: .whitespacesAndNewlines)
+  }
+
+  private var currentMatchLine: Int? {
+    matches.indices.contains(matchIndex) ? matches[matchIndex] : nil
+  }
+
+  private var lineNumberWidth: CGFloat {
+    min(max(CGFloat(String(lines.count).count) * 8 + 10, 26), 58)
+  }
+
+  private var language: FilesLanguage {
+    FilesLanguage.detect(
+      languageId: request.languageId,
+      filePath: "snippet.\(request.languageId ?? "txt")"
+    )
+  }
+
+  var body: some View {
+    NavigationStack {
+      ScrollViewReader { proxy in
+        contentScroll
+          .onChange(of: matchScrollToken) { _, _ in
+            guard let line = currentMatchLine else { return }
+            withAnimation(.easeOut(duration: 0.18)) {
+              proxy.scrollTo(line, anchor: .center)
+            }
+          }
+      }
+      .adeScreenBackground()
+      .navigationTitle(request.title)
+      .navigationBarTitleDisplayMode(.inline)
+      .adeNavigationGlass()
+      .toolbar { toolbarContent }
+      .safeAreaInset(edge: .top, spacing: 0) { topStrip }
+      .task(id: query) { await refreshMatches() }
+    }
+  }
+
+  @ViewBuilder
+  private var contentScroll: some View {
+    if wrapsLines {
+      ScrollView(.vertical) { rows }
+    } else {
+      ScrollView([.horizontal, .vertical]) { rows }
+    }
+  }
+
+  private var rows: some View {
+    LazyVStack(alignment: .leading, spacing: 0) {
+      ForEach(lines.indices, id: \.self) { index in
+        row(index: index, line: lines[index])
+      }
+    }
+    .padding(.vertical, 10)
+    .frame(maxWidth: wrapsLines ? .infinity : nil, alignment: .leading)
+  }
+
+  private func row(index: Int, line: String) -> some View {
+    HStack(alignment: .top, spacing: 10) {
+      Text("\(index + 1)")
+        .font(.caption2.monospacedDigit())
+        .foregroundStyle(ADEColor.textMuted)
+        .frame(width: lineNumberWidth, alignment: .trailing)
+      Text(rowText(index: index, line: line))
+        .font(.system(.caption, design: .monospaced))
+        .foregroundStyle(foreground(for: line))
+        .lineLimit(nil)
+        .fixedSize(horizontal: !wrapsLines, vertical: wrapsLines)
+        .frame(maxWidth: wrapsLines ? .infinity : nil, alignment: .leading)
+        .textSelection(.enabled)
+    }
+    .frame(maxWidth: wrapsLines ? .infinity : nil, alignment: .leading)
+    .padding(.horizontal, 12)
+    .padding(.vertical, 1)
+    .background(background(index: index, line: line))
+    .id(index)
+  }
+
+  /// Search highlighting wins over syntax highlighting on a matched line: two
+  /// competing sets of colours on one line reads as noise, and the reason the
+  /// line is on screen is the match.
+  private func rowText(index: Int, line: String) -> AttributedString {
+    let rendered = line.isEmpty ? " " : line
+    if matchedLines.contains(index) {
+      return searchHighlighted(rendered)
+    }
+    guard request.kind == .code else {
+      return AttributedString(rendered)
+    }
+    return SyntaxHighlighter.highlightedAttributedString(rendered, as: language)
+  }
+
+  private func searchHighlighted(_ line: String) -> AttributedString {
+    var attributed = AttributedString(line)
+    let needle = trimmedQuery
+    guard !needle.isEmpty else { return attributed }
+    var cursor = line.startIndex
+    while cursor < line.endIndex,
+          let found = line.range(of: needle, options: [.caseInsensitive], range: cursor..<line.endIndex) {
+      if let lower = AttributedString.Index(found.lowerBound, within: attributed),
+         let upper = AttributedString.Index(found.upperBound, within: attributed) {
+        attributed[lower..<upper].backgroundColor = ADEColor.accent.opacity(0.32)
+        attributed[lower..<upper].foregroundColor = ADEColor.textPrimary
+      }
+      cursor = found.upperBound > found.lowerBound
+        ? found.upperBound
+        : line.index(after: found.lowerBound)
+    }
+    return attributed
+  }
+
+  private func foreground(for line: String) -> Color {
+    request.kind == .diff ? diffLineColor(for: line) : ADEColor.textPrimary
+  }
+
+  @ViewBuilder
+  private func background(index: Int, line: String) -> some View {
+    if index == currentMatchLine {
+      ADEColor.accent.opacity(0.14)
+    } else if request.kind == .diff {
+      diffLineBackground(for: line)
+    } else {
+      Color.clear
+    }
+  }
+
+  @ToolbarContentBuilder
+  private var toolbarContent: some ToolbarContent {
+    ToolbarItem(placement: .topBarLeading) {
+      Button("Done") { dismiss() }
+        .fontWeight(.semibold)
+    }
+    ToolbarItemGroup(placement: .topBarTrailing) {
+      Button {
+        searchVisible.toggle()
+        searchFocused = searchVisible
+        if !searchVisible { query = "" }
+      } label: {
+        Image(systemName: searchVisible ? "magnifyingglass.circle.fill" : "magnifyingglass")
+      }
+      .accessibilityLabel(searchVisible ? "Hide search" : "Search output")
+
+      Menu {
+        Toggle("Wrap lines", isOn: $wrapsLines)
+        Button {
+          UIPasteboard.general.string = request.text
+          copied = true
+          Task { @MainActor in
+            try? await Task.sleep(nanoseconds: 1_400_000_000)
+            copied = false
+          }
+        } label: {
+          Label(copied ? "Copied" : "Copy all", systemImage: copied ? "checkmark" : "doc.on.doc")
+        }
+        ShareLink(item: request.text) {
+          Label("Share", systemImage: "square.and.arrow.up")
+        }
+      } label: {
+        Image(systemName: "ellipsis.circle")
+      }
+      .accessibilityLabel("Output actions")
+    }
+  }
+
+  private var topStrip: some View {
+    VStack(spacing: 0) {
+      HStack(spacing: 8) {
+        if let subtitle = request.subtitle, !subtitle.isEmpty {
+          Text(subtitle)
+            .font(.caption2)
+            .foregroundStyle(ADEColor.textMuted)
+            .lineLimit(1)
+            .truncationMode(.middle)
+        }
+        Spacer(minLength: 0)
+        Text("\(lines.count) line\(lines.count == 1 ? "" : "s")")
+          .font(.caption2.monospacedDigit())
+          .foregroundStyle(ADEColor.textMuted)
+      }
+      .padding(.horizontal, 16)
+      .padding(.vertical, 6)
+
+      if searchVisible {
+        searchBar
+      }
+
+      Divider().opacity(0.4)
+    }
+    .background(.ultraThinMaterial)
+  }
+
+  private var searchBar: some View {
+    HStack(spacing: 8) {
+      Image(systemName: "magnifyingglass")
+        .font(.caption)
+        .foregroundStyle(ADEColor.textMuted)
+      TextField("Find in output", text: $query)
+        .font(.caption)
+        .focused($searchFocused)
+        .autocorrectionDisabled()
+        .textInputAutocapitalization(.never)
+        .submitLabel(.search)
+
+      if !trimmedQuery.isEmpty {
+        Text(matches.isEmpty ? "No matches" : "\(matchIndex + 1) of \(matches.count)")
+          .font(.caption2.monospacedDigit())
+          .foregroundStyle(ADEColor.textMuted)
+      }
+
+      Button {
+        matchIndex = workOutputViewerSteppedMatchIndex(current: matchIndex, delta: -1, count: matches.count)
+        matchScrollToken += 1
+      } label: {
+        Image(systemName: "chevron.up")
+          .font(.caption.weight(.semibold))
+          .frame(width: 44, height: 34)
+          .contentShape(Rectangle())
+      }
+      .buttonStyle(.plain)
+      .disabled(matches.isEmpty)
+      .accessibilityLabel("Previous match")
+
+      Button {
+        matchIndex = workOutputViewerSteppedMatchIndex(current: matchIndex, delta: 1, count: matches.count)
+        matchScrollToken += 1
+      } label: {
+        Image(systemName: "chevron.down")
+          .font(.caption.weight(.semibold))
+          .frame(width: 44, height: 34)
+          .contentShape(Rectangle())
+      }
+      .buttonStyle(.plain)
+      .disabled(matches.isEmpty)
+      .accessibilityLabel("Next match")
+    }
+    .foregroundStyle(ADEColor.textSecondary)
+    .padding(.horizontal, 16)
+    .padding(.bottom, 6)
+  }
+
+  /// Debounced: scanning 100k characters per keystroke would land the work on
+  /// the main thread between every two letters the reader types.
+  private func refreshMatches() async {
+    let needle = trimmedQuery
+    guard !needle.isEmpty else {
+      matches = []
+      matchedLines = []
+      matchIndex = 0
+      return
+    }
+    try? await Task.sleep(nanoseconds: 180_000_000)
+    guard !Task.isCancelled else { return }
+    let found = workOutputViewerMatchLines(lines, query: needle)
+    matches = found
+    matchedLines = Set(found)
+    matchIndex = 0
+    matchScrollToken += 1
+  }
+}

--- a/apps/ios/ADE/Views/Work/WorkPreviews.swift
+++ b/apps/ios/ADE/Views/Work/WorkPreviews.swift
@@ -432,6 +432,8 @@ private enum WorkPreviewData {
       chatSummaryContext: WorkChatSummaryRenderContext(WorkPreviewData.chatSummary),
       transcript: WorkPreviewData.transcript,
       transcriptRenderSignature: workChatEnvelopeListRenderSignature(WorkPreviewData.transcript),
+      allowsIncrementalTranscriptUpdate: false,
+      transcriptIncrementalDelta: .constant([]),
       fallbackEntries: [],
       fallbackEntriesRenderSignature: workFallbackEntriesRenderSignature([]),
       artifacts: [WorkPreviewData.artifact],

--- a/apps/ios/ADE/Views/Work/WorkPreviews.swift
+++ b/apps/ios/ADE/Views/Work/WorkPreviews.swift
@@ -440,13 +440,15 @@ private enum WorkPreviewData {
       optimisticPendingSteersRenderSignature: workPendingSteersRenderSignature([]),
       localEchoMessages: [],
       localEchoMessagesRenderSignature: workLocalEchoMessagesRenderSignature([]),
-      expandedToolCardIdsSnapshot: ["cmd-1"],
-      expandedToolCardIdsRenderSignature: workExpandedToolCardIdsRenderSignature(["cmd-1"]),
+      cardExpansionSnapshot: WorkCardExpansionState(expandedIds: ["cmd-1"]),
+      cardExpansionRenderSignature: workCardExpansionRenderSignature(
+        WorkCardExpansionState(expandedIds: ["cmd-1"])
+      ),
       artifactContentRenderSignature: workLoadedArtifactContentRenderSignature([:]),
       artifactDrawerPresentedSnapshot: false,
       sendingSnapshot: false,
       errorMessageSnapshot: nil,
-      expandedToolCardIds: Binding<Set<String>>.constant(["cmd-1"]),
+      cardExpansion: .constant(WorkCardExpansionState(expandedIds: ["cmd-1"])),
       artifactContent: .constant([:]),
       fullscreenImage: Binding<WorkFullscreenImage?>.constant(nil),
       artifactDrawerPresented: .constant(false),

--- a/apps/ios/ADE/Views/Work/WorkReasoningCard.swift
+++ b/apps/ios/ADE/Views/Work/WorkReasoningCard.swift
@@ -8,12 +8,14 @@ import SwiftUI
 struct WorkReasoningCard: View {
   let card: WorkEventCardModel
   let isLive: Bool
-
-  @Environment(\.accessibilityReduceMotion) private var reduceMotion
   // Default collapsed — reasoning is the model's scratchpad, not the answer.
   // We no longer auto-expand while live: thoughts should not fill the view
-  // unless the user explicitly opts in by tapping the pill.
-  @State private var isExpanded: Bool = false
+  // unless the user explicitly opts in by tapping the pill. Expansion is owned
+  // by the session's central set so it survives list recycling.
+  let isExpanded: Bool
+  let onToggle: () -> Void
+
+  @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
   private var bodyText: String? {
     guard let body = card.body else { return nil }
@@ -54,7 +56,7 @@ struct WorkReasoningCard: View {
   private var compactPill: some View {
     Button {
       withAnimation(ADEMotion.quick(reduceMotion: reduceMotion)) {
-        isExpanded.toggle()
+        onToggle()
       }
     } label: {
       HStack(spacing: 6) {

--- a/apps/ios/ADE/Views/Work/WorkSessionDestinationView+Actions.swift
+++ b/apps/ios/ADE/Views/Work/WorkSessionDestinationView+Actions.swift
@@ -39,7 +39,17 @@ extension WorkSessionDestinationView {
     let pendingUploadRefs = WorkPendingUploadPreviewStore.shared.register(
       workChatInputReadyAttachments(inputAttachments)
     )
-    let initialDeliveryState = (sendWillQueueChatMessage || useSteer) ? "queued" : "sending"
+    // Desktop parity: the chosen active-turn mode rides the steer itself, so a
+    // host that can honor it dispatches in one round-trip and the message never
+    // enters the staged queue. Resolved before the send, not after it, so the
+    // "turn is already active" resend below carries the same mode — that is
+    // where a Send-now tap used to be silently downgraded to a staged message.
+    let atomicDispatchMode = workChatAtomicSteerDispatchMode(
+      deliveryMode: deliveryMode,
+      dispatchModes: manualSteerDispatchModes
+    )
+    let willStage = sendWillQueueChatMessage || (useSteer && atomicDispatchMode == nil)
+    let initialDeliveryState = willStage ? "queued" : "sending"
     let echo = WorkLocalEchoMessage(
       text: text,
       timestamp: workDateFormatter.string(from: Date()),
@@ -81,7 +91,8 @@ extension WorkSessionDestinationView {
         delivery = try await syncService.steerChatSession(
           sessionId: sessionId,
           text: text,
-          attachments: attachmentRefs.isEmpty ? nil : attachmentRefs
+          attachments: attachmentRefs.isEmpty ? nil : attachmentRefs,
+          dispatchMode: atomicDispatchMode
         )
       } else {
         do {
@@ -91,22 +102,33 @@ extension WorkSessionDestinationView {
             attachments: attachmentRefs.isEmpty ? nil : attachmentRefs
           )
         } catch where workChatErrorIndicatesActiveTurn(error) {
-          updateLocalEchoDeliveryState(echoId: echoId, deliveryState: "queued")
+          // The row said idle but the runtime is busy. Resend as a steer — with
+          // the mode attached, so an atomic send stays an atomic send and the
+          // echo keeps its "sending" state instead of flashing "queued".
+          if atomicDispatchMode == nil {
+            updateLocalEchoDeliveryState(echoId: echoId, deliveryState: "queued")
+          }
           delivery = try await syncService.steerChatSession(
             sessionId: sessionId,
             text: text,
-            attachments: attachmentRefs.isEmpty ? nil : attachmentRefs
+            attachments: attachmentRefs.isEmpty ? nil : attachmentRefs,
+            dispatchMode: atomicDispatchMode
           )
         }
       }
       switch delivery {
       case .queued(let steerId):
-        if useSteer, let steerId, deliveryMode == .inline || deliveryMode == .interrupt {
+        // We asked for an atomic dispatch and got a staged row back, so this
+        // host predates `dispatchMode` on `chat.steer` (it shipped later than
+        // `chat.dispatchSteer`, which is what the capability gate checks).
+        // Promote with the older two-step call rather than dropping the mode
+        // the user picked. Current hosts answer `.sent` and never land here.
+        if let steerId, let atomicDispatchMode {
           do {
             try await syncService.dispatchChatSteer(
               sessionId: sessionId,
               steerId: steerId,
-              mode: deliveryMode.rawValue
+              mode: atomicDispatchMode
             )
           } catch {
             // Staging already succeeded on the host. Keep the single queued

--- a/apps/ios/ADE/Views/Work/WorkSessionDestinationView.swift
+++ b/apps/ios/ADE/Views/Work/WorkSessionDestinationView.swift
@@ -91,6 +91,23 @@ func workChatManualSteerDispatchModes(
   return WorkActiveSendCapability.forProvider(provider).atomicDispatchModes
 }
 
+/// The `dispatchMode` that rides `chat.steer` itself, so a busy host dispatches
+/// the message in the same round-trip instead of staging it and waiting for a
+/// second `chat.dispatchSteer` call. This is the desktop contract, and the
+/// strings are the desktop's exactly — the host rejects anything else.
+///
+/// Nil means "stage it", which covers the queue mode, a provider with no
+/// mid-turn channel, and a host too old to promote at all. Resolving it once,
+/// up front, is what keeps the "turn was already active" resend from quietly
+/// downgrading a Send-now tap into a staged message.
+func workChatAtomicSteerDispatchMode(
+  deliveryMode: WorkActiveSendMode,
+  dispatchModes: [WorkActiveSendMode]
+) -> String? {
+  guard deliveryMode != .queue, dispatchModes.contains(deliveryMode) else { return nil }
+  return deliveryMode.rawValue
+}
+
 func latestActiveTurnId(from transcript: [WorkChatEnvelope]) -> String? {
   for envelope in sortedWorkChatEnvelopes(transcript).reversed() {
     switch envelope.event {
@@ -891,8 +908,16 @@ struct WorkSessionDestinationView: View {
     syncService.chatTurnActiveHint(sessionId: sessionId)
   }
 
+  /// Host-gated as well as provider-gated. A brain that predates
+  /// `chat.dispatchSteer` can neither promote a staged row nor honor an atomic
+  /// `dispatchMode`, so the staged strip's buttons and the send path have to
+  /// read the same empty list — otherwise the send path would ask for a mode
+  /// the strip is hiding the recovery for.
   var manualSteerDispatchModes: [WorkActiveSendMode] {
-    workChatManualSteerDispatchModes(session: session, summary: chatSummary)
+    guard syncService.supportsChatRemoteAction("chat.dispatchSteer", sessionId: sessionId) else {
+      return []
+    }
+    return workChatManualSteerDispatchModes(session: session, summary: chatSummary)
   }
 
   /// Lane id the header menu acts on. Resolved against the loaded lane list so
@@ -1463,12 +1488,12 @@ struct WorkSessionDestinationView: View {
     // same table.
     // Also host-gated: a brain that predates `chat.dispatchSteer` cannot
     // promote a staged row at all, so the buttons would only ever produce an
-    // error toast.
+    // error toast. `manualSteerDispatchModes` carries the same gate.
     let activeSendModesAvailable = syncService.supportsChatRemoteAction(
       "chat.dispatchSteer",
       sessionId: session.id
     )
-    let manualDispatchModes = activeSendModesAvailable ? manualSteerDispatchModes : []
+    let manualDispatchModes = manualSteerDispatchModes
     let dispatchSteerInlineAction: (@MainActor (String) async -> Void)?
     if manualDispatchModes.contains(.inline) {
       dispatchSteerInlineAction = { steerId in await dispatchSteerInline(steerId) }
@@ -2562,6 +2587,10 @@ struct WorkSessionDestinationView: View {
     updateLocalEchoDeliveryState(echoId: echo.id, deliveryState: (sendWillQueueChatMessage || useSteer) ? "queued" : "sending")
     do {
       let delivery: SyncChatMessageDelivery
+      // No `dispatchMode` on either steer: a launch prompt has no composer
+      // behind it, so there is no chosen active-turn mode to carry. Landing on
+      // an already-busy session stages it, which is the conservative reading of
+      // "run this next" and matches what the desktop launcher does.
       if useSteer {
         delivery = try await syncService.steerChatSession(sessionId: sessionId, text: prompt)
       } else {

--- a/apps/ios/ADE/Views/Work/WorkSessionDestinationView.swift
+++ b/apps/ios/ADE/Views/Work/WorkSessionDestinationView.swift
@@ -200,6 +200,8 @@ func workChatErrorIndicatesActiveTurn(_ error: Error) -> Bool {
 
 func workTranscriptEntryIdentity(_ entry: AgentChatTranscriptEntry) -> String {
   [
+    entry.messageId ?? "",
+    entry.itemId ?? "",
     entry.timestamp,
     entry.role,
     entry.turnId ?? "",
@@ -207,15 +209,66 @@ func workTranscriptEntryIdentity(_ entry: AgentChatTranscriptEntry) -> String {
   ].joined(separator: "\u{1F}")
 }
 
+private func workTranscriptEntryLegacyIdentity(_ entry: AgentChatTranscriptEntry) -> String {
+  [
+    entry.timestamp,
+    entry.role,
+    entry.turnId ?? "",
+    entry.text
+  ].joined(separator: "\u{1F}")
+}
+
+private func workTranscriptEntryStableIdentity(_ entry: AgentChatTranscriptEntry) -> String? {
+  if let messageId = entry.messageId?.trimmingCharacters(in: .whitespacesAndNewlines), !messageId.isEmpty {
+    return "message:\(messageId)"
+  }
+  if let itemId = entry.itemId?.trimmingCharacters(in: .whitespacesAndNewlines), !itemId.isEmpty {
+    return "item:\(itemId)"
+  }
+  return nil
+}
+
+/// A refreshed transcript can gain host ids after its first page was cached.
+/// Stable host ids identify the physical row even when its text changes while
+/// a turn is streaming; id-less rows still use their legacy occurrence fields.
+/// Two genuinely different stable ids remain distinct even when they render
+/// identical text.
+private func workTranscriptEntriesRepresentSameOccurrence(
+  _ lhs: AgentChatTranscriptEntry,
+  _ rhs: AgentChatTranscriptEntry
+) -> Bool {
+  let lhsStableId = workTranscriptEntryStableIdentity(lhs)
+  let rhsStableId = workTranscriptEntryStableIdentity(rhs)
+  if let lhsStableId, let rhsStableId {
+    return lhsStableId == rhsStableId
+  }
+  return workTranscriptEntryLegacyIdentity(lhs) == workTranscriptEntryLegacyIdentity(rhs)
+}
+
 func mergeWorkTranscriptEntries(
   older: [AgentChatTranscriptEntry],
   newer: [AgentChatTranscriptEntry]
 ) -> [AgentChatTranscriptEntry] {
-  var seen = Set<String>()
+  var seenStableOccurrences = Set<String>()
+  var seenStableLegacyOccurrences = Set<String>()
+  var seenLegacyOnlyOccurrences = Set<String>()
   var result: [AgentChatTranscriptEntry] = []
   result.reserveCapacity(older.count + newer.count)
   for entry in older + newer {
-    if seen.insert(workTranscriptEntryIdentity(entry)).inserted {
+    let legacyIdentity = workTranscriptEntryLegacyIdentity(entry)
+    if let stableIdentity = workTranscriptEntryStableIdentity(entry) {
+      guard !seenStableOccurrences.contains(stableIdentity) else { continue }
+      // A later refresh can add a stable id to a row that was already kept
+      // from the id-less page. Keep the first occurrence and avoid a duplicate.
+      guard !seenLegacyOnlyOccurrences.contains(legacyIdentity) else { continue }
+      seenStableOccurrences.insert(stableIdentity)
+      seenStableLegacyOccurrences.insert(legacyIdentity)
+      result.append(entry)
+    } else {
+      guard !seenLegacyOnlyOccurrences.contains(legacyIdentity),
+            !seenStableLegacyOccurrences.contains(legacyIdentity)
+      else { continue }
+      seenLegacyOnlyOccurrences.insert(legacyIdentity)
       result.append(entry)
     }
   }
@@ -237,8 +290,10 @@ func mergeWorkTranscriptPageOccurrences(
       let olderStart = older.count - candidate
       var matches = true
       for index in 0..<candidate {
-        if workTranscriptEntryIdentity(older[olderStart + index])
-          != workTranscriptEntryIdentity(newer[index]) {
+        if !workTranscriptEntriesRepresentSameOccurrence(
+          older[olderStart + index],
+          newer[index]
+        ) {
           matches = false
           break
         }
@@ -569,7 +624,9 @@ struct WorkSessionDestinationView: View {
     _chatSummary = State(initialValue: initialChatSummary)
     _lastKnownChatSummary = State(initialValue: initialChatSummary)
     _transcript = State(initialValue: seededTranscript)
-    _transcriptRenderSignature = State(initialValue: workChatEnvelopeListRenderSignature(seededTranscript))
+    // This is a monotonic invalidation token, not a content hash. The old
+    // initializer scanned every assistant string before the first frame.
+    _transcriptRenderSignature = State(initialValue: 0)
     _fallbackEntries = State(initialValue: seededFallbackEntries)
     _fallbackEntriesRenderSignature = State(initialValue: workFallbackEntriesRenderSignature(seededFallbackEntries))
     _transcriptEntriesByIndex = State(initialValue: workChatTranscriptEntriesByIndexForRestoredPresentation(
@@ -701,7 +758,7 @@ struct WorkSessionDestinationView: View {
       mainChatRenderEpoch &+= 1
     }
     transcript = next
-    transcriptRenderSignature = workChatEnvelopeListRenderSignature(next)
+    transcriptRenderSignature &+= 1
     cacheCurrentTranscriptPresentationIfNeeded()
   }
 
@@ -787,7 +844,7 @@ struct WorkSessionDestinationView: View {
   @MainActor
   func setSubagentTranscript(_ next: [WorkChatEnvelope]) {
     subagentTranscript = next
-    subagentTranscriptRenderSignature = workChatEnvelopeListRenderSignature(next)
+    subagentTranscriptRenderSignature &+= 1
   }
 
   @MainActor

--- a/apps/ios/ADE/Views/Work/WorkSessionDestinationView.swift
+++ b/apps/ios/ADE/Views/Work/WorkSessionDestinationView.swift
@@ -218,6 +218,14 @@ private func workTranscriptEntryLegacyIdentity(_ entry: AgentChatTranscriptEntry
   ].joined(separator: "\u{1F}")
 }
 
+private func workTranscriptEntryLegacyFrame(_ entry: AgentChatTranscriptEntry) -> String {
+  [
+    entry.timestamp,
+    entry.role,
+    entry.turnId ?? ""
+  ].joined(separator: "\u{1F}")
+}
+
 private func workTranscriptEntryStableIdentity(_ entry: AgentChatTranscriptEntry) -> String? {
   if let messageId = entry.messageId?.trimmingCharacters(in: .whitespacesAndNewlines), !messageId.isEmpty {
     return "message:\(messageId)"
@@ -245,6 +253,21 @@ private func workTranscriptEntriesRepresentSameOccurrence(
   return workTranscriptEntryLegacyIdentity(lhs) == workTranscriptEntryLegacyIdentity(rhs)
 }
 
+private func workTranscriptEntriesAreStableUpgrade(
+  _ lhs: AgentChatTranscriptEntry,
+  _ rhs: AgentChatTranscriptEntry,
+  uniqueIdlessFrameCount: Int
+) -> Bool {
+  guard workTranscriptEntryStableIdentity(lhs) == nil
+    || workTranscriptEntryStableIdentity(rhs) == nil
+  else { return false }
+  guard workTranscriptEntryStableIdentity(lhs) != nil
+    || workTranscriptEntryStableIdentity(rhs) != nil
+  else { return false }
+  return uniqueIdlessFrameCount == 1
+    && workTranscriptEntryLegacyFrame(lhs) == workTranscriptEntryLegacyFrame(rhs)
+}
+
 func mergeWorkTranscriptEntries(
   older: [AgentChatTranscriptEntry],
   newer: [AgentChatTranscriptEntry]
@@ -258,9 +281,38 @@ func mergeWorkTranscriptEntries(
     let legacyIdentity = workTranscriptEntryLegacyIdentity(entry)
     if let stableIdentity = workTranscriptEntryStableIdentity(entry) {
       guard !seenStableOccurrences.contains(stableIdentity) else { continue }
-      // A later refresh can add a stable id to a row that was already kept
-      // from the id-less page. Keep the first occurrence and avoid a duplicate.
-      guard !seenLegacyOnlyOccurrences.contains(legacyIdentity) else { continue }
+      // A later refresh can add a stable id while also completing the text of
+      // a row that was cached without one. Match that upgrade by the physical
+      // transcript frame, not the mutable text, but only when the frame is
+      // unique; repeated id-less rows must never be collapsed accidentally.
+      let matchingIdlessIndices = result.indices.filter { index in
+        workTranscriptEntryStableIdentity(result[index]) == nil
+          && workTranscriptEntryLegacyFrame(result[index]) == workTranscriptEntryLegacyFrame(entry)
+      }
+      if matchingIdlessIndices.count == 1,
+         workTranscriptEntriesAreStableUpgrade(
+           result[matchingIdlessIndices[0]],
+           entry,
+           uniqueIdlessFrameCount: matchingIdlessIndices.count
+         ) {
+        result[matchingIdlessIndices[0]] = entry
+        seenStableOccurrences.insert(stableIdentity)
+        seenStableLegacyOccurrences.insert(legacyIdentity)
+        continue
+      }
+      // If the frame is repeated, retain every physical row and append the
+      // newly identified one instead of deleting an occurrence. For the
+      // ordinary same-text case with no stable upgrade target, preserve the
+      // existing id-less row rather than duplicating it.
+      let hasStableFrame = result.contains { existing in
+        workTranscriptEntryStableIdentity(existing) != nil
+          && workTranscriptEntryLegacyFrame(existing) == workTranscriptEntryLegacyFrame(entry)
+      }
+      if matchingIdlessIndices.isEmpty,
+         !hasStableFrame,
+         seenLegacyOnlyOccurrences.contains(legacyIdentity) {
+        continue
+      }
       seenStableOccurrences.insert(stableIdentity)
       seenStableLegacyOccurrences.insert(legacyIdentity)
       result.append(entry)
@@ -290,10 +342,18 @@ func mergeWorkTranscriptPageOccurrences(
       let olderStart = older.count - candidate
       var matches = true
       for index in 0..<candidate {
-        if !workTranscriptEntriesRepresentSameOccurrence(
-          older[olderStart + index],
-          newer[index]
-        ) {
+        let cached = older[olderStart + index]
+        let refreshed = newer[index]
+        let sameOccurrence = workTranscriptEntriesRepresentSameOccurrence(cached, refreshed)
+          || workTranscriptEntriesAreStableUpgrade(
+            cached,
+            refreshed,
+            uniqueIdlessFrameCount: older.filter {
+              workTranscriptEntryStableIdentity($0) == nil
+                && workTranscriptEntryLegacyFrame($0) == workTranscriptEntryLegacyFrame(cached)
+            }.count
+          )
+        if !sameOccurrence {
           matches = false
           break
         }
@@ -307,19 +367,32 @@ func mergeWorkTranscriptPageOccurrences(
   guard overlap > 0 else { return older + newer }
 
   // A page refresh can carry the completed payload for a row that was cached
-  // while it was still streaming. Replace only stable-ID overlap entries;
-  // id-less rows may represent repeated physical occurrences and must keep
-  // the payload/order already established by the older page.
+  // while it was still streaming. Replace stable-ID overlap entries and a
+  // unique id-less → stable upgrade. Id-less rows may represent repeated
+  // physical occurrences and must keep the payload/order already established
+  // by the older page when the frame is ambiguous.
   var mergedOlder = older
   for index in 0..<overlap {
     let olderIndex = older.count - overlap + index
     let cached = older[olderIndex]
     let refreshed = newer[index]
-    guard let cachedStableId = workTranscriptEntryStableIdentity(cached),
-          let refreshedStableId = workTranscriptEntryStableIdentity(refreshed),
-          cachedStableId == refreshedStableId
-    else { continue }
-    mergedOlder[olderIndex] = refreshed
+    if let cachedStableId = workTranscriptEntryStableIdentity(cached),
+       let refreshedStableId = workTranscriptEntryStableIdentity(refreshed),
+       cachedStableId == refreshedStableId {
+      mergedOlder[olderIndex] = refreshed
+      continue
+    }
+    let uniqueIdlessFrameCount = older.filter {
+      workTranscriptEntryStableIdentity($0) == nil
+        && workTranscriptEntryLegacyFrame($0) == workTranscriptEntryLegacyFrame(cached)
+    }.count
+    if workTranscriptEntriesAreStableUpgrade(
+      cached,
+      refreshed,
+      uniqueIdlessFrameCount: uniqueIdlessFrameCount
+    ) {
+      mergedOlder[olderIndex] = refreshed
+    }
   }
   return mergedOlder + newer.dropFirst(overlap)
 }

--- a/apps/ios/ADE/Views/Work/WorkSessionDestinationView.swift
+++ b/apps/ios/ADE/Views/Work/WorkSessionDestinationView.swift
@@ -304,7 +304,24 @@ func mergeWorkTranscriptPageOccurrences(
       }
     }
   }
-  return older + newer.dropFirst(overlap)
+  guard overlap > 0 else { return older + newer }
+
+  // A page refresh can carry the completed payload for a row that was cached
+  // while it was still streaming. Replace only stable-ID overlap entries;
+  // id-less rows may represent repeated physical occurrences and must keep
+  // the payload/order already established by the older page.
+  var mergedOlder = older
+  for index in 0..<overlap {
+    let olderIndex = older.count - overlap + index
+    let cached = older[olderIndex]
+    let refreshed = newer[index]
+    guard let cachedStableId = workTranscriptEntryStableIdentity(cached),
+          let refreshedStableId = workTranscriptEntryStableIdentity(refreshed),
+          cachedStableId == refreshedStableId
+    else { continue }
+    mergedOlder[olderIndex] = refreshed
+  }
+  return mergedOlder + newer.dropFirst(overlap)
 }
 
 struct WorkLiveTranscriptCache {

--- a/apps/ios/ADE/Views/Work/WorkSessionDestinationView.swift
+++ b/apps/ios/ADE/Views/Work/WorkSessionDestinationView.swift
@@ -638,7 +638,10 @@ struct WorkSessionDestinationView: View {
   @State var expandedSubagentDetailIds: Set<String> = []
   @State var probingSubagentTaskId: String?
   @State var remoteSubagentRefreshInFlight = false
-  @State var expandedToolCardIds = Set<String>()
+  /// Central expansion state for every collapsible transcript card. Lives
+  /// here, above the list, so it survives `LazyVStack` recycling and can be
+  /// swept in one move when a turn ends.
+  @State var cardExpansion = WorkCardExpansionState()
   @State var artifactContent: [String: WorkLoadedArtifactContent] = [:]
   @State var artifactContentRenderSignature = 0
   @State var artifactContentLoadsInFlight = Set<String>()
@@ -1563,13 +1566,13 @@ struct WorkSessionDestinationView: View {
       optimisticPendingSteersRenderSignature: viewingSubagent ? 0 : workPendingSteersRenderSignature(optimisticPendingSteers),
       localEchoMessages: localEchoMessagesForView,
       localEchoMessagesRenderSignature: viewingSubagent ? 0 : workLocalEchoMessagesRenderSignature(localEchoMessages),
-      expandedToolCardIdsSnapshot: expandedToolCardIds,
-      expandedToolCardIdsRenderSignature: workExpandedToolCardIdsRenderSignature(expandedToolCardIds),
+      cardExpansionSnapshot: cardExpansion,
+      cardExpansionRenderSignature: workCardExpansionRenderSignature(cardExpansion),
       artifactContentRenderSignature: artifactContentRenderSignature,
       artifactDrawerPresentedSnapshot: artifactDrawerPresented,
       sendingSnapshot: sending,
       errorMessageSnapshot: errorMessage ?? openingDeliveryWarning,
-      expandedToolCardIds: $expandedToolCardIds,
+      cardExpansion: $cardExpansion,
       artifactContent: $artifactContent,
       fullscreenImage: $fullscreenImage,
       artifactDrawerPresented: $artifactDrawerPresented,
@@ -1629,11 +1632,11 @@ struct WorkSessionDestinationView: View {
       scheduledWorkSnapshots: viewingSubagent ? [] : scheduledWorkSnapshots,
       scheduledWorkSnapshotsRenderSignature: viewingSubagent ? 0 : workScheduledWorkSnapshotsRenderSignature(scheduledWorkSnapshots),
       selectedSubagentTaskId: subagentView?.taskId,
+      // One chip, one destination: subagents, background work and schedules
+      // all live in the Chat Info sheet. Timeline-row selection stays scoped
+      // to the parent chat, so nested transcript state cannot accidentally
+      // fetch from itself.
       onOpenChatInfo: viewingSubagent ? nil : { Task { await prepareChatInfoPresentation() } },
-      // A singular badge opens its child directly; an aggregate badge opens
-      // Chat Info. Timeline-row selection stays scoped to the parent chat, so
-      // nested transcript state cannot accidentally fetch from itself.
-      onOpenSubagents: viewingSubagent ? nil : { Task { await prepareChatInfoPresentation() } },
       onSelectSubagentRow: subagentRowSelectionHandler(viewingSubagent: viewingSubagent),
       onForkChatInLane: {
         let modelId = (composerChatSummary?.modelId ?? composerChatSummary?.model ?? "")

--- a/apps/ios/ADE/Views/Work/WorkSessionDestinationView.swift
+++ b/apps/ios/ADE/Views/Work/WorkSessionDestinationView.swift
@@ -275,6 +275,8 @@ func mergeWorkTranscriptEntries(
   var seenStableOccurrences = Set<String>()
   var seenStableLegacyOccurrences = Set<String>()
   var seenLegacyOnlyOccurrences = Set<String>()
+  var idlessIndicesByFrame: [String: [Int]] = [:]
+  var stableFrames = Set<String>()
   var result: [AgentChatTranscriptEntry] = []
   result.reserveCapacity(older.count + newer.count)
   for entry in older + newer {
@@ -285,10 +287,8 @@ func mergeWorkTranscriptEntries(
       // a row that was cached without one. Match that upgrade by the physical
       // transcript frame, not the mutable text, but only when the frame is
       // unique; repeated id-less rows must never be collapsed accidentally.
-      let matchingIdlessIndices = result.indices.filter { index in
-        workTranscriptEntryStableIdentity(result[index]) == nil
-          && workTranscriptEntryLegacyFrame(result[index]) == workTranscriptEntryLegacyFrame(entry)
-      }
+      let frame = workTranscriptEntryLegacyFrame(entry)
+      let matchingIdlessIndices = idlessIndicesByFrame[frame] ?? []
       if matchingIdlessIndices.count == 1,
          workTranscriptEntriesAreStableUpgrade(
            result[matchingIdlessIndices[0]],
@@ -296,6 +296,8 @@ func mergeWorkTranscriptEntries(
            uniqueIdlessFrameCount: matchingIdlessIndices.count
          ) {
         result[matchingIdlessIndices[0]] = entry
+        idlessIndicesByFrame[frame] = nil
+        stableFrames.insert(frame)
         seenStableOccurrences.insert(stableIdentity)
         seenStableLegacyOccurrences.insert(legacyIdentity)
         continue
@@ -304,10 +306,7 @@ func mergeWorkTranscriptEntries(
       // newly identified one instead of deleting an occurrence. For the
       // ordinary same-text case with no stable upgrade target, preserve the
       // existing id-less row rather than duplicating it.
-      let hasStableFrame = result.contains { existing in
-        workTranscriptEntryStableIdentity(existing) != nil
-          && workTranscriptEntryLegacyFrame(existing) == workTranscriptEntryLegacyFrame(entry)
-      }
+      let hasStableFrame = stableFrames.contains(frame)
       if matchingIdlessIndices.isEmpty,
          !hasStableFrame,
          seenLegacyOnlyOccurrences.contains(legacyIdentity) {
@@ -316,11 +315,14 @@ func mergeWorkTranscriptEntries(
       seenStableOccurrences.insert(stableIdentity)
       seenStableLegacyOccurrences.insert(legacyIdentity)
       result.append(entry)
+      stableFrames.insert(frame)
     } else {
       guard !seenLegacyOnlyOccurrences.contains(legacyIdentity),
             !seenStableLegacyOccurrences.contains(legacyIdentity)
       else { continue }
       seenLegacyOnlyOccurrences.insert(legacyIdentity)
+      let frame = workTranscriptEntryLegacyFrame(entry)
+      idlessIndicesByFrame[frame, default: []].append(result.count)
       result.append(entry)
     }
   }
@@ -336,6 +338,11 @@ func mergeWorkTranscriptPageOccurrences(
   guard !older.isEmpty else { return newer }
   guard !newer.isEmpty else { return older }
   let maxOverlap = min(older.count, newer.count)
+  var idlessFrameCounts: [String: Int] = [:]
+  for entry in older where workTranscriptEntryStableIdentity(entry) == nil {
+    let frame = workTranscriptEntryLegacyFrame(entry)
+    idlessFrameCounts[frame, default: 0] += 1
+  }
   var overlap = 0
   if maxOverlap > 0 {
     for candidate in stride(from: maxOverlap, through: 1, by: -1) {
@@ -348,10 +355,7 @@ func mergeWorkTranscriptPageOccurrences(
           || workTranscriptEntriesAreStableUpgrade(
             cached,
             refreshed,
-            uniqueIdlessFrameCount: older.filter {
-              workTranscriptEntryStableIdentity($0) == nil
-                && workTranscriptEntryLegacyFrame($0) == workTranscriptEntryLegacyFrame(cached)
-            }.count
+            uniqueIdlessFrameCount: idlessFrameCounts[workTranscriptEntryLegacyFrame(cached)] ?? 0
           )
         if !sameOccurrence {
           matches = false
@@ -382,10 +386,7 @@ func mergeWorkTranscriptPageOccurrences(
       mergedOlder[olderIndex] = refreshed
       continue
     }
-    let uniqueIdlessFrameCount = older.filter {
-      workTranscriptEntryStableIdentity($0) == nil
-        && workTranscriptEntryLegacyFrame($0) == workTranscriptEntryLegacyFrame(cached)
-    }.count
+    let uniqueIdlessFrameCount = idlessFrameCounts[workTranscriptEntryLegacyFrame(cached)] ?? 0
     if workTranscriptEntriesAreStableUpgrade(
       cached,
       refreshed,
@@ -748,6 +749,8 @@ struct WorkSessionDestinationView: View {
   @State var lastKnownChatSummary: AgentChatSessionSummary?
   @State var transcript: [WorkChatEnvelope] = []
   @State var transcriptRenderSignature = 0
+  @State var transcriptAllowsIncrementalSnapshot = false
+  @State var transcriptIncrementalDelta: [WorkChatEnvelope] = []
   @State var mainChatRenderEpoch = 0
   @State var liveTranscriptCache = WorkLiveTranscriptCache()
   @State var fallbackEntries: [AgentChatTranscriptEntry] = []
@@ -843,9 +846,24 @@ struct WorkSessionDestinationView: View {
   }
 
   @MainActor
-  func setTranscript(_ next: [WorkChatEnvelope]) {
+  func setTranscript(
+    _ next: [WorkChatEnvelope],
+    allowsIncrementalSnapshot: Bool = false,
+    incrementalDelta: [WorkChatEnvelope] = []
+  ) {
     if transcript.isEmpty, !next.isEmpty {
       mainChatRenderEpoch &+= 1
+    }
+    let canUseIncrementalSnapshot = allowsIncrementalSnapshot && !incrementalDelta.isEmpty
+    if canUseIncrementalSnapshot {
+      // Multiple host ticks can arrive before the renderer's coalescing window
+      // wakes. Keep every fragment since the last rendered revision together;
+      // the child clears this binding after it consumes them.
+      transcriptIncrementalDelta.append(contentsOf: incrementalDelta)
+      transcriptAllowsIncrementalSnapshot = true
+    } else {
+      transcriptAllowsIncrementalSnapshot = false
+      transcriptIncrementalDelta = []
     }
     transcript = next
     transcriptRenderSignature &+= 1
@@ -1705,6 +1723,8 @@ struct WorkSessionDestinationView: View {
       ),
       transcript: transcriptForView,
       transcriptRenderSignature: viewingSubagent ? subagentTranscriptRenderSignature : transcriptRenderSignature,
+      allowsIncrementalTranscriptUpdate: viewingSubagent ? false : transcriptAllowsIncrementalSnapshot,
+      transcriptIncrementalDelta: viewingSubagent ? .constant([]) : $transcriptIncrementalDelta,
       fallbackEntries: fallbackEntriesForView,
       fallbackEntriesRenderSignature: viewingSubagent ? 0 : fallbackEntriesRenderSignature,
       artifacts: artifactsForView,
@@ -2310,7 +2330,11 @@ struct WorkSessionDestinationView: View {
       )
     }
     if !mergedTranscript.isEmpty, mergedTranscript != transcript {
-      setTranscript(mergedTranscript)
+      setTranscript(
+        mergedTranscript,
+        allowsIncrementalSnapshot: !liveDeltaTranscript.isEmpty && !liveTranscriptWasRebuilt,
+        incrementalDelta: liveDeltaTranscript
+      )
     }
     if fetchedFallbackEntriesAvailable, fallbackEntries != fetchedFallbackEntries {
       setFallbackEntries(fetchedFallbackEntries)
@@ -2872,7 +2896,11 @@ struct WorkSessionDestinationView: View {
       )
     }
     if !mergedTranscript.isEmpty, mergedTranscript != transcript {
-      setTranscript(mergedTranscript)
+      setTranscript(
+        mergedTranscript,
+        allowsIncrementalSnapshot: !liveDeltaTranscript.isEmpty && !liveTranscriptWasRebuilt,
+        incrementalDelta: liveDeltaTranscript
+      )
     }
     reconcileOptimisticPendingSteers(with: mergedTranscript)
     reconcileLocalEchoMessages()

--- a/apps/ios/ADE/Views/Work/WorkTimelineHelpers.swift
+++ b/apps/ios/ADE/Views/Work/WorkTimelineHelpers.swift
@@ -1687,6 +1687,24 @@ private func isInterruptStoppedSubagentResultEntry(_ entry: WorkTimelineEntry) -
   return false
 }
 
+/// The rows the transcript actually draws, from the rows the timeline holds.
+///
+/// This is the seam where a presentation-only rule belongs — and for a while it
+/// held one that swallowed whole turns: every normalized `.toolGroup` row was
+/// dropped here, so a turn whose only work was one `Read` and one approved shell
+/// command rendered no trace of either. The turn-end marker's 8pt chevron was
+/// the sole way back to them.
+///
+/// That filter dated from when a cluster had no compact form and N stacked tool
+/// cards ate the phone viewport. A finished cluster is now a single 44pt row in
+/// the same one-liner grammar `WorkChangedFilesPanelView` already uses right
+/// beside it, so there is nothing left to protect the viewport from — and
+/// hiding tool calls while showing file changes made the transcript disagree
+/// with itself about what a cluster is.
+func workPresentedTimelineEntries(_ timeline: [WorkTimelineEntry]) -> [WorkTimelineEntry] {
+  timeline
+}
+
 /// Fold tool-like timeline entries (tool cards, commands, file changes) into
 /// a single `.toolGroup` entry so the iOS chat mirrors the desktop
 /// `work_log_group` behavior — one summary row per cluster instead of N

--- a/apps/ios/ADE/Views/Work/WorkTimelineHelpers.swift
+++ b/apps/ios/ADE/Views/Work/WorkTimelineHelpers.swift
@@ -63,6 +63,7 @@ func buildWorkChatTimelineSnapshot(
     latestTranscriptTimestamp: latestTranscriptTimestamp,
     latestMessageAssistantId: latestWorkTimelineMessageAssistantId(timeline),
     latestTurnEndTurnId: workLatestTurnEndTurnId(in: timeline),
+    liveTurnEntryIds: workEntryIdsAfterLatestTurnEnd(in: timeline),
     timeline: timeline
   )
 }

--- a/apps/ios/ADE/Views/Work/WorkTimelineHelpers.swift
+++ b/apps/ios/ADE/Views/Work/WorkTimelineHelpers.swift
@@ -1495,7 +1495,12 @@ func buildWorkTimeline(
     : buildWorkChatMessages(from: transcript)
 
   var entries: [WorkTimelineEntry] = messages.enumerated().map { index, message in
-    WorkTimelineEntry(id: "message-\(message.id)", timestamp: message.timestamp, rank: index, payload: .message(message))
+    // Stamped here, at the end of the fold, rather than at construction: the
+    // builders above merge streaming fragments by mutating `markdown` in place,
+    // so this is the first point where a message's text is final.
+    var message = message
+    message.markdownDigest = workStableDigest(message.markdown)
+    return WorkTimelineEntry(id: "message-\(message.id)", timestamp: message.timestamp, rank: index, payload: .message(message))
   }
   // Counted, not set-membership: two identical echoes must not both vanish on
   // one matching row. Built from `messages` rather than the transcript so the
@@ -1591,6 +1596,7 @@ func buildWorkTimeline(
       id: echo.id,
       role: "user",
       markdown: echo.text,
+      markdownDigest: workStableDigest(echo.text),
       timestamp: echo.timestamp,
       turnId: nil,
       itemId: nil,

--- a/apps/ios/ADE/Views/Work/WorkTimelineHelpers.swift
+++ b/apps/ios/ADE/Views/Work/WorkTimelineHelpers.swift
@@ -418,8 +418,13 @@ private func combineLongTextSignature(_ text: String, into hasher: inout Hasher)
     hasher.combine(text)
     return
   }
-  hasher.combine(text.prefix(512))
-  hasher.combine(text.suffix(512))
+  // The incremental path uses WorkChatMessage.markdownRevision, but this is
+  // the full snapshot fold. Prefix/suffix sampling can collide when a host
+  // replaces the middle of a same-length response, leaving the old timeline
+  // snapshot in place. The exact digest is linear in the text and runs off the
+  // main actor during a full rebuild, where correctness is more important than
+  // the bounded live-delta shortcut.
+  hasher.combine(workStableDigest(text))
 }
 
 private func combineAgentChatFileRefs(_ refs: [AgentChatFileRef]?, into hasher: inout Hasher) {
@@ -2430,6 +2435,24 @@ private func workResolvedInlineItemIds(from transcript: [WorkChatEnvelope]) -> S
     }
   }
   return ids
+}
+
+func workIncrementalEventCard(for envelope: WorkChatEnvelope) -> WorkEventCardModel? {
+  eventCard(for: envelope)
+}
+
+func workIncrementalMergedEventCard(
+  _ existing: WorkEventCardModel,
+  with incoming: WorkEventCardModel
+) -> WorkEventCardModel? {
+  mergedWorkEventCard(existing, with: incoming)
+}
+
+func workIncrementalEventCards(from timeline: [WorkTimelineEntry]) -> [WorkEventCardModel] {
+  timeline.compactMap { entry in
+    guard case .eventCard(let card) = entry.payload else { return nil }
+    return card
+  }
 }
 
 func buildWorkEventCards(

--- a/apps/ios/ADE/Views/Work/WorkTimelineHelpers.swift
+++ b/apps/ios/ADE/Views/Work/WorkTimelineHelpers.swift
@@ -46,6 +46,7 @@ func buildWorkChatTimelineSnapshot(
     artifacts: artifacts,
     localEchoMessages: localEchoMessages
   )
+  let latestAssistantTail = latestWorkTimelineAssistantTail(timeline)
 
   return WorkChatTimelineSnapshot(
     signature: signature,
@@ -61,7 +62,8 @@ func buildWorkChatTimelineSnapshot(
     transcriptLatestTurnEnded: transcriptLatestTurnEnded,
     transcriptHasInterruptibleActivity: transcriptHasInterruptibleActivity,
     latestTranscriptTimestamp: latestTranscriptTimestamp,
-    latestMessageAssistantId: latestWorkTimelineMessageAssistantId(timeline),
+    latestMessageAssistantId: latestAssistantTail?.id,
+    latestMessageAssistantItemId: latestAssistantTail?.itemId,
     latestTurnEndTurnId: workLatestTurnEndTurnId(in: timeline),
     liveTurnEntryIds: workEntryIdsAfterLatestTurnEnd(in: timeline),
     timeline: timeline
@@ -493,10 +495,18 @@ private func latestWorkTranscriptTimestamp(_ transcript: [WorkChatEnvelope]) -> 
   return latest
 }
 
-private func latestWorkTimelineMessageAssistantId(_ timeline: [WorkTimelineEntry]) -> String? {
+private struct WorkTimelineAssistantTail {
+  let id: String?
+  let itemId: String?
+}
+
+private func latestWorkTimelineAssistantTail(_ timeline: [WorkTimelineEntry]) -> WorkTimelineAssistantTail? {
   for entry in timeline.reversed() {
     guard case .message(let message) = entry.payload else { continue }
-    return message.role == "assistant" ? message.id : nil
+    return WorkTimelineAssistantTail(
+      id: message.role == "assistant" ? message.id : nil,
+      itemId: message.role == "assistant" ? message.itemId : nil
+    )
   }
   return nil
 }
@@ -1506,6 +1516,7 @@ func buildWorkTimeline(
     // so this is the first point where a message's text is final.
     var message = message
     message.markdownDigest = workStableDigest(message.markdown)
+    message.markdownUTF8Count = message.markdown.utf8.count
     let hasCarriageReturn = message.markdown.utf8.contains(0x0D)
     let normalizedMarkdown = hasCarriageReturn
       ? message.markdown.replacingOccurrences(of: "\r\n", with: "\n")

--- a/apps/ios/ADE/Views/Work/WorkTimelineHelpers.swift
+++ b/apps/ios/ADE/Views/Work/WorkTimelineHelpers.swift
@@ -1501,6 +1501,18 @@ func buildWorkTimeline(
     // so this is the first point where a message's text is final.
     var message = message
     message.markdownDigest = workStableDigest(message.markdown)
+    let hasCarriageReturn = message.markdown.utf8.contains(0x0D)
+    let normalizedMarkdown = hasCarriageReturn
+      ? message.markdown.replacingOccurrences(of: "\r\n", with: "\n")
+      : message.markdown
+    message.markdownCharacterCount = normalizedMarkdown.count
+    message.markdownLineCount = workAssistantMessageLineCount(normalizedMarkdown)
+    message.markdownHasCarriageReturn = hasCarriageReturn
+    message.markdownContainsFence = normalizedMarkdown.contains("```")
+    message.markdownTrailingBacktickRun = workMarkdownTrailingBacktickRun(normalizedMarkdown)
+    let classifier = WorkStreamingMonospacedClassifierState(text: normalizedMarkdown)
+    message.markdownMonospacedClassifier = classifier
+    message.markdownOpenFenceMarker = classifier.openFenceMarker
     return WorkTimelineEntry(id: "message-\(message.id)", timestamp: message.timestamp, rank: index, payload: .message(message))
   }
   // Counted, not set-membership: two identical echoes must not both vanish on

--- a/apps/ios/ADETests/ADETests.swift
+++ b/apps/ios/ADETests/ADETests.swift
@@ -13356,6 +13356,63 @@ final class ADETests: XCTestCase {
     XCTAssertEqual(workChatManualSteerDispatchModes(session: nil, summary: nil), [])
   }
 
+  /// The mode the user picked has to ride `chat.steer` itself. When it did not,
+  /// the message was staged first and promoted by a second round-trip — and the
+  /// branch that resends after a "turn already active" rejection never made that
+  /// second call, so a Send-now tap silently became a queued message.
+  func testWorkChatAtomicSteerDispatchModeMatchesDesktopValues() {
+    let claudeModes = WorkActiveSendCapability.forProvider("claude").atomicDispatchModes
+
+    XCTAssertEqual(
+      workChatAtomicSteerDispatchMode(deliveryMode: .inline, dispatchModes: claudeModes),
+      "inline"
+    )
+    XCTAssertEqual(
+      workChatAtomicSteerDispatchMode(deliveryMode: .interrupt, dispatchModes: claudeModes),
+      "interrupt"
+    )
+    // Queue is the absence of an atomic dispatch, not a third wire value.
+    XCTAssertNil(workChatAtomicSteerDispatchMode(deliveryMode: .queue, dispatchModes: claudeModes))
+
+    // Cursor has no inline channel; asking for one must not put a value the host
+    // would reject on the wire.
+    let cursorModes = WorkActiveSendCapability.forProvider("cursor").atomicDispatchModes
+    XCTAssertEqual(
+      workChatAtomicSteerDispatchMode(deliveryMode: .interrupt, dispatchModes: cursorModes),
+      "interrupt"
+    )
+    XCTAssertNil(workChatAtomicSteerDispatchMode(deliveryMode: .inline, dispatchModes: cursorModes))
+
+    // Codex has neither, and an empty list is also what a host that predates
+    // `chat.dispatchSteer` resolves to — the gate the composer and the staged
+    // strip share. Either way the steer goes out plain.
+    XCTAssertNil(workChatAtomicSteerDispatchMode(deliveryMode: .inline, dispatchModes: []))
+    XCTAssertNil(workChatAtomicSteerDispatchMode(deliveryMode: .interrupt, dispatchModes: []))
+  }
+
+  /// The host validates `dispatchMode` as a string literal, so the field has to
+  /// be absent — not null, not "queue" — for a plain staged steer.
+  func testAgentChatSteerRequestEncodesDispatchModeOnlyWhenSet() throws {
+    let encoder = JSONEncoder()
+
+    let plain = try XCTUnwrap(
+      try JSONSerialization.jsonObject(
+        with: encoder.encode(AgentChatSteerRequest(sessionId: "chat-1", text: "hi"))
+      ) as? [String: Any]
+    )
+    XCTAssertNil(plain["dispatchMode"], "A staged steer must not carry the field at all")
+    XCTAssertEqual(plain["sessionId"] as? String, "chat-1")
+
+    let atomic = try XCTUnwrap(
+      try JSONSerialization.jsonObject(
+        with: encoder.encode(
+          AgentChatSteerRequest(sessionId: "chat-1", text: "hi", dispatchMode: "interrupt")
+        )
+      ) as? [String: Any]
+    )
+    XCTAssertEqual(atomic["dispatchMode"] as? String, "interrupt")
+  }
+
   /// Guards the hand mirror of the desktop's `ACTIVE_TURN_DISPATCH_MODES` table
   /// in `shared/types/chat.ts`. Menu order is load-bearing: the first entry is
   /// the provider's default, and a queue-only provider hides the picker.
@@ -18970,6 +19027,47 @@ final class ADETests: XCTestCase {
     XCTAssertTrue(steers.isEmpty)
   }
 
+  /// The staged strip is now the "you queued this" surface and nothing else. An
+  /// atomically dispatched send writes a user message with an immediate
+  /// delivery state (or none at all) and must never produce a strip entry —
+  /// that was the visible symptom of the old two-step send, where every
+  /// active-turn message flashed through the strip on its way out.
+  func testDerivePendingWorkSteersIgnoresNonQueuedDeliveries() {
+    let transcript = [
+      WorkChatEnvelope(
+        sessionId: "chat-1",
+        timestamp: "2026-03-25T00:00:01.000Z",
+        sequence: 1,
+        event: .userMessage(text: "folded into the turn", attachments: nil, turnId: "turn-1", steerId: "steer-1", deliveryState: "inline", processed: nil)
+      ),
+      WorkChatEnvelope(
+        sessionId: "chat-1",
+        timestamp: "2026-03-25T00:00:02.000Z",
+        sequence: 2,
+        event: .userMessage(text: "plain send", attachments: nil, turnId: "turn-1", steerId: nil, deliveryState: nil, processed: nil)
+      ),
+      WorkChatEnvelope(
+        sessionId: "chat-1",
+        timestamp: "2026-03-25T00:00:03.000Z",
+        sequence: 3,
+        event: .userMessage(text: "interrupted with this", attachments: nil, turnId: "turn-2", steerId: "steer-2", deliveryState: "delivered", processed: nil)
+      ),
+    ]
+
+    XCTAssertTrue(derivePendingWorkSteers(from: transcript).isEmpty)
+
+    // ...and one the user actually queued still shows up.
+    let queued = transcript + [
+      WorkChatEnvelope(
+        sessionId: "chat-1",
+        timestamp: "2026-03-25T00:00:04.000Z",
+        sequence: 4,
+        event: .userMessage(text: "wait for the turn", attachments: nil, turnId: "turn-2", steerId: "steer-3", deliveryState: "queued", processed: nil)
+      ),
+    ]
+    XCTAssertEqual(derivePendingWorkSteers(from: queued).map(\.id), ["steer-3"])
+  }
+
   func testMergeWorkChatTranscriptsReplacesQueuedSteerEditInPlace() {
     let base = [
       WorkChatEnvelope(
@@ -23943,6 +24041,55 @@ final class ADETests: XCTestCase {
     // And switching back restores A's draft rather than B's empty box.
     state.bind(persistenceKey: keyA)
     XCTAssertEqual(state.text, "half-written message for chat A")
+  }
+
+  /// The active-turn send mode is a working habit, not a per-turn decision, so
+  /// it is remembered per chat across launches. Scoped per chat: a user who
+  /// always interrupts one agent must not have that applied to a chat where
+  /// they always queue.
+  func testActiveSendModeIsRememberedPerChat() {
+    let keyA = WorkActiveSendModeStore.chatKey(sessionId: "sess-A-\(UUID().uuidString)")
+    let keyB = WorkActiveSendModeStore.chatKey(sessionId: "sess-B-\(UUID().uuidString)")
+    defer {
+      WorkActiveSendModeStore.clear(keyA)
+      WorkActiveSendModeStore.clear(keyB)
+    }
+
+    XCTAssertNil(WorkActiveSendModeStore.load(keyA), "An untouched chat has no preference")
+
+    WorkActiveSendModeStore.save(.interrupt, for: keyA)
+    XCTAssertEqual(WorkActiveSendModeStore.load(keyA), .interrupt)
+    XCTAssertNil(WorkActiveSendModeStore.load(keyB), "Preferences must not leak between chats")
+
+    WorkActiveSendModeStore.save(.queue, for: keyA)
+    XCTAssertEqual(WorkActiveSendModeStore.load(keyA), .queue, "The latest pick wins")
+
+    // A composer that renders before its session id resolves must not write
+    // every chat's preference into one shared bucket.
+    XCTAssertEqual(WorkActiveSendModeStore.chatKey(sessionId: "   "), "")
+    WorkActiveSendModeStore.save(.inline, for: "")
+    XCTAssertNil(WorkActiveSendModeStore.load(""))
+  }
+
+  /// A remembered mode is only restorable when the chat's current provider can
+  /// honor it — Cursor has no inline channel, so a mode carried over from a
+  /// Claude chat has to fall back to that provider's default rather than being
+  /// sent and rejected by the host.
+  func testRememberedSendModeFallsBackWhenProviderCannotHonorIt() {
+    let cursor = WorkActiveSendCapability.forProvider("cursor")
+    XCTAssertFalse(cursor.modes.contains(.inline))
+    XCTAssertEqual(cursor.defaultMode, .interrupt)
+
+    let codex = WorkActiveSendCapability.forProvider("codex")
+    XCTAssertEqual(codex.modes, [.queue])
+    XCTAssertFalse(codex.modes.contains(.interrupt))
+    XCTAssertEqual(codex.defaultMode, .queue)
+
+    // And the wire value for an unhonorable mode is always nil, so nothing the
+    // fallback misses can still reach the host.
+    XCTAssertNil(
+      workChatAtomicSteerDispatchMode(deliveryMode: .inline, dispatchModes: cursor.atomicDispatchModes)
+    )
   }
 
   /// A question marked `isSecret` renders its freeform in a `SecureField`, and

--- a/apps/ios/ADETests/ADETests.swift
+++ b/apps/ios/ADETests/ADETests.swift
@@ -19258,7 +19258,8 @@ final class ADETests: XCTestCase {
     XCTAssertEqual(rendered.count, 3)
     XCTAssertTrue(rendered.allSatisfy { $0.sourceEntryId == entry.id })
     XCTAssertEqual(Set(rendered.map(\.id)).count, rendered.count)
-    XCTAssertTrue(rendered.allSatisfy { $0.id.hasPrefix("message-assistant-1-markdown-block-") })
+    XCTAssertEqual(rendered.first?.id, entry.id)
+    XCTAssertTrue(rendered.dropFirst().allSatisfy { $0.id.hasPrefix("message-assistant-1-markdown-block-") })
     for row in rendered {
       guard case .assistantMarkdownBlock(let block) = row.payload else {
         return XCTFail("Expected assistant markdown block render rows.")
@@ -24273,6 +24274,70 @@ final class ADETests: XCTestCase {
     XCTAssertEqual(card.id, "tool-1")
   }
 
+  func testIncrementalReasoningMetadataUpdatesOneVisibleCard() {
+    let first = WorkChatEnvelope(
+      sessionId: "chat-1",
+      timestamp: "2026-04-20T00:00:01.000Z",
+      sequence: 1,
+      event: .reasoning(text: "First thought.", turnId: "turn-1", itemId: "reasoning-1", summaryIndex: nil)
+    )
+    let second = WorkChatEnvelope(
+      sessionId: "chat-1",
+      timestamp: "2026-04-20T00:00:02.000Z",
+      sequence: 2,
+      event: .reasoning(text: "Second thought.", turnId: "turn-1", itemId: "reasoning-1", summaryIndex: nil)
+    )
+    var timeline: [WorkTimelineEntry] = []
+
+    XCTAssertTrue(workIncrementalApplyLiveMetadata(first, to: &timeline))
+    XCTAssertTrue(workIncrementalApplyLiveMetadata(second, to: &timeline))
+    XCTAssertEqual(timeline.count, 1)
+    guard case .eventCard(let card) = timeline.first?.payload else {
+      return XCTFail("Expected the reasoning envelope to own an event card")
+    }
+    XCTAssertEqual(card.kind, "reasoning")
+    XCTAssertTrue(card.body?.contains("First thought.") == true)
+    XCTAssertTrue(card.body?.contains("Second thought.") == true)
+    XCTAssertEqual(workIncrementalEventCards(from: timeline), [card])
+  }
+
+  func testLongMiddleReplacementChangesFullTimelineSnapshotSignature() {
+    let prefix = String(repeating: "a", count: 700)
+    let suffix = String(repeating: "b", count: 700)
+    let firstText = prefix + "A" + suffix
+    let secondText = prefix + "B" + suffix
+    let first = WorkChatEnvelope(
+      sessionId: "chat-1",
+      timestamp: "2026-04-20T00:00:01.000Z",
+      sequence: 1,
+      event: .assistantText(text: firstText, turnId: "turn-1", itemId: "message-1")
+    )
+    let second = WorkChatEnvelope(
+      sessionId: "chat-1",
+      timestamp: first.timestamp,
+      sequence: first.sequence,
+      event: .assistantText(text: secondText, turnId: "turn-1", itemId: "message-1")
+    )
+
+    let firstSnapshot = buildWorkChatTimelineSnapshot(
+      transcript: [first],
+      fallbackEntries: [],
+      artifacts: [],
+      localEchoMessages: []
+    )
+    let secondSnapshot = buildWorkChatTimelineSnapshot(
+      transcript: [second],
+      fallbackEntries: [],
+      artifacts: [],
+      localEchoMessages: []
+    )
+    XCTAssertNotEqual(
+      firstSnapshot.signature,
+      secondSnapshot.signature,
+      "A same-length middle replacement must invalidate the full snapshot"
+    )
+  }
+
   func testBuildWorkTimelineKeepsMalformedAskUserFallbackOnMobile() {
     let transcript: [WorkChatEnvelope] = [
       WorkChatEnvelope(
@@ -25103,11 +25168,70 @@ final class ADETests: XCTestCase {
 
     XCTAssertEqual(
       mergeWorkTranscriptEntries(older: [cachedRow], newer: [refreshedRow]),
-      [cachedRow]
+      [refreshedRow]
     )
     XCTAssertEqual(
       mergeWorkTranscriptPageOccurrences(older: [cachedRow], newer: [refreshedRow]),
-      [cachedRow]
+      [refreshedRow]
+    )
+  }
+
+  func testWorkTranscriptStableUpgradeMatchesFrameWhenTextChanges() {
+    let cachedRow = AgentChatTranscriptEntry(
+      role: "assistant",
+      text: "draft answer",
+      timestamp: "2026-07-24T10:00:00.000Z",
+      turnId: "turn-same"
+    )
+    let refreshedRow = AgentChatTranscriptEntry(
+      role: "assistant",
+      text: "completed answer",
+      timestamp: cachedRow.timestamp,
+      turnId: cachedRow.turnId,
+      messageId: "message-a"
+    )
+
+    XCTAssertEqual(
+      mergeWorkTranscriptEntries(older: [cachedRow], newer: [refreshedRow]),
+      [refreshedRow]
+    )
+    XCTAssertEqual(
+      mergeWorkTranscriptPageOccurrences(older: [cachedRow], newer: [refreshedRow]),
+      [refreshedRow]
+    )
+  }
+
+  func testWorkTranscriptStableUpgradeDoesNotCollapseRepeatedIdlessFrames() {
+    let first = AgentChatTranscriptEntry(
+      role: "assistant",
+      text: "same frame",
+      timestamp: "2026-07-24T10:00:00.000Z",
+      turnId: "turn-same"
+    )
+    let second = AgentChatTranscriptEntry(
+      role: "assistant",
+      text: "same frame",
+      timestamp: first.timestamp,
+      turnId: first.turnId
+    )
+    let refreshed = AgentChatTranscriptEntry(
+      role: "assistant",
+      text: "completed frame",
+      timestamp: first.timestamp,
+      turnId: first.turnId,
+      messageId: "message-a"
+    )
+
+    // The global merge intentionally deduplicates identical id-less legacy
+    // rows. Page-occurrence merging below is the physical-row-preserving path
+    // used for repeated transcript pages.
+    XCTAssertEqual(
+      mergeWorkTranscriptEntries(older: [first, second], newer: [refreshed]),
+      [refreshed]
+    )
+    XCTAssertEqual(
+      mergeWorkTranscriptPageOccurrences(older: [first, second], newer: [refreshed]),
+      [first, second, refreshed]
     )
   }
 

--- a/apps/ios/ADETests/ADETests.swift
+++ b/apps/ios/ADETests/ADETests.swift
@@ -19513,6 +19513,7 @@ final class ADETests: XCTestCase {
     XCTAssertTrue(workApplyStreamingAssistantText("\nSecond line", to: &message))
     XCTAssertTrue(workApplyStreamingAssistantText("\nThird line", to: &message))
     XCTAssertEqual(message.markdownCharacterCount, message.markdown.count)
+    XCTAssertEqual(message.markdownUTF8Count, message.markdown.utf8.count)
     XCTAssertEqual(message.markdownLineCount, 3)
     XCTAssertEqual(message.markdownHasCarriageReturn, false)
     XCTAssertEqual(message.markdownContainsFence, false)
@@ -19521,6 +19522,263 @@ final class ADETests: XCTestCase {
     XCTAssertEqual(preview.totalCharacterCount, message.markdown.count)
     XCTAssertEqual(preview.totalLineCount, 3)
     XCTAssertFalse(preview.isTruncated)
+  }
+
+  func testStreamingPreviewMetadataKeepsGraphemeCountAcrossDeltaBoundary() {
+    var message = WorkChatMessage(
+      id: "assistant-streaming-graphemes",
+      role: "assistant",
+      markdown: "Cafe",
+      timestamp: "2026-03-25T00:00:01.000Z",
+      turnId: "turn-1",
+      itemId: "msg-1"
+    )
+
+    XCTAssertTrue(workApplyStreamingAssistantText("\u{301}", to: &message))
+    XCTAssertEqual(message.markdown, "Cafe\u{301}")
+    XCTAssertEqual(message.markdownCharacterCount, message.markdown.count)
+    XCTAssertEqual(message.markdownUTF8Count, message.markdown.utf8.count)
+  }
+
+  func testStreamingPreviewMetadataKeepsRegionalIndicatorPairingAcrossDeltaBoundary() {
+    var message = WorkChatMessage(
+      id: "assistant-streaming-regional-indicators",
+      role: "assistant",
+      markdown: "\u{1F1FA}",
+      timestamp: "2026-03-25T00:00:01.000Z",
+      turnId: "turn-1",
+      itemId: "msg-2"
+    )
+
+    XCTAssertTrue(workApplyStreamingAssistantText("\u{1F1F8}\u{1F1E6}\u{1F1E7}", to: &message))
+    XCTAssertEqual(message.markdown, "\u{1F1FA}\u{1F1F8}\u{1F1E6}\u{1F1E7}")
+    XCTAssertEqual(message.markdownCharacterCount, message.markdown.count)
+    XCTAssertEqual(message.markdownUTF8Count, message.markdown.utf8.count)
+    XCTAssertEqual(message.markdownCharacterCount, 2)
+  }
+
+  func testStreamingPreviewMetadataKeepsEvenRegionalIndicatorDeltaAdditive() {
+    var message = WorkChatMessage(
+      id: "assistant-streaming-even-regional-indicators",
+      role: "assistant",
+      markdown: "\u{1F1FA}",
+      timestamp: "2026-03-25T00:00:01.000Z",
+      turnId: "turn-1",
+      itemId: "msg-3"
+    )
+
+    XCTAssertTrue(workApplyStreamingAssistantText("\u{1F1F8}\u{1F1E6}", to: &message))
+    XCTAssertEqual(message.markdownCharacterCount, message.markdown.count)
+    XCTAssertEqual(message.markdownUTF8Count, message.markdown.utf8.count)
+    XCTAssertEqual(message.markdownCharacterCount, 2)
+  }
+
+  func testStreamingPreviewMetadataKeepsUTF8CountAcrossReplayAndCarriageReturn() {
+    var message = WorkChatMessage(
+      id: "assistant-streaming-utf8",
+      role: "assistant",
+      markdown: "Café",
+      timestamp: "2026-03-25T00:00:01.000Z",
+      turnId: "turn-1",
+      itemId: "msg-4"
+    )
+
+    XCTAssertTrue(workApplyStreamingAssistantText("\nnext", to: &message))
+    XCTAssertEqual(message.markdownUTF8Count, message.markdown.utf8.count)
+    XCTAssertFalse(workApplyStreamingAssistantText(message.markdown, to: &message))
+    XCTAssertEqual(message.markdownUTF8Count, message.markdown.utf8.count)
+
+    XCTAssertTrue(workApplyStreamingAssistantText("\r\nfinal", to: &message))
+    XCTAssertEqual(message.markdownUTF8Count, message.markdown.utf8.count)
+  }
+
+  func testIncrementalTimelineSortDetectsSameTimestampRankInversion() {
+    let first = WorkChatMessage(
+      id: "first",
+      role: "assistant",
+      markdown: "first",
+      timestamp: "2026-03-25T00:00:01.000Z",
+      turnId: "turn-1",
+      itemId: "first"
+    )
+    let second = WorkChatMessage(
+      id: "second",
+      role: "assistant",
+      markdown: "second",
+      timestamp: first.timestamp,
+      turnId: "turn-1",
+      itemId: "second"
+    )
+    let timeline = [
+      WorkTimelineEntry(id: "second", timestamp: second.timestamp, rank: 1_500, payload: .message(second)),
+      WorkTimelineEntry(id: "first", timestamp: first.timestamp, rank: 2, payload: .message(first))
+    ]
+
+    XCTAssertTrue(workIncrementalTimelineNeedsSort(timeline))
+  }
+
+  func testIncrementalTailTracksNewEntryWhenFutureEchoMovesSuffix() {
+    let assistant = WorkChatEnvelope(
+      sessionId: "chat-1",
+      timestamp: "2026-03-25T00:00:01.000Z",
+      sequence: 1,
+      event: .assistantText(text: "first", turnId: "turn-1", itemId: "item-1")
+    )
+    let futureEcho = WorkLocalEchoMessage(
+      text: "queued later",
+      timestamp: "2026-03-25T00:00:03.000Z"
+    )
+    let previous = buildWorkChatTimelineSnapshot(
+      transcript: [assistant],
+      fallbackEntries: [],
+      artifacts: [],
+      localEchoMessages: [futureEcho]
+    )
+    let nextAssistant = WorkChatEnvelope(
+      sessionId: "chat-1",
+      timestamp: "2026-03-25T00:00:02.000Z",
+      sequence: 2,
+      event: .assistantText(text: "second", turnId: "turn-1", itemId: "item-2")
+    )
+    let insertedEntry = WorkTimelineEntry(
+      id: "message-\(nextAssistant.id)",
+      timestamp: nextAssistant.timestamp,
+      rank: 1,
+      payload: .message(WorkChatMessage(
+        id: nextAssistant.id,
+        role: "assistant",
+        markdown: "second",
+        timestamp: nextAssistant.timestamp,
+        turnId: "turn-1",
+        itemId: "item-2"
+      ))
+    )
+    let sortedTimeline = (previous.timeline + [insertedEntry]).sorted { lhs, rhs in
+      if lhs.timestamp == rhs.timestamp { return lhs.rank < rhs.rank }
+      return lhs.timestamp < rhs.timestamp
+    }
+
+    let summary = workIncrementalUpdatedTailSummary(
+      previous: previous,
+      timeline: sortedTimeline,
+      previousTimelineCount: previous.timeline.count,
+      candidateEnvelopes: [nextAssistant][...],
+      newTimelineEntryIDs: [insertedEntry.id]
+    )
+
+    // The queued local echo is the sorted visible message tail, so the
+    // canonical streaming target is intentionally nil; it must not fall back
+    // to the previous assistant just because the new row moved before it.
+    XCTAssertNil(summary.latestAssistantMessageId)
+    XCTAssertTrue(summary.liveTurnEntryIds.contains(insertedEntry.id))
+  }
+
+  func testIncrementalStreamingHintClearsWhenCanonicalUserReplacesEcho() {
+    let previousAssistant = WorkChatMessage(
+      id: "assistant-previous",
+      role: "assistant",
+      markdown: "Done",
+      timestamp: "2026-03-25T00:00:01.000Z",
+      turnId: "turn-1",
+      itemId: "assistant-item"
+    )
+    let canonicalUser = WorkChatMessage(
+      id: "user-canonical",
+      role: "user",
+      markdown: "Next turn",
+      timestamp: "2026-03-25T00:00:02.000Z",
+      turnId: "turn-2",
+      itemId: nil
+    )
+    let timeline = [
+      WorkTimelineEntry(
+        id: "message-\(previousAssistant.id)",
+        timestamp: previousAssistant.timestamp,
+        rank: 0,
+        payload: .message(previousAssistant)
+      ),
+      WorkTimelineEntry(
+        id: "message-\(canonicalUser.id)",
+        timestamp: canonicalUser.timestamp,
+        rank: 1,
+        payload: .message(canonicalUser)
+      ),
+    ]
+    let userEnvelope = WorkChatEnvelope(
+      sessionId: "chat-1",
+      timestamp: canonicalUser.timestamp,
+      sequence: 2,
+      event: .userMessage(
+        text: canonicalUser.markdown,
+        attachments: nil,
+        turnId: canonicalUser.turnId,
+        steerId: nil,
+        deliveryState: nil,
+        processed: nil
+      )
+    )
+
+    let candidates = Array([userEnvelope])[...]
+    XCTAssertNil(
+      workIncrementalLatestAssistantMessageId(
+        previous: previousAssistant.id,
+        timeline: timeline,
+        candidateEnvelopes: candidates
+      )
+    )
+  }
+
+  func testIncrementalStreamingHintFollowsNewAssistantItemWithoutUserBoundary() {
+    let firstAssistant = WorkChatMessage(
+      id: "assistant-first",
+      role: "assistant",
+      markdown: "First item",
+      timestamp: "2026-03-25T00:00:01.000Z",
+      turnId: "turn-1",
+      itemId: "item-first"
+    )
+    let secondAssistant = WorkChatMessage(
+      id: "assistant-second",
+      role: "assistant",
+      markdown: "Second item",
+      timestamp: "2026-03-25T00:00:02.000Z",
+      turnId: "turn-1",
+      itemId: "item-second"
+    )
+    let timeline = [
+      WorkTimelineEntry(
+        id: "message-\(firstAssistant.id)",
+        timestamp: firstAssistant.timestamp,
+        rank: 0,
+        payload: .message(firstAssistant)
+      ),
+      WorkTimelineEntry(
+        id: "message-\(secondAssistant.id)",
+        timestamp: secondAssistant.timestamp,
+        rank: 1,
+        payload: .message(secondAssistant)
+      ),
+    ]
+    let secondItemEnvelope = WorkChatEnvelope(
+      sessionId: "chat-1",
+      timestamp: secondAssistant.timestamp,
+      sequence: 2,
+      event: .assistantText(
+        text: "Second item grows",
+        turnId: secondAssistant.turnId,
+        itemId: secondAssistant.itemId
+      )
+    )
+
+    XCTAssertEqual(
+      workIncrementalLatestAssistantMessageId(
+        previous: firstAssistant.id,
+        previousItemId: firstAssistant.itemId,
+        timeline: timeline,
+        candidateEnvelopes: [secondItemEnvelope][...]
+      ),
+      secondAssistant.id
+    )
   }
 
   func testWorkChatAccessibilityPreviewCapsHugeMessages() {
@@ -24299,6 +24557,160 @@ final class ADETests: XCTestCase {
     XCTAssertTrue(card.body?.contains("First thought.") == true)
     XCTAssertTrue(card.body?.contains("Second thought.") == true)
     XCTAssertEqual(workIncrementalEventCards(from: timeline), [card])
+  }
+
+  func testIncrementalReasoningDeclinesAfterCanonicalPhaseCollapse() {
+    let first = WorkChatEnvelope(
+      sessionId: "chat-1",
+      timestamp: "2026-04-20T00:00:01.000Z",
+      sequence: 1,
+      event: .reasoning(text: "First thought.", turnId: "turn-1", itemId: "reasoning-1", summaryIndex: nil)
+    )
+    let second = WorkChatEnvelope(
+      sessionId: "chat-1",
+      timestamp: "2026-04-20T00:00:02.000Z",
+      sequence: 2,
+      event: .reasoning(text: "Second thought.", turnId: "turn-1", itemId: "reasoning-2", summaryIndex: nil)
+    )
+    let third = WorkChatEnvelope(
+      sessionId: "chat-1",
+      timestamp: "2026-04-20T00:00:03.000Z",
+      sequence: 3,
+      event: .reasoning(text: "Third thought.", turnId: "turn-1", itemId: "reasoning-3", summaryIndex: nil)
+    )
+    let snapshot = buildWorkChatTimelineSnapshot(
+      transcript: [first, second],
+      fallbackEntries: [],
+      artifacts: [],
+      localEchoMessages: []
+    )
+    XCTAssertTrue(
+      snapshot.timeline.contains { $0.id.hasPrefix("activity-phase-reasoning:") },
+      "the fixture must exercise the canonical collapsed phase"
+    )
+
+    var timeline = snapshot.timeline
+    XCTAssertFalse(workIncrementalApplyLiveMetadata(third, to: &timeline))
+    XCTAssertEqual(timeline, snapshot.timeline, "a raw event must not be appended beside a collapsed phase")
+  }
+
+  func testIncrementalReasoningHistoricalPhaseDoesNotBlockLaterTurn() {
+    let first = WorkChatEnvelope(
+      sessionId: "chat-1",
+      timestamp: "2026-04-20T00:00:01.000Z",
+      sequence: 1,
+      event: .reasoning(text: "First thought.", turnId: "turn-1", itemId: "reasoning-1", summaryIndex: nil)
+    )
+    let second = WorkChatEnvelope(
+      sessionId: "chat-1",
+      timestamp: "2026-04-20T00:00:02.000Z",
+      sequence: 2,
+      event: .reasoning(text: "Second thought.", turnId: "turn-1", itemId: "reasoning-2", summaryIndex: nil)
+    )
+    let laterUser = WorkChatEnvelope(
+      sessionId: "chat-1",
+      timestamp: "2026-04-20T00:01:00.000Z",
+      sequence: 3,
+      event: .userMessage(
+        text: "Next turn",
+        attachments: nil,
+        turnId: "turn-2",
+        steerId: nil,
+        deliveryState: nil,
+        processed: nil
+      )
+    )
+    let laterReasoning = WorkChatEnvelope(
+      sessionId: "chat-1",
+      timestamp: "2026-04-20T00:01:01.000Z",
+      sequence: 4,
+      event: .reasoning(text: "Later thought.", turnId: "turn-2", itemId: "reasoning-3", summaryIndex: nil)
+    )
+    let snapshot = buildWorkChatTimelineSnapshot(
+      transcript: [first, second, laterUser],
+      fallbackEntries: [],
+      artifacts: [],
+      localEchoMessages: []
+    )
+    XCTAssertTrue(snapshot.timeline.contains { $0.id.hasPrefix("activity-phase-reasoning:") })
+
+    var timeline = snapshot.timeline
+    XCTAssertTrue(
+      workIncrementalApplyLiveMetadata(laterReasoning, to: &timeline),
+      "a historical collapsed phase must not force every later turn through a full rebuild"
+    )
+  }
+
+  func testIncrementalReasoningReplayDeclinesWhenHistoricalCardIsCollapsed() {
+    let first = WorkChatEnvelope(
+      sessionId: "chat-1",
+      timestamp: "2026-04-20T00:00:01.000Z",
+      sequence: 1,
+      event: .reasoning(text: "First thought.", turnId: "turn-1", itemId: "reasoning-1", summaryIndex: nil)
+    )
+    let second = WorkChatEnvelope(
+      sessionId: "chat-1",
+      timestamp: "2026-04-20T00:00:02.000Z",
+      sequence: 2,
+      event: .reasoning(text: "Second thought.", turnId: "turn-1", itemId: "reasoning-2", summaryIndex: nil)
+    )
+    let laterUser = WorkChatEnvelope(
+      sessionId: "chat-1",
+      timestamp: "2026-04-20T00:01:00.000Z",
+      sequence: 3,
+      event: .userMessage(
+        text: "Next turn",
+        attachments: nil,
+        turnId: "turn-2",
+        steerId: nil,
+        deliveryState: nil,
+        processed: nil
+      )
+    )
+    let snapshot = buildWorkChatTimelineSnapshot(
+      transcript: [first, second, laterUser],
+      fallbackEntries: [],
+      artifacts: [],
+      localEchoMessages: []
+    )
+    let historicalCardId = workIncrementalEventCard(for: first)?.id
+    XCTAssertNotNil(historicalCardId)
+    XCTAssertTrue(snapshot.eventCards.contains { $0.id == historicalCardId })
+    XCTAssertTrue(snapshot.timeline.contains { $0.id.hasPrefix("activity-phase-reasoning:") })
+
+    let replay = WorkChatEnvelope(
+      sessionId: "chat-1",
+      timestamp: "2026-04-20T00:01:01.000Z",
+      sequence: 4,
+      event: .reasoning(text: "First thought, replayed.", turnId: "turn-1", itemId: "reasoning-1", summaryIndex: nil)
+    )
+    var timeline = snapshot.timeline
+    var eventCards = snapshot.eventCards
+    XCTAssertFalse(
+      workIncrementalApplyLiveMetadata(replay, to: &timeline, eventCards: &eventCards),
+      "a replay for a collapsed historical card must use the canonical rebuild"
+    )
+    XCTAssertEqual(timeline, snapshot.timeline)
+  }
+
+  func testIncrementalReasoningDeclinesAtCollapseThreshold() {
+    let first = WorkChatEnvelope(
+      sessionId: "chat-1",
+      timestamp: "2026-04-20T00:00:01.000Z",
+      sequence: 1,
+      event: .reasoning(text: "First thought.", turnId: "turn-1", itemId: "reasoning-1", summaryIndex: nil)
+    )
+    let second = WorkChatEnvelope(
+      sessionId: "chat-1",
+      timestamp: "2026-04-20T00:00:02.000Z",
+      sequence: 2,
+      event: .reasoning(text: "Second thought.", turnId: "turn-1", itemId: "reasoning-2", summaryIndex: nil)
+    )
+    var timeline: [WorkTimelineEntry] = []
+
+    XCTAssertTrue(workIncrementalApplyLiveMetadata(first, to: &timeline))
+    XCTAssertFalse(workIncrementalApplyLiveMetadata(second, to: &timeline))
+    XCTAssertEqual(timeline.count, 1, "the fast path must not append a raw row before canonical collapse")
   }
 
   func testLongMiddleReplacementChangesFullTimelineSnapshotSignature() {

--- a/apps/ios/ADETests/ADETests.swift
+++ b/apps/ios/ADETests/ADETests.swift
@@ -25133,8 +25133,38 @@ final class ADETests: XCTestCase {
     )
     XCTAssertEqual(
       mergeWorkTranscriptPageOccurrences(older: [draft], newer: [completed]),
-      [draft]
+      [completed]
     )
+  }
+
+  func testWorkTranscriptPageOccurrenceMergeReplacesStableOverlapWithoutCollapsingIdlessRows() {
+    let repeated = AgentChatTranscriptEntry(
+      role: "user",
+      text: "same physical payload",
+      timestamp: "2026-07-24T10:00:00.000Z",
+      turnId: "turn-same"
+    )
+    let draft = AgentChatTranscriptEntry(
+      role: "assistant",
+      text: "draft answer",
+      timestamp: "2026-07-24T10:01:00.000Z",
+      turnId: "turn-same",
+      messageId: "message-a"
+    )
+    let completed = AgentChatTranscriptEntry(
+      role: "assistant",
+      text: "completed answer",
+      timestamp: draft.timestamp,
+      turnId: draft.turnId,
+      messageId: draft.messageId
+    )
+
+    let merged = mergeWorkTranscriptPageOccurrences(
+      older: [repeated, repeated, draft],
+      newer: [repeated, completed]
+    )
+
+    XCTAssertEqual(merged, [repeated, repeated, completed])
   }
 
   func testRestoredByteCursorTranscriptCacheRehydratesOrderedIndexStore() {

--- a/apps/ios/ADETests/ADETests.swift
+++ b/apps/ios/ADETests/ADETests.swift
@@ -15521,6 +15521,42 @@ final class ADETests: XCTestCase {
       hasBufferedEntries: false,
       hasHostHistory: true
     ))
+    // A dropped host page must not strand the reader on top of history the
+    // phone already holds: revealing buffered entries costs no network, and
+    // gating it on the failure is what froze scroll-back after one timeout.
+    XCTAssertTrue(workChatShouldRequestOlderHistory(
+      distanceFromTop: 0,
+      triggerArmed: true,
+      loading: false,
+      hasError: true,
+      hasBufferedEntries: true,
+      hasHostHistory: true
+    ))
+    XCTAssertTrue(workChatShouldRequestOlderHistory(
+      distanceFromTop: 0,
+      triggerArmed: true,
+      loading: false,
+      hasError: true,
+      hasBufferedEntries: true,
+      hasHostHistory: false
+    ))
+    // A failure still cannot outrank the states that mean "not now".
+    XCTAssertFalse(workChatShouldRequestOlderHistory(
+      distanceFromTop: 0,
+      triggerArmed: true,
+      loading: true,
+      hasError: true,
+      hasBufferedEntries: true,
+      hasHostHistory: true
+    ))
+    XCTAssertFalse(workChatShouldRequestOlderHistory(
+      distanceFromTop: 0,
+      triggerArmed: false,
+      loading: false,
+      hasError: true,
+      hasBufferedEntries: true,
+      hasHostHistory: true
+    ))
 
     XCTAssertTrue(workChatShouldContinueAutomaticOlderHistory(
       distanceFromBottom: 0,
@@ -15549,6 +15585,22 @@ final class ADETests: XCTestCase {
       hasError: true,
       hasBufferedEntries: false,
       hasHostHistory: true
+    ))
+    // A transcript that fits the viewport cannot be scrolled, so there is no
+    // gesture that re-arms anything. Buffered rows have to stay reachable.
+    XCTAssertTrue(workChatShouldContinueAutomaticOlderHistory(
+      distanceFromBottom: 0,
+      loading: false,
+      hasError: true,
+      hasBufferedEntries: true,
+      hasHostHistory: false
+    ))
+    XCTAssertFalse(workChatShouldContinueAutomaticOlderHistory(
+      distanceFromBottom: 0,
+      loading: true,
+      hasError: true,
+      hasBufferedEntries: true,
+      hasHostHistory: false
     ))
     XCTAssertFalse(workChatShouldContinueAutomaticOlderHistory(
       distanceFromBottom: 0,

--- a/apps/ios/ADETests/ADETests.swift
+++ b/apps/ios/ADETests/ADETests.swift
@@ -15309,7 +15309,7 @@ final class ADETests: XCTestCase {
 
   func testMobileChatHistoryTriggerAndRenderCapStayBounded() {
     XCTAssertTrue(workChatShouldRequestOlderHistory(
-      topY: -120,
+      distanceFromTop: 120,
       triggerArmed: true,
       loading: false,
       hasError: false,
@@ -15317,7 +15317,7 @@ final class ADETests: XCTestCase {
       hasHostHistory: true
     ))
     XCTAssertFalse(workChatShouldRequestOlderHistory(
-      topY: -500,
+      distanceFromTop: 500,
       triggerArmed: true,
       loading: false,
       hasError: false,
@@ -15325,7 +15325,7 @@ final class ADETests: XCTestCase {
       hasHostHistory: false
     ))
     XCTAssertFalse(workChatShouldRequestOlderHistory(
-      topY: 0,
+      distanceFromTop: 0,
       triggerArmed: false,
       loading: false,
       hasError: false,
@@ -15333,7 +15333,7 @@ final class ADETests: XCTestCase {
       hasHostHistory: false
     ))
     XCTAssertFalse(workChatShouldRequestOlderHistory(
-      topY: 0,
+      distanceFromTop: 0,
       triggerArmed: true,
       loading: true,
       hasError: false,
@@ -15341,7 +15341,7 @@ final class ADETests: XCTestCase {
       hasHostHistory: true
     ))
     XCTAssertFalse(workChatShouldRequestOlderHistory(
-      topY: 0,
+      distanceFromTop: 0,
       triggerArmed: true,
       loading: false,
       hasError: true,

--- a/apps/ios/ADETests/ADETests.swift
+++ b/apps/ios/ADETests/ADETests.swift
@@ -19477,6 +19477,51 @@ final class ADETests: XCTestCase {
     XCTAssertEqual(preview?.totalLineCount, 5000)
   }
 
+  func testAssistantPreviewCacheInvalidatesOnIncrementalRevisionWithoutRehashing() {
+    var message = WorkChatMessage(
+      id: "assistant-streaming",
+      role: "assistant",
+      markdown: "Before",
+      markdownDigest: workStableDigest("Before"),
+      timestamp: "2026-03-25T00:00:01.000Z",
+      turnId: "turn-1",
+      itemId: "msg-1"
+    )
+    let cache = WorkAssistantPreviewCache()
+
+    XCTAssertEqual(cache.preview(for: message).text, "Before")
+    XCTAssertTrue(workApplyStreamingAssistantText("Before and after", to: &message))
+    XCTAssertEqual(message.markdown, "Before and after")
+    XCTAssertEqual(message.markdownRevision, 1)
+    XCTAssertEqual(message.markdownDigest, workStableDigest("Before"), "the live path must not rescan the full text")
+    XCTAssertEqual(cache.preview(for: message).text, "Before and after")
+    XCTAssertFalse(workApplyStreamingAssistantText("Before and after", to: &message))
+    XCTAssertEqual(message.markdownRevision, 1, "duplicate replay must not cause another render refresh")
+  }
+
+  func testStreamingPreviewMetadataKeepsExactCountsAcrossAppendedDeltas() {
+    var message = WorkChatMessage(
+      id: "assistant-streaming-counts",
+      role: "assistant",
+      markdown: "First line",
+      timestamp: "2026-03-25T00:00:01.000Z",
+      turnId: "turn-1",
+      itemId: "msg-1"
+    )
+
+    XCTAssertTrue(workApplyStreamingAssistantText("\nSecond line", to: &message))
+    XCTAssertTrue(workApplyStreamingAssistantText("\nThird line", to: &message))
+    XCTAssertEqual(message.markdownCharacterCount, message.markdown.count)
+    XCTAssertEqual(message.markdownLineCount, 3)
+    XCTAssertEqual(message.markdownHasCarriageReturn, false)
+    XCTAssertEqual(message.markdownContainsFence, false)
+
+    let preview = WorkAssistantPreviewCache().preview(for: message, anchor: .tail)
+    XCTAssertEqual(preview.totalCharacterCount, message.markdown.count)
+    XCTAssertEqual(preview.totalLineCount, 3)
+    XCTAssertFalse(preview.isTruncated)
+  }
+
   func testWorkChatAccessibilityPreviewCapsHugeMessages() {
     let text = String(repeating: "x", count: workChatAccessibilityPreviewLimit + 50)
     let preview = workChatAccessibilityPreview(text)
@@ -25010,6 +25055,86 @@ final class ADETests: XCTestCase {
     )
 
     XCTAssertEqual(merged, [duplicate, duplicate, newest])
+  }
+
+  func testWorkTranscriptMergeKeepsDistinctStableIdsWithIdenticalVisibleText() {
+    let olderRow = AgentChatTranscriptEntry(
+      role: "assistant",
+      text: "same visible text",
+      timestamp: "2026-07-24T10:00:00.000Z",
+      turnId: "turn-same",
+      messageId: "message-a",
+      itemId: "item-a"
+    )
+    let newerRow = AgentChatTranscriptEntry(
+      role: "assistant",
+      text: "same visible text",
+      timestamp: "2026-07-24T10:00:00.000Z",
+      turnId: "turn-same",
+      messageId: "message-b",
+      itemId: "item-b"
+    )
+
+    XCTAssertEqual(
+      mergeWorkTranscriptEntries(older: [olderRow], newer: [newerRow]),
+      [olderRow, newerRow]
+    )
+    XCTAssertEqual(
+      mergeWorkTranscriptPageOccurrences(older: [olderRow], newer: [newerRow]),
+      [olderRow, newerRow]
+    )
+  }
+
+  func testWorkTranscriptMergeDoesNotDuplicateRowWhenRefreshAddsStableIds() {
+    let cachedRow = AgentChatTranscriptEntry(
+      role: "assistant",
+      text: "same visible text",
+      timestamp: "2026-07-24T10:00:00.000Z",
+      turnId: "turn-same"
+    )
+    let refreshedRow = AgentChatTranscriptEntry(
+      role: "assistant",
+      text: "same visible text",
+      timestamp: "2026-07-24T10:00:00.000Z",
+      turnId: "turn-same",
+      messageId: "message-a",
+      itemId: "item-a"
+    )
+
+    XCTAssertEqual(
+      mergeWorkTranscriptEntries(older: [cachedRow], newer: [refreshedRow]),
+      [cachedRow]
+    )
+    XCTAssertEqual(
+      mergeWorkTranscriptPageOccurrences(older: [cachedRow], newer: [refreshedRow]),
+      [cachedRow]
+    )
+  }
+
+  func testWorkTranscriptMergeUsesStableIdWhenStreamingTextChanges() {
+    let draft = AgentChatTranscriptEntry(
+      role: "assistant",
+      text: "draft answer",
+      timestamp: "2026-07-24T10:00:00.000Z",
+      turnId: "turn-same",
+      messageId: "message-a"
+    )
+    let completed = AgentChatTranscriptEntry(
+      role: "assistant",
+      text: "completed answer",
+      timestamp: draft.timestamp,
+      turnId: draft.turnId,
+      messageId: draft.messageId
+    )
+
+    XCTAssertEqual(
+      mergeWorkTranscriptEntries(older: [draft], newer: [completed]),
+      [draft]
+    )
+    XCTAssertEqual(
+      mergeWorkTranscriptPageOccurrences(older: [draft], newer: [completed]),
+      [draft]
+    )
   }
 
   func testRestoredByteCursorTranscriptCacheRehydratesOrderedIndexStore() {

--- a/apps/ios/ADETests/ADETests.swift
+++ b/apps/ios/ADETests/ADETests.swift
@@ -15307,6 +15307,179 @@ final class ADETests: XCTestCase {
     ), 0)
   }
 
+  // MARK: - Work chat transcript scroll policy
+
+  func testProgrammaticScrollWaitsForTheWholeInteractionNotJustTheDrag() {
+    XCTAssertTrue(workChatMayWriteScrollOffset(dragActive: false, scrollPhaseUserDriven: false))
+    XCTAssertFalse(workChatMayWriteScrollOffset(dragActive: true, scrollPhaseUserDriven: false))
+    // Finger-up ends the drag gesture, but the fling it launched still owns the
+    // offset. Writing here is what killed flings mid-deceleration.
+    XCTAssertFalse(workChatMayWriteScrollOffset(dragActive: false, scrollPhaseUserDriven: true))
+
+    XCTAssertTrue(workChatScrollPhaseIsUserDriven(.tracking))
+    XCTAssertTrue(workChatScrollPhaseIsUserDriven(.interacting))
+    XCTAssertTrue(workChatScrollPhaseIsUserDriven(.decelerating))
+    XCTAssertFalse(workChatScrollPhaseIsUserDriven(.idle))
+    // `.animating` is OUR animation. Treating it as the reader's would let one
+    // programmatic scroll suppress the next one.
+    XCTAssertFalse(workChatScrollPhaseIsUserDriven(.animating))
+  }
+
+  func testShortTranscriptRendersFromTheTop() {
+    XCTAssertEqual(workChatTranscriptContentAlignment(contentFitsViewport: true), .topLeading)
+    XCTAssertEqual(workChatTranscriptContentAlignment(contentFitsViewport: false), .bottomLeading)
+  }
+
+  func testPrependCorrectionBailsOutWhenTheProbeDescribesAnotherRow() {
+    let anchor = WorkChatPrependAnchor(
+      rowId: "message-42",
+      rowY: 100,
+      offsetY: 500,
+      remainingAttempts: workChatPrependAnchorAttempts
+    )
+
+    // The probe is measuring some other row, so it says nothing about the
+    // anchored one. Falling through with a zero row shift would reduce the
+    // correction to the reader's own scroll delta and apply it a second time.
+    XCTAssertEqual(
+      workChatPrependCorrection(
+        anchor: anchor,
+        probed: WorkChatPrependProbeSample(rowId: "message-99", y: 340),
+        currentOffsetY: 740,
+        mayWriteScrollOffset: true
+      ),
+      .retry
+    )
+    XCTAssertEqual(
+      workChatPrependCorrection(
+        anchor: anchor,
+        probed: nil,
+        currentOffsetY: 740,
+        mayWriteScrollOffset: true
+      ),
+      .retry
+    )
+  }
+
+  func testPrependCorrectionIsolatesTheInsertionFromTheReadersOwnScrolling() {
+    let anchor = WorkChatPrependAnchor(
+      rowId: "message-42",
+      rowY: 100,
+      offsetY: 500,
+      remainingAttempts: workChatPrependAnchorAttempts
+    )
+    // 900pt inserted above while the reader scrolled 240pt: the row moves
+    // 900 - 240 and the offset moves 240, so the sum is the insertion.
+    XCTAssertEqual(
+      workChatPrependCorrection(
+        anchor: anchor,
+        probed: WorkChatPrependProbeSample(rowId: "message-42", y: 100 + 900 - 240),
+        currentOffsetY: 500 + 240,
+        mayWriteScrollOffset: true
+      ),
+      .apply(900)
+    )
+    // A pure scroll with no prepend sums to zero and correctly restores nothing.
+    XCTAssertEqual(
+      workChatPrependCorrection(
+        anchor: anchor,
+        probed: WorkChatPrependProbeSample(rowId: "message-42", y: 100 - 240),
+        currentOffsetY: 500 + 240,
+        mayWriteScrollOffset: true
+      ),
+      .retry
+    )
+  }
+
+  func testPrependCorrectionWaitsOutTheReaderWithoutSpendingAnAttempt() {
+    let anchor = WorkChatPrependAnchor(
+      rowId: "message-42",
+      rowY: 100,
+      offsetY: 500,
+      remainingAttempts: 1
+    )
+    XCTAssertEqual(
+      workChatPrependCorrection(
+        anchor: anchor,
+        probed: WorkChatPrependProbeSample(rowId: "message-42", y: 1_000),
+        currentOffsetY: 500,
+        mayWriteScrollOffset: false
+      ),
+      .wait
+    )
+  }
+
+  func testOverlappingPrependsKeepTheAnchorThatAccumulatesBoth() {
+    // Second page lands while the first correction is still open. Re-arming on
+    // the new first row would measure only the second insertion and leave the
+    // first one uncorrected.
+    XCTAssertEqual(
+      workChatPrependArmDecision(
+        previousFirstId: "message-20",
+        nextFirstId: "message-10",
+        previousVisibleCount: 40,
+        nextVisibleCount: 60,
+        existingAnchorRowId: "message-42",
+        anchorRowStillVisible: true,
+        previousFirstRowStillVisible: true,
+        probeRowId: "message-42",
+        probeRowY: 220
+      ),
+      .extendExistingAnchorWindow
+    )
+    // Unless the anchored row is gone, in which case there is nothing left to
+    // measure against.
+    XCTAssertEqual(
+      workChatPrependArmDecision(
+        previousFirstId: "message-20",
+        nextFirstId: "message-10",
+        previousVisibleCount: 40,
+        nextVisibleCount: 60,
+        existingAnchorRowId: "message-42",
+        anchorRowStillVisible: false,
+        previousFirstRowStillVisible: true,
+        probeRowId: "message-42",
+        probeRowY: 220
+      ),
+      .retireAnchor
+    )
+  }
+
+  func testPrependAnchorOnlyArmsOnAGenuineInsertionAbove() {
+    func decision(
+      previousFirstId: String? = "message-20",
+      nextFirstId: String? = "message-10",
+      previousVisibleCount: Int = 40,
+      nextVisibleCount: Int = 60,
+      previousFirstRowStillVisible: Bool = true,
+      probeRowId: String? = "message-20",
+      probeRowY: CGFloat? = 180
+    ) -> WorkChatPrependArmDecision {
+      workChatPrependArmDecision(
+        previousFirstId: previousFirstId,
+        nextFirstId: nextFirstId,
+        previousVisibleCount: previousVisibleCount,
+        nextVisibleCount: nextVisibleCount,
+        existingAnchorRowId: nil,
+        anchorRowStillVisible: false,
+        previousFirstRowStillVisible: previousFirstRowStillVisible,
+        probeRowId: probeRowId,
+        probeRowY: probeRowY
+      )
+    }
+
+    XCTAssertEqual(decision(), .arm(rowId: "message-20", rowY: 180))
+    // Appended, not prepended: the list grew but still leads with the same row.
+    XCTAssertEqual(decision(nextFirstId: "message-20"), .ignore)
+    // Rows replaced rather than inserted.
+    XCTAssertEqual(decision(nextVisibleCount: 40), .ignore)
+    // The leading row is gone, so this is not a prepend.
+    XCTAssertEqual(decision(previousFirstRowStillVisible: false), .ignore)
+    // The probe was measuring a different row, so there is no "before" position.
+    XCTAssertEqual(decision(probeRowId: "message-77"), .ignore)
+    XCTAssertEqual(decision(probeRowY: nil), .ignore)
+  }
+
   func testMobileChatHistoryTriggerAndRenderCapStayBounded() {
     XCTAssertTrue(workChatShouldRequestOlderHistory(
       distanceFromTop: 120,

--- a/apps/ios/ADETests/WorkAssistantRenderingTests.swift
+++ b/apps/ios/ADETests/WorkAssistantRenderingTests.swift
@@ -435,6 +435,27 @@ final class WorkAssistantRenderingTests: XCTestCase {
     )
   }
 
+  func testLongSingleLineKeepsItsControlUntilTheNextRungIsActuallyComplete() {
+    let markdown = String(repeating: "x", count: 15_000)
+    let preview = workAssistantMessagePreview(
+      markdown,
+      lineBudget: workAssistantMessageInitialLineBudget,
+      characterBudget: workAssistantMessageCharacterBudget(
+        forLineBudget: workAssistantMessageInitialLineBudget
+      )
+    )
+
+    XCTAssertTrue(preview.isTruncated)
+    XCTAssertEqual(preview.totalLineCount, 1)
+    XCTAssertTrue(
+      workAssistantMessageWillRemainTruncated(
+        preview,
+        nextLineBudget: workAssistantMessageInitialLineBudget + workAssistantMessageLineBudgetStep
+      )
+    )
+    XCTAssertFalse(workAssistantMessageWillRemainTruncated(preview, nextLineBudget: 240))
+  }
+
   /// End to end over the real preview slicer: a message that rendered in full as
   /// the tail is still rendered in full — with no "Show more" — after a newer
   /// message pushes it into head-anchoring.

--- a/apps/ios/ADETests/WorkAssistantRenderingTests.swift
+++ b/apps/ios/ADETests/WorkAssistantRenderingTests.swift
@@ -519,7 +519,215 @@ final class WorkAssistantRenderingTests: XCTestCase {
     XCTAssertEqual(Array(first.prefix(2)), Array(second.prefix(2)))
   }
 
+  // MARK: - Copy is always the full content
+
+  /// The transcript renders a bounded slice, so the code a block view holds can
+  /// be a prefix of the real block. Copy has to reach past the slice.
+  func testHeadSlicedCodeBlocksCopyTheWholeBlock() {
+    let markdown = codeBlockMarkdown(blockCount: 3, linesPerBlock: 60)
+    let preview = workAssistantMessagePreview(
+      markdown,
+      lineBudget: workAssistantMessageInitialLineBudget,
+      characterBudget: workAssistantMessageCharacterBudget(forLineBudget: workAssistantMessageInitialLineBudget),
+      anchor: .head
+    )
+    XCTAssertTrue(preview.isTruncated)
+
+    let fullCode = codeBlockPayloads(of: markdown)
+    let rendered = renderedCodeBlocks(markdown: markdown, preview: preview, id: "assistant-head-code")
+    XCTAssertFalse(rendered.isEmpty)
+    for (ordinal, block) in rendered.enumerated() {
+      XCTAssertNotNil(block.source)
+      XCTAssertEqual(block.source?.ordinal, ordinal)
+      XCTAssertEqual(block.source?.countsFromEnd, false)
+      XCTAssertEqual(block.source?.resolvedCode(fallback: block.code), fullCode[ordinal])
+    }
+    // The slice really was partial — otherwise this proves nothing.
+    XCTAssertNotEqual(rendered.last?.code, fullCode[rendered.count - 1])
+  }
+
+  /// A tail slice can start *inside* a fence, and the preview prepends a
+  /// synthetic opening fence (`workOpeningMarkdownFenceBeforeTail`) so it parses
+  /// at all. That synthetic block is the one most likely to copy a fragment, so
+  /// it is numbered from the end and resolved against the real message.
+  func testTailSlicedCodeBlocksCopyTheWholeBlockThroughTheSyntheticFence() {
+    let markdown = codeBlockMarkdown(blockCount: 3, linesPerBlock: 80)
+    let preview = workAssistantMessagePreview(
+      markdown,
+      lineBudget: workAssistantMessageTailFullLineBudget,
+      characterBudget: workAssistantMessageTailFullCharacterBudget,
+      anchor: .tail
+    )
+    XCTAssertTrue(preview.isTruncated)
+    XCTAssertTrue(preview.text.hasPrefix("```"), "expected a synthetic opening fence on this tail")
+
+    let fullCode = codeBlockPayloads(of: markdown)
+    let rendered = renderedCodeBlocks(markdown: markdown, preview: preview, id: "assistant-tail-code")
+    XCTAssertFalse(rendered.isEmpty)
+    for (offsetFromEnd, block) in rendered.reversed().enumerated() {
+      XCTAssertEqual(block.source?.countsFromEnd, true)
+      XCTAssertEqual(block.source?.ordinal, offsetFromEnd)
+      XCTAssertEqual(
+        block.source?.resolvedCode(fallback: block.code),
+        fullCode[fullCode.count - 1 - offsetFromEnd]
+      )
+    }
+    // The synthetic-fence block is the fragment; copying it must not yield one.
+    let first = rendered[0]
+    XCTAssertNotEqual(first.code, first.source?.resolvedCode(fallback: first.code))
+  }
+
+  /// A slice that cannot be located falls back to what is on screen rather than
+  /// copying some other block's contents.
+  func testUnresolvableCodeBlockOrdinalFallsBackToTheRenderedSlice() {
+    let markdown = "```swift\nlet a = 1\n```"
+    let source = WorkCodeBlockSource(markdown: markdown, ordinal: 7, countsFromEnd: false)
+    XCTAssertEqual(source.resolvedCode(fallback: "let a = 1"), "let a = 1")
+  }
+
+  func testCodeBlockOrdinalsCountFromTheEndForATailSlice() {
+    let blocks = parseMarkdownBlocks("```\na\n```\n\ntext\n\n```\nb\n```")
+    XCTAssertEqual(workCodeBlockOrdinals(blocks, countsFromEnd: false).values.sorted(), [0, 1])
+    XCTAssertEqual(workCodeBlockOrdinals(blocks, countsFromEnd: true).values.sorted(), [0, 1])
+    let codeIds = blocks.filter { if case .code = $0.kind { return true }; return false }.map(\.id)
+    XCTAssertEqual(workCodeBlockOrdinals(blocks, countsFromEnd: true)[codeIds[0]], 1)
+    XCTAssertEqual(workCodeBlockOrdinals(blocks, countsFromEnd: true)[codeIds[1]], 0)
+  }
+
+  /// The result box shows a slice; the clipboard never does.
+  func testToolResultBoxSeparatesWhatIsShownFromWhatIsCopied() {
+    let resultText = String(repeating: "x", count: workToolResultTruncateLimit + 400)
+    let collapsed = workToolResultBlockText(resultText, expanded: false)
+    XCTAssertTrue(collapsed.didTruncate)
+    XCTAssertLessThan(collapsed.displayed.count, resultText.count)
+    XCTAssertEqual(collapsed.copy, resultText)
+
+    let expanded = workToolResultBlockText(resultText, expanded: true)
+    XCTAssertFalse(expanded.didTruncate)
+    XCTAssertEqual(expanded.displayed, resultText)
+    XCTAssertEqual(expanded.copy, resultText)
+  }
+
+  // MARK: - Hybrid expand ladder
+
+  func testHybridLadderStepsOnceInPlaceThenOffersTheViewer() {
+    XCTAssertEqual(
+      workTruncatedOutputAffordance(isTruncated: true, hasExpandedInPlace: false, isClipped: false),
+      .showMore
+    )
+    XCTAssertEqual(
+      workTruncatedOutputAffordance(isTruncated: true, hasExpandedInPlace: true, isClipped: false),
+      .openFullOutput
+    )
+  }
+
+  /// Nothing truncated and nothing clipped means nothing to offer — the ladder
+  /// must not leave a permanent control under every box.
+  func testHybridLadderOffersNothingWhenTheWholeBoxIsVisible() {
+    XCTAssertEqual(
+      workTruncatedOutputAffordance(isTruncated: false, hasExpandedInPlace: false, isClipped: false),
+      .none
+    )
+    XCTAssertEqual(
+      workTruncatedOutputAffordance(isTruncated: false, hasExpandedInPlace: true, isClipped: false),
+      .none
+    )
+  }
+
+  /// Expanding a box that clips at a fixed height adds text nobody can see, so
+  /// a fully-expanded-but-clipped box goes straight to the viewer.
+  func testHybridLadderOffersTheViewerForAClippedBox() {
+    XCTAssertEqual(
+      workTruncatedOutputAffordance(isTruncated: false, hasExpandedInPlace: true, isClipped: true),
+      .openFullOutput
+    )
+  }
+
+  func testOutputBoxOverflowsCountsWrappedLinesForAWrappingBox() {
+    let short = "one\ntwo\nthree"
+    XCTAssertFalse(workOutputBoxOverflows(short, lineCapacity: 11, columnCapacity: 46))
+
+    let tall = (1...40).map { "line \($0)" }.joined(separator: "\n")
+    XCTAssertTrue(workOutputBoxOverflows(tall, lineCapacity: 11, columnCapacity: 46))
+
+    // One long line wraps into many in a wrapping box…
+    let oneLongLine = String(repeating: "y", count: 46 * 12)
+    XCTAssertTrue(workOutputBoxOverflows(oneLongLine, lineCapacity: 11, columnCapacity: 46))
+    // …and stays one line in a box that scrolls horizontally instead.
+    XCTAssertFalse(workOutputBoxOverflows(oneLongLine, lineCapacity: 11, columnCapacity: nil))
+  }
+
+  func testOutputBoxOverflowsCountsOnlyHardBreaksForADiff() {
+    let diff = (1...30).map { "+ added line \($0)" }.joined(separator: "\n")
+    XCTAssertTrue(workOutputBoxOverflows(diff, lineCapacity: workDiffOutputBoxLineCapacity, columnCapacity: nil))
+    XCTAssertFalse(workOutputBoxOverflows(diff, lineCapacity: 40, columnCapacity: nil))
+    XCTAssertFalse(workOutputBoxOverflows("", lineCapacity: 11, columnCapacity: nil))
+  }
+
+  // MARK: - Viewer search
+
+  func testViewerSearchCountsEveryOccurrenceNotEveryLine() {
+    let lines = ["alpha beta alpha", "gamma", "ALPHA"]
+    XCTAssertEqual(workOutputViewerMatchLines(lines, query: "alpha"), [0, 0, 2])
+    XCTAssertEqual(workOutputViewerMatchLines(lines, query: "delta"), [])
+    XCTAssertEqual(workOutputViewerMatchLines(lines, query: "   "), [])
+  }
+
+  func testViewerSearchStepsWrapAtBothEnds() {
+    XCTAssertEqual(workOutputViewerSteppedMatchIndex(current: 2, delta: 1, count: 3), 0)
+    XCTAssertEqual(workOutputViewerSteppedMatchIndex(current: 0, delta: -1, count: 3), 2)
+    XCTAssertEqual(workOutputViewerSteppedMatchIndex(current: 0, delta: 1, count: 0), 0)
+  }
+
   // MARK: - Helpers
+
+  private struct RenderedCodeBlock {
+    let code: String
+    let source: WorkCodeBlockSource?
+  }
+
+  private func codeBlockMarkdown(blockCount: Int, linesPerBlock: Int) -> String {
+    var parts: [String] = []
+    for block in 1...blockCount {
+      parts.append("Step \(block): here is the change.")
+      parts.append("")
+      parts.append("```swift")
+      parts.append(contentsOf: (1...linesPerBlock).map { "let block\(block)Line\($0) = \($0)" })
+      parts.append("```")
+      parts.append("")
+    }
+    parts.append("That is every change.")
+    return parts.joined(separator: "\n")
+  }
+
+  private func codeBlockPayloads(of markdown: String) -> [String] {
+    parseMarkdownBlocks(markdown).compactMap { block in
+      guard case .code(_, let code) = block.kind else { return nil }
+      return code
+    }
+  }
+
+  /// Runs the real render path so the test covers the plumbing, not just the
+  /// resolver: preview → timeline entries → per-block render models.
+  private func renderedCodeBlocks(
+    markdown: String,
+    preview: WorkAssistantMessagePreview,
+    id: String
+  ) -> [RenderedCodeBlock] {
+    var message = makeAssistantMessage(id: id, markdown: markdown)
+    message.assistantPreview = preview
+    let rendered = workTimelineRenderEntries(
+      from: [makeMessageEntry(message)],
+      streamingAssistantMessageId: nil,
+      splitAssistantMessageId: message.id
+    )
+    return rendered.compactMap { entry in
+      guard case .assistantMarkdownBlock(let model) = entry.payload,
+            case .code(_, let code) = model.block.kind
+      else { return nil }
+      return RenderedCodeBlock(code: code, source: model.codeSource)
+    }
+  }
 
   private struct ShowMoreWalk {
     let taps: Int

--- a/apps/ios/ADETests/WorkAssistantRenderingTests.swift
+++ b/apps/ios/ADETests/WorkAssistantRenderingTests.swift
@@ -585,6 +585,21 @@ final class WorkAssistantRenderingTests: XCTestCase {
     XCTAssertEqual(source.resolvedCode(fallback: "let a = 1"), "let a = 1")
   }
 
+  func testCodeBlockSourceIdentityDetectsSameLengthAuthoritativeEdits() {
+    let first = WorkCodeBlockSource(
+      markdown: "```swift\nlet a = 1\n```",
+      ordinal: 0,
+      countsFromEnd: false
+    )
+    let second = WorkCodeBlockSource(
+      markdown: "```swift\nlet b = 2\n```",
+      ordinal: 0,
+      countsFromEnd: false
+    )
+
+    XCTAssertNotEqual(first, second)
+  }
+
   func testCodeBlockOrdinalsCountFromTheEndForATailSlice() {
     let blocks = parseMarkdownBlocks("```\na\n```\n\ntext\n\n```\nb\n```")
     XCTAssertEqual(workCodeBlockOrdinals(blocks, countsFromEnd: false).values.sorted(), [0, 1])

--- a/apps/ios/ADETests/WorkAssistantRenderingTests.swift
+++ b/apps/ios/ADETests/WorkAssistantRenderingTests.swift
@@ -355,6 +355,170 @@ final class WorkAssistantRenderingTests: XCTestCase {
     }
   }
 
+  // MARK: - Budget stability
+
+  /// The regression this rule exists for: the newest assistant answer renders
+  /// tail-anchored under the generous budget, and the moment a newer message
+  /// arrives it flips to head-anchoring. That flip used to drop the budget back
+  /// to 48 lines, so a message the reader had already read in full grew a
+  /// "Show more" behind their back.
+  func testBudgetSurvivesTheFlipOutOfTailAnchoring() {
+    let asTail = workAssistantRenderBudget(
+      userLineBudget: nil,
+      floorLineBudget: nil,
+      isTail: true,
+      headAnchorOverride: false,
+      tailCanRenderFull: true
+    )
+    XCTAssertEqual(asTail.lineBudget, workAssistantMessageTailFullLineBudget)
+    XCTAssertEqual(asTail.anchor, .tail)
+
+    // A newer message arrived. Same message, no longer the tail.
+    let afterFlip = workAssistantRenderBudget(
+      userLineBudget: nil,
+      floorLineBudget: asTail.lineBudget,
+      isTail: false,
+      headAnchorOverride: false,
+      tailCanRenderFull: false
+    )
+    XCTAssertEqual(afterFlip.lineBudget, workAssistantMessageTailFullLineBudget)
+    XCTAssertEqual(afterFlip.anchor, .head)
+  }
+
+  func testBudgetNeverShrinksBelowWhatWasAlreadyRendered() {
+    let expanded = workAssistantMessageInitialLineBudget + (4 * workAssistantMessageLineBudgetStep)
+    for isTail in [true, false] {
+      let budget = workAssistantRenderBudget(
+        userLineBudget: nil,
+        floorLineBudget: expanded,
+        isTail: isTail,
+        headAnchorOverride: false,
+        tailCanRenderFull: false
+      )
+      XCTAssertEqual(budget.lineBudget, expanded)
+    }
+    // The floor is a floor, not a ceiling: a further expansion still applies.
+    XCTAssertEqual(
+      workAssistantRenderBudget(
+        userLineBudget: expanded + workAssistantMessageLineBudgetStep,
+        floorLineBudget: expanded,
+        isTail: false,
+        headAnchorOverride: true,
+        tailCanRenderFull: false
+      ).lineBudget,
+      expanded + workAssistantMessageLineBudgetStep
+    )
+  }
+
+  func testExpandingTheTailMessageAnchorsItAtItsHead() {
+    let budget = workAssistantRenderBudget(
+      userLineBudget: workAssistantMessageInitialLineBudget + workAssistantMessageLineBudgetStep,
+      floorLineBudget: workAssistantMessageTailFullLineBudget,
+      isTail: true,
+      headAnchorOverride: true,
+      tailCanRenderFull: true
+    )
+    XCTAssertEqual(budget.anchor, .head)
+    XCTAssertEqual(budget.lineBudget, workAssistantMessageTailFullLineBudget)
+  }
+
+  func testShowMoreStepsFromTheBudgetTheMessageIsRenderingUnder() {
+    XCTAssertEqual(
+      workAssistantMessageShowMoreLineBudget(current: nil),
+      workAssistantMessageInitialLineBudget + workAssistantMessageLineBudgetStep
+    )
+    // A message held at the tail-full floor steps up from that floor, not back
+    // down to the initial budget.
+    XCTAssertEqual(
+      workAssistantMessageShowMoreLineBudget(current: workAssistantMessageTailFullLineBudget),
+      workAssistantMessageTailFullLineBudget + workAssistantMessageLineBudgetStep
+    )
+  }
+
+  /// End to end over the real preview slicer: a message that rendered in full as
+  /// the tail is still rendered in full — with no "Show more" — after a newer
+  /// message pushes it into head-anchoring.
+  func testMessageRenderedFullyAsTailIsNeverTruncatedLater() {
+    let markdown = (1...100).map { "Line \($0): the agent explained another step." }
+      .joined(separator: "\n")
+    XCTAssertFalse(workAssistantMessageUsesMonospacedPreview(markdown))
+
+    func preview(_ budget: WorkAssistantRenderBudget) -> WorkAssistantMessagePreview {
+      workAssistantMessagePreview(
+        markdown,
+        lineBudget: budget.lineBudget,
+        characterBudget: workAssistantMessageCharacterBudget(forLineBudget: budget.lineBudget),
+        anchor: budget.anchor
+      )
+    }
+
+    let asTail = workAssistantRenderBudget(
+      userLineBudget: nil,
+      floorLineBudget: nil,
+      isTail: true,
+      headAnchorOverride: false,
+      tailCanRenderFull: true
+    )
+    let tailPreview = preview(asTail)
+    XCTAssertFalse(tailPreview.isTruncated)
+
+    let afterFlip = workAssistantRenderBudget(
+      userLineBudget: nil,
+      floorLineBudget: asTail.lineBudget,
+      isTail: false,
+      headAnchorOverride: false,
+      tailCanRenderFull: false
+    )
+    let headPreview = preview(afterFlip)
+    XCTAssertFalse(headPreview.isTruncated, "Show more reappeared on a message the reader already read in full")
+    XCTAssertEqual(headPreview.text, markdown)
+
+    // And the same message WITHOUT the floor is exactly the regression: it
+    // truncates. This is what the floor is protecting against.
+    let withoutFloor = workAssistantRenderBudget(
+      userLineBudget: nil,
+      floorLineBudget: nil,
+      isTail: false,
+      headAnchorOverride: false,
+      tailCanRenderFull: false
+    )
+    XCTAssertTrue(preview(withoutFloor).isTruncated)
+  }
+
+  // MARK: - Position-stable block ids
+
+  func testMarkdownBlockIdsAreIndexBasedAndSurviveContentEdits() {
+    let before = parseMarkdownBlocks("First paragraph.\n\n## Heading\n\nSecond paragraph.")
+    let after = parseMarkdownBlocks("First paragraph, revised.\n\n## Heading\n\nSecond paragraph.")
+
+    XCTAssertEqual(before.map(\.id), after.map(\.id))
+    XCTAssertEqual(before.map(\.id), (0..<before.count).map { "markdown-block-\($0)" })
+    // Identity is stable, but the change is still visible to change detection.
+    XCTAssertNotEqual(before[0].digest, after[0].digest)
+    XCTAssertEqual(before[1].digest, after[1].digest)
+    XCTAssertNotEqual(before[0], after[0])
+  }
+
+  func testStreamingBlockIdsMatchTheWholeTextParse() {
+    let markdown = "Intro paragraph.\n\n```swift\nlet x = 1\n```\n\nClosing paragraph."
+    let streamed = parseMarkdownBlocksForStreaming(markdown, cacheKey: "streaming-id-parity")
+    let whole = parseMarkdownBlocks(markdown)
+    XCTAssertEqual(streamed.map(\.id), whole.map(\.id))
+    XCTAssertEqual(streamed.map(\.digest), whole.map(\.digest))
+  }
+
+  /// A streaming message grows one delta at a time. Every already-rendered row
+  /// has to keep its identity across those deltas, or the LazyVStack rebuilds
+  /// the whole subtree on every frame instead of updating the tail.
+  func testStreamingDeltasDoNotChurnEarlierBlockIds() {
+    let head = "Intro paragraph.\n\n## Findings\n\n"
+    let first = parseMarkdownBlocksForStreaming(head + "Partial", cacheKey: "streaming-churn")
+    let second = parseMarkdownBlocksForStreaming(head + "Partial answer, now longer.", cacheKey: "streaming-churn")
+    XCTAssertGreaterThanOrEqual(first.count, 2)
+    XCTAssertEqual(Array(first.prefix(2)).map(\.id), Array(second.prefix(2)).map(\.id))
+    XCTAssertEqual(Array(first.prefix(2)), Array(second.prefix(2)))
+  }
+
   // MARK: - Helpers
 
   private struct ShowMoreWalk {

--- a/apps/ios/ADETests/WorkCardExpansionTests.swift
+++ b/apps/ios/ADETests/WorkCardExpansionTests.swift
@@ -1,0 +1,405 @@
+import XCTest
+@testable import ADE
+
+/// Auto-collapse rules for the Work transcript: which cards belong to the turn
+/// in flight, what a turn ending does to the reader's overrides, and what the
+/// collapsed one-liners say.
+final class WorkCardExpansionTests: XCTestCase {
+
+  // MARK: - Turn attribution
+
+  func testEntriesAfterLastTurnEndBelongToTheLiveTurn() {
+    let timeline = [
+      entry("a"),
+      turnEnd("turn-1", id: "end-1"),
+      entry("b"),
+      entry("c"),
+    ]
+
+    XCTAssertEqual(workEntryIdsAfterLatestTurnEnd(in: timeline), ["b", "c"])
+  }
+
+  func testEverythingBelongsToTheLiveTurnBeforeAnyTurnHasEnded() {
+    let timeline = [entry("a"), entry("b")]
+
+    XCTAssertEqual(workEntryIdsAfterLatestTurnEnd(in: timeline), ["a", "b"])
+  }
+
+  /// The state a reopened chat lands in: the last row is a turn-end marker, so
+  /// nothing is attributed to a live turn and every card renders collapsed.
+  func testNoLiveEntriesWhenTheTranscriptEndsOnATurnEnd() {
+    let timeline = [
+      entry("a"),
+      turnEnd("turn-1", id: "end-1"),
+      entry("b"),
+      turnEnd("turn-2", id: "end-2"),
+    ]
+
+    XCTAssertTrue(workEntryIdsAfterLatestTurnEnd(in: timeline).isEmpty)
+  }
+
+  func testOnlyTheMostRecentTurnCounts() {
+    let timeline = [
+      turnEnd("turn-1", id: "end-1"),
+      entry("stale"),
+      turnEnd("turn-2", id: "end-2"),
+      entry("fresh"),
+    ]
+
+    let live = workEntryIdsAfterLatestTurnEnd(in: timeline)
+    XCTAssertTrue(live.contains("fresh"))
+    XCTAssertFalse(live.contains("stale"))
+  }
+
+  // MARK: - Expansion overrides
+
+  func testCardWithoutAnOverrideFollowsItsDefault() {
+    let state = WorkCardExpansionState()
+
+    XCTAssertTrue(state.isExpanded(id: "plan-1", defaultsOpen: true))
+    XCTAssertFalse(state.isExpanded(id: "tool-1", defaultsOpen: false))
+  }
+
+  func testManualExpandOnAnEndedTurnSticks() {
+    var state = WorkCardExpansionState()
+    state.toggle(id: "tool-1", defaultsOpen: false)
+
+    XCTAssertTrue(state.isExpanded(id: "tool-1", defaultsOpen: false))
+  }
+
+  /// The escape hatch: shutting a card that auto-opens while its turn is live
+  /// has to survive every subsequent streaming delta.
+  func testManualCollapseDuringALiveTurnSticks() {
+    var state = WorkCardExpansionState()
+    state.toggle(id: "plan-1", defaultsOpen: true)
+
+    XCTAssertFalse(state.isExpanded(id: "plan-1", defaultsOpen: true))
+  }
+
+  func testTogglingBackToTheDefaultDropsTheOverride() {
+    var state = WorkCardExpansionState()
+    state.toggle(id: "plan-1", defaultsOpen: true)
+    state.toggle(id: "plan-1", defaultsOpen: true)
+
+    XCTAssertTrue(state.isExpanded(id: "plan-1", defaultsOpen: true))
+    XCTAssertTrue(state.isEmpty, "a card back at its default should carry no override")
+  }
+
+  func testTurnEndClearsBothManualExpandsAndManualCollapses() {
+    var state = WorkCardExpansionState()
+    state.toggle(id: "tool-1", defaultsOpen: false)   // opened by hand
+    state.toggle(id: "plan-1", defaultsOpen: true)    // shut by hand while live
+    XCTAssertFalse(state.isEmpty)
+
+    state.clearForTurnEnd()
+
+    XCTAssertTrue(state.isEmpty)
+    // Everything now renders collapsed, because an ended turn's cards never
+    // default open.
+    XCTAssertFalse(state.isExpanded(id: "tool-1", defaultsOpen: false))
+    XCTAssertFalse(state.isExpanded(id: "plan-1", defaultsOpen: false))
+  }
+
+  func testRenderSignatureChangesWhenExpansionChanges() {
+    var state = WorkCardExpansionState()
+    let empty = workCardExpansionRenderSignature(state)
+
+    state.toggle(id: "tool-1", defaultsOpen: false)
+    let expanded = workCardExpansionRenderSignature(state)
+    XCTAssertNotEqual(empty, expanded)
+
+    state.clearForTurnEnd()
+    XCTAssertEqual(empty, workCardExpansionRenderSignature(state))
+  }
+
+  /// An expand and a collapse of the same id must not hash alike — the two sets
+  /// are what tell the row which way to draw.
+  func testRenderSignatureDistinguishesExpandFromCollapse() {
+    var expandedState = WorkCardExpansionState()
+    expandedState.toggle(id: "card-1", defaultsOpen: false)
+
+    var collapsedState = WorkCardExpansionState()
+    collapsedState.toggle(id: "card-1", defaultsOpen: true)
+
+    XCTAssertNotEqual(
+      workCardExpansionRenderSignature(expandedState),
+      workCardExpansionRenderSignature(collapsedState)
+    )
+  }
+
+  // MARK: - Collapsed CI row
+
+  func testCollapsedCiRowSummarizesTitleAndPrNumber() throws {
+    let card = try adeCard(
+      """
+      {
+        "cardId": "ci-490",
+        "variant": "pr_ci",
+        "state": "terminal",
+        "title": "CI",
+        "subtitle": "PR #490 · build-and-test",
+        "progress": {"passed": 18, "failed": 3, "running": 0, "queued": 0},
+        "fallbackText": "PR #490 checks failing."
+      }
+      """
+    )
+
+    XCTAssertEqual(workAdeCardCollapsedSummary(card), "CI · PR #490")
+    XCTAssertEqual(workAdeCardCollapsedChips(card).map(\.label), ["18✓", "3✕"])
+    XCTAssertEqual(workAdeCardCollapsedGlyph(card), "checklist")
+  }
+
+  func testCollapsedCiRowOmitsAZeroChip() throws {
+    let card = try adeCard(
+      """
+      {
+        "cardId": "ci-491",
+        "variant": "pr_ci",
+        "state": "terminal",
+        "title": "CI",
+        "subtitle": "PR #491",
+        "progress": {"passed": 21, "failed": 0, "running": 0, "queued": 0},
+        "fallbackText": "PR #491 checks passing."
+      }
+      """
+    )
+
+    XCTAssertEqual(workAdeCardCollapsedChips(card).map(\.label), ["21✓"])
+  }
+
+  func testCollapsedCiRowHasNoChipsWithoutProgress() throws {
+    let card = try adeCard(
+      """
+      {
+        "cardId": "ci-492",
+        "variant": "pr_ci",
+        "state": "running",
+        "title": "CI",
+        "subtitle": "PR #492",
+        "fallbackText": "PR #492 checks running."
+      }
+      """
+    )
+
+    XCTAssertTrue(workAdeCardCollapsedChips(card).isEmpty)
+  }
+
+  func testCollapsedCiAccessibilityLabelSpeaksTheCounts() throws {
+    let card = try adeCard(
+      """
+      {
+        "cardId": "ci-490",
+        "variant": "pr_ci",
+        "state": "terminal",
+        "title": "CI",
+        "subtitle": "PR #490 · build-and-test",
+        "progress": {"passed": 18, "failed": 3, "running": 0, "queued": 0},
+        "fallbackText": "PR #490 checks failing."
+      }
+      """
+    )
+
+    XCTAssertEqual(
+      workAdeCardCollapsedAccessibilityLabel(card),
+      "CI · PR #490, 18 passed, 3 failed, collapsed"
+    )
+  }
+
+  func testCollapsedAdeCardFallsBackToItsFallbackTextWhenUntitled() throws {
+    let card = try adeCard(
+      """
+      {
+        "cardId": "mystery-1",
+        "variant": "some_future_variant",
+        "state": "terminal",
+        "fallbackText": "Something happened upstream."
+      }
+      """
+    )
+
+    XCTAssertEqual(workAdeCardCollapsedSummary(card), "Something happened upstream.")
+    XCTAssertEqual(workAdeCardCollapsedGlyph(card), "square.stack")
+  }
+
+  /// The slug substitution happens for known variants too, so the row has to
+  /// refuse `pr_ci` there as well and lead with the subtitle instead.
+  func testCollapsedAdeCardNeverShowsTheRawVariantSlug() throws {
+    let card = try adeCard(
+      """
+      {
+        "cardId": "ci-493",
+        "variant": "pr_ci",
+        "state": "terminal",
+        "subtitle": "PR #493 · build-and-test",
+        "progress": {"passed": 4, "failed": 0, "running": 0, "queued": 0},
+        "fallbackText": "PR #493 checks passing."
+      }
+      """
+    )
+
+    XCTAssertEqual(workAdeCardCollapsedSummary(card), "PR #493")
+  }
+
+  // MARK: - Collapsed plan row
+
+  func testCollapsedPlanRowCountsDoneStepsAndLeadsWithTheActiveOne() {
+    let card = planCard(steps: [
+      ("Read the failing test", "completed"),
+      ("Patch the parser", "completed"),
+      ("Add a regression test", "completed"),
+      ("Update the snapshot", "completed"),
+      ("Run the suite", "in_progress"),
+      ("Write the changelog", "pending"),
+      ("Open the PR", "pending"),
+    ])
+
+    XCTAssertEqual(workPlanCardCollapsedProgressLabel(card), "4/7")
+    XCTAssertEqual(workPlanCardCollapsedSummary(card), "Plan · Run the suite")
+  }
+
+  func testCollapsedPlanRowHasNoProgressChipWithoutSteps() {
+    let card = planCard(steps: [])
+
+    XCTAssertNil(workPlanCardCollapsedProgressLabel(card))
+    XCTAssertEqual(workPlanCardCollapsedSummary(card), "Plan")
+  }
+
+  func testCollapsedPlanRowPrefersAMeaningfulTitle() {
+    let card = planCard(
+      title: "Fix the flaky sync test",
+      steps: [("Reproduce", "pending"), ("Fix", "pending")]
+    )
+
+    XCTAssertEqual(workPlanCardCollapsedSummary(card), "Plan · Fix the flaky sync test")
+    XCTAssertEqual(workPlanCardCollapsedProgressLabel(card), "0/2")
+  }
+
+  func testCollapsedPlanRowFallsBackToTheFirstStepOnceEveryStepIsDone() {
+    let card = planCard(steps: [("Ship it", "completed")])
+
+    XCTAssertEqual(workPlanCardCollapsedSummary(card), "Plan · Ship it")
+    XCTAssertEqual(workPlanCardCollapsedProgressLabel(card), "1/1")
+  }
+
+  /// `done`/`complete`/`success` are all terminal on the wire; the collapsed
+  /// count has to agree with the expanded checklist's checkmarks.
+  func testCompletedStepDetectionMatchesTheExpandedChecklist() {
+    XCTAssertTrue(workPlanStepIsCompleted("completed"))
+    XCTAssertTrue(workPlanStepIsCompleted("done"))
+    XCTAssertTrue(workPlanStepIsCompleted("complete"))
+    XCTAssertTrue(workPlanStepIsCompleted("success"))
+    XCTAssertFalse(workPlanStepIsCompleted("in_progress"))
+    XCTAssertFalse(workPlanStepIsCompleted("failed"))
+    XCTAssertFalse(workPlanStepIsCompleted("pending"))
+  }
+
+  func testCollapsedPlanAccessibilityLabelSpeaksTheProgress() {
+    let card = planCard(steps: [
+      ("Read", "completed"),
+      ("Write", "pending"),
+    ])
+
+    XCTAssertEqual(
+      workPlanCardCollapsedAccessibilityLabel(card),
+      "Plan · Write, 1 of 2 steps done, collapsed"
+    )
+  }
+
+  // MARK: - Composer chip count
+
+  func testChatInfoCountCoversSubagentsAndScheduledWork() {
+    let count = workChatInfoItemCount(
+      subagents: [subagent(taskId: "task-1"), subagent(taskId: "task-2")],
+      scheduledWork: []
+    )
+
+    XCTAssertEqual(count, 2, "the one chip has to speak for the whole sheet")
+  }
+
+  func testChatInfoChipIsHiddenWhenThereIsNothingToShow() {
+    XCTAssertEqual(workChatInfoItemCount(subagents: [], scheduledWork: []), 0)
+  }
+
+  // MARK: - Fixtures
+
+  private func entry(_ id: String) -> WorkTimelineEntry {
+    WorkTimelineEntry(
+      id: id,
+      timestamp: "2026-01-01T00:00:00.000Z",
+      rank: 0,
+      payload: .usageSummary(
+        WorkUsageSummary(
+          turnCount: 1,
+          inputTokens: 0,
+          outputTokens: 0,
+          cacheReadTokens: 0,
+          cacheCreationTokens: 0,
+          costUsd: 0
+        )
+      )
+    )
+  }
+
+  private func turnEnd(_ turnId: String, id: String) -> WorkTimelineEntry {
+    WorkTimelineEntry(
+      id: id,
+      timestamp: "2026-01-01T00:00:00.000Z",
+      rank: 0,
+      payload: .turnEndMarker(
+        WorkTurnEndMarker(
+          turnId: turnId,
+          time: "12:00",
+          workedDurationLabel: "1m",
+          status: "completed",
+          terminalReasonLabel: nil,
+          provider: "claude",
+          modelLabel: "Opus",
+          modelId: nil
+        )
+      )
+    )
+  }
+
+  private func adeCard(_ json: String) throws -> WorkAdeCardModel {
+    let payload = try JSONDecoder().decode(
+      AgentChatAdeCardPayload.self,
+      from: Data(json.utf8)
+    )
+    return makeWorkAdeCardModel(from: payload)
+  }
+
+  private func planCard(title: String = "Plan", steps: [(String, String)]) -> WorkEventCardModel {
+    WorkEventCardModel(
+      id: "plan-1",
+      kind: "plan",
+      title: title,
+      icon: "list.bullet.clipboard",
+      tint: .accent,
+      timestamp: "2026-01-01T00:00:00.000Z",
+      body: nil,
+      bullets: [],
+      metadata: [],
+      planSteps: steps.map { WorkPlanStep(text: $0.0, status: $0.1) }
+    )
+  }
+
+  private func subagent(taskId: String) -> WorkSubagentSnapshot {
+    WorkSubagentSnapshot(
+      taskId: taskId,
+      agentId: nil,
+      agentType: "general-purpose",
+      parentToolUseId: nil,
+      description: "Investigate",
+      background: false,
+      label: nil,
+      model: nil,
+      reasoningEffort: nil,
+      status: .running,
+      lastToolName: nil,
+      latestSummary: nil,
+      turnId: "turn-1",
+      startedAt: nil,
+      updatedAt: nil
+    )
+  }
+}

--- a/apps/ios/ADETests/WorkCardExpansionTests.swift
+++ b/apps/ios/ADETests/WorkCardExpansionTests.swift
@@ -305,6 +305,68 @@ final class WorkCardExpansionTests: XCTestCase {
     )
   }
 
+  // MARK: - Finished turns keep their work
+
+  /// The shape that reported this: a Claude turn whose whole body was one
+  /// `Read` and one approved shell command. Both fold into one cluster, and the
+  /// transcript has to still draw that cluster once the turn ends — a finished
+  /// turn collapses to one line, it does not disappear.
+  func testFinishedTurnKeepsItsToolClusterInTheTranscript() {
+    let grouped = collapseConsecutiveWorkToolEntries([
+      userMessage("msg-1"),
+      toolCard(id: "read-1", toolName: "Read", argsText: #"{"file_path":"README.md"}"#),
+      commandCard(id: "bash-1", command: "npm test"),
+      assistantMessage("msg-2"),
+      turnEnd("turn-1", id: "end-1"),
+    ])
+
+    let presented = workPresentedTimelineEntries(grouped)
+    let members = presented.flatMap { entry -> [WorkToolGroupMember] in
+      guard case .toolGroup(let group) = entry.payload else { return [] }
+      return group.members
+    }
+
+    XCTAssertTrue(
+      members.contains { $0.id == "tool:read-1" },
+      "the finished turn's Read has to keep a row in the transcript"
+    )
+    XCTAssertTrue(
+      members.contains { $0.id == "command:bash-1" },
+      "the finished turn's shell command has to keep a row in the transcript"
+    )
+  }
+
+  /// A cluster and a file-change group are the same kind of thing to a reader,
+  /// so the transcript cannot draw one and swallow the other.
+  func testPresentationDrawsToolClustersAndFileChangesAlike() {
+    let grouped = collapseConsecutiveWorkToolEntries([
+      toolCard(id: "read-1", toolName: "Read", argsText: #"{"file_path":"README.md"}"#),
+      assistantMessage("msg-1"),
+      toolCard(id: "edit-1", toolName: "Edit", argsText: #"{"file_path":"main.swift"}"#),
+    ])
+
+    let presented = workPresentedTimelineEntries(grouped)
+    let hasToolCluster = presented.contains {
+      if case .toolGroup = $0.payload { return true }
+      return false
+    }
+    let hasChangedFiles = presented.contains {
+      if case .changedFiles = $0.payload { return true }
+      return false
+    }
+
+    XCTAssertTrue(hasChangedFiles, "file-change clusters already render")
+    XCTAssertTrue(hasToolCluster, "so read-only clusters have to render too")
+  }
+
+  /// Nothing streams in a reopened chat, so the cluster lands on its own default
+  /// — the one-line row, not the member list.
+  func testFinishedToolClusterDefaultsToItsCollapsedRow() {
+    let state = WorkCardExpansionState()
+
+    XCTAssertFalse(state.isExpanded(id: "tool-group:read-1", defaultsOpen: false))
+  }
+
   // MARK: - Composer chip count
 
   func testChatInfoCountCoversSubagentsAndScheduledWork() {
@@ -355,6 +417,71 @@ final class WorkCardExpansionTests: XCTestCase {
           provider: "claude",
           modelLabel: "Opus",
           modelId: nil
+        )
+      )
+    )
+  }
+
+  private func toolCard(id: String, toolName: String, argsText: String?) -> WorkTimelineEntry {
+    WorkTimelineEntry(
+      id: "tool-\(id)",
+      timestamp: "2026-01-01T00:00:00.000Z",
+      rank: 0,
+      payload: .toolCard(
+        WorkToolCardModel(
+          id: id,
+          toolName: toolName,
+          status: .completed,
+          startedAt: "2026-01-01T00:00:00.000Z",
+          completedAt: "2026-01-01T00:00:01.000Z",
+          argsText: argsText,
+          resultText: "ok"
+        )
+      )
+    )
+  }
+
+  private func commandCard(id: String, command: String) -> WorkTimelineEntry {
+    WorkTimelineEntry(
+      id: "command-\(id)",
+      timestamp: "2026-01-01T00:00:00.000Z",
+      rank: 0,
+      payload: .commandCard(
+        WorkCommandCardModel(
+          id: id,
+          command: command,
+          cwd: "/repo",
+          output: "3 passing",
+          status: .completed,
+          timestamp: "2026-01-01T00:00:00.000Z",
+          exitCode: 0,
+          durationMs: 1200
+        )
+      )
+    )
+  }
+
+  private func userMessage(_ id: String) -> WorkTimelineEntry {
+    message(id, role: "user", markdown: "run the tests")
+  }
+
+  private func assistantMessage(_ id: String) -> WorkTimelineEntry {
+    message(id, role: "assistant", markdown: "Done.")
+  }
+
+  private func message(_ id: String, role: String, markdown: String) -> WorkTimelineEntry {
+    WorkTimelineEntry(
+      id: "message-\(id)",
+      timestamp: "2026-01-01T00:00:00.000Z",
+      rank: 0,
+      payload: .message(
+        WorkChatMessage(
+          id: id,
+          role: role,
+          markdown: markdown,
+          timestamp: "2026-01-01T00:00:00.000Z",
+          turnId: "turn-1",
+          itemId: nil
         )
       )
     )

--- a/apps/ios/ADETests/WorkMarkdownStreamingParsingTests.swift
+++ b/apps/ios/ADETests/WorkMarkdownStreamingParsingTests.swift
@@ -155,6 +155,106 @@ final class WorkMarkdownStreamingParsingTests: XCTestCase {
     assertStreamingMatchesFullParse("Short opener.\n\n\(wall)\n\nShort closer.", deltaSizes: [23, 61])
   }
 
+  func testPlainProseAppendKeepsSettledRowsAndFallsBackForMarkdown() {
+    let base = (1...100)
+      .map { "The keeper walked the length of the gallery and counted lamp \($0) again." }
+      .joined(separator: " ")
+    let key = "\(#function)-plain"
+    let initial = parseMarkdownBlocksForStreaming(base, cacheKey: key)
+    let grownText = base + " The next inspection began before sunrise."
+    let grown = parseMarkdownBlocksForStreaming(grownText, cacheKey: key)
+
+    XCTAssertGreaterThan(initial.count, 1)
+    XCTAssertEqual(grown, parseMarkdownBlocks(grownText))
+    for index in 0..<(initial.count - 1) {
+      XCTAssertEqual(
+        grown[index],
+        initial[index],
+        "an append may change only the still-growing final prose row"
+      )
+    }
+    XCTAssertEqual(
+      grown.map(\.id),
+      grown.indices.map { "markdown-block-\($0)" },
+      "the append path must retain positional block ids"
+    )
+
+    let whitespaceKey = "\(#function)-trailing-space"
+    _ = parseMarkdownBlocksForStreaming(base + " ", cacheKey: whitespaceKey)
+    let whitespaceGrown = parseMarkdownBlocksForStreaming(base + " next", cacheKey: whitespaceKey)
+    XCTAssertEqual(
+      whitespaceGrown,
+      parseMarkdownBlocks(base + " next"),
+      "trailing stream whitespace must not be dropped when the next token arrives"
+    )
+
+    let markdownText = grownText + "\n\n**A Markdown paragraph.**"
+    XCTAssertEqual(
+      parseMarkdownBlocksForStreaming(markdownText, cacheKey: key),
+      parseMarkdownBlocks(markdownText),
+      "Markdown must leave the plain-prose fast path"
+    )
+    let fencedText = markdownText + "\n\n```swift\nlet value = 1\n```"
+    XCTAssertEqual(
+      parseMarkdownBlocksForStreaming(fencedText, cacheKey: key),
+      parseMarkdownBlocks(fencedText),
+      "fences must keep using the full parser"
+    )
+  }
+
+  func testPlainProseAppendDoesNotDuplicateWhitespaceAcrossDeltas() {
+    let key = "\(#function)"
+    _ = parseMarkdownBlocksForStreaming("hello", cacheKey: key)
+    let trailingSpace = parseMarkdownBlocksForStreaming("hello ", cacheKey: key)
+    XCTAssertEqual(trailingSpace, parseMarkdownBlocks("hello "))
+    let grown = parseMarkdownBlocksForStreaming("hello  next", cacheKey: key)
+
+    XCTAssertEqual(grown, parseMarkdownBlocks("hello  next"))
+  }
+
+  func testOrderedListMarkerSplitAcrossStreamingDeltasFallsBackToMarkdownParser() {
+    let numericKey = "\(#function)-numeric"
+    _ = parseMarkdownBlocksForStreaming("1", cacheKey: numericKey)
+    XCTAssertEqual(
+      parseMarkdownBlocksForStreaming("1. item", cacheKey: numericKey),
+      parseMarkdownBlocks("1. item"),
+      "a numeric marker split after its digits must not be cached as prose"
+    )
+
+    let dottedKey = "\(#function)-dotted"
+    _ = parseMarkdownBlocksForStreaming("1.", cacheKey: dottedKey)
+    XCTAssertEqual(
+      parseMarkdownBlocksForStreaming("1. item", cacheKey: dottedKey),
+      parseMarkdownBlocks("1. item"),
+      "a numeric marker split after its dot must not be cached as prose"
+    )
+
+    let spacedNumericKey = "\(#function)-spaced-numeric"
+    _ = parseMarkdownBlocksForStreaming(" 1", cacheKey: spacedNumericKey)
+    XCTAssertEqual(
+      parseMarkdownBlocksForStreaming(" 1. item", cacheKey: spacedNumericKey),
+      parseMarkdownBlocks(" 1. item"),
+      "leading spaces must not hide an ordered-list marker"
+    )
+
+    let spacedHeadingKey = "\(#function)-spaced-heading"
+    _ = parseMarkdownBlocksForStreaming(" ", cacheKey: spacedHeadingKey)
+    XCTAssertEqual(
+      parseMarkdownBlocksForStreaming(" # Heading", cacheKey: spacedHeadingKey),
+      parseMarkdownBlocks(" # Heading"),
+      "leading spaces must not hide a heading marker"
+    )
+  }
+
+  func testStreamingParserKeepsUnicodePrefixFastPathAtGraphemeBoundary() {
+    let key = "\(#function)-unicode"
+    _ = parseMarkdownBlocksForStreaming("Cafe", cacheKey: key)
+    let grown = parseMarkdownBlocksForStreaming("Cafe\u{301}", cacheKey: key)
+
+    XCTAssertEqual(grown, parseMarkdownBlocks("Cafe\u{301}"))
+    XCTAssertEqual(grown.first?.kind, .paragraph("Cafe\u{301}"))
+  }
+
   func testStreamingDoesNotSplitInsideLongNestedLinkDestination() {
     let destination = "<https://example.test/path (one_(two)) \(String(repeating: "segment", count: 260))>"
     let text = "See [the long link](\(destination)) and then keep reading. "
@@ -173,6 +273,69 @@ final class WorkMarkdownStreamingParsingTests: XCTestCase {
     }
     XCTAssertEqual(chunks.joined(), text)
     assertStreamingMatchesFullParse(text, deltaSizes: [17, 43, 89])
+  }
+
+  func testStreamingDoesNotSplitInsideEscapedParenthesesInLinkDestination() {
+    let destination = "https://example.test/path\\) (one_(two)) "
+      + String(repeating: "segment ", count: 260)
+    let text = "See [the long link](\(destination)) and then keep reading. "
+      + (1...90).map { "word\($0)" }.joined(separator: " ")
+    let chunks = workBoundedProseChunks(text)
+    let linkStart = text.firstIndex(of: "[")!
+    let linkEnd = text.range(of: ") and then")!.lowerBound
+
+    var boundary = text.startIndex
+    for chunk in chunks.dropLast() {
+      boundary = text.index(boundary, offsetBy: chunk.count)
+      XCTAssertFalse(
+        boundary > linkStart && boundary < linkEnd,
+        "an escaped close parenthesis must not end the link destination"
+      )
+    }
+    XCTAssertEqual(chunks.joined(), text)
+  }
+
+  func testIncompleteLongLinkDestinationHasHardProseCut() {
+    let text = "See [the unfinished link](https://example.test/"
+      + String(repeating: "segment ", count: 500)
+    let chunks = workBoundedProseChunks(text)
+
+    XCTAssertGreaterThan(chunks.count, 1, "an incomplete destination cannot create one unbounded row")
+    XCTAssertTrue(chunks.allSatisfy { $0.count <= workMarkdownProseRowCharacterLimit })
+    XCTAssertEqual(chunks.joined(), text, "the hard cut must preserve every source character")
+  }
+
+  func testLinkDestinationOpenedAfterBudgetEdgeStillHasHardProseCut() {
+    let text = "See [the unfinished link "
+      + String(repeating: "segment ", count: 180)
+      + "](https://example.test/"
+      + String(repeating: "tail ", count: 500)
+    let chunks = workBoundedProseChunks(text)
+
+    XCTAssertGreaterThan(chunks.count, 1, "a destination opened after the edge cannot create one unbounded row")
+    XCTAssertTrue(chunks.allSatisfy { $0.count <= workMarkdownProseRowCharacterLimit })
+    XCTAssertEqual(chunks.joined(), text, "the hard cut must preserve every source character")
+  }
+
+  func testAngleDelimitedLinkDestinationClosesDespiteLiteralUnmatchedParenthesis() {
+    let destination = "<https://example.test/path (literal "
+      + String(repeating: "segment ", count: 260)
+      + ">"
+    let text = "See [the long link](\(destination)) and then keep reading. "
+      + (1...90).map { "word\($0)" }.joined(separator: " ")
+    let chunks = workBoundedProseChunks(text)
+    let linkStart = text.firstIndex(of: "[")!
+    let linkEnd = text.range(of: ") and then")!.lowerBound
+
+    var boundary = text.startIndex
+    for chunk in chunks.dropLast() {
+      boundary = text.index(boundary, offsetBy: chunk.count)
+      XCTAssertFalse(
+        boundary > linkStart && boundary < linkEnd,
+        "an angle-delimited destination must close at `>` even when it contains `(`"
+      )
+    }
+    XCTAssertEqual(chunks.joined(), text)
   }
 
   func testStreamingRepeatedCallsWithSameTextReturnStableBlocks() {
@@ -309,6 +472,37 @@ final class WorkStreamingPreviewPerformanceTests: XCTestCase {
       format: "assistant preview streaming benchmark: %d deltas / %d chars; optimized %.1f ms, full-rescan baseline %.1f ms, speedup %.1fx",
       deltaCount,
       baselineText.count,
+      optimizedSeconds * 1000,
+      baselineSeconds * 1000,
+      baselineSeconds / max(optimizedSeconds, .leastNonzeroMagnitude)
+    ))
+  }
+
+  func testPlainProseStreamingParserCostIsReported() {
+    let deltaCount = 500
+    let delta = " The keeper walked the length of the gallery and counted the lamps again."
+    var optimizedText = "Seed."
+    let optimizedKey = "\(#function)-optimized"
+    let optimizedStart = Date()
+    for _ in 1...deltaCount {
+      optimizedText += delta
+      _ = parseMarkdownBlocksForStreaming(optimizedText, cacheKey: optimizedKey)
+    }
+    let optimizedSeconds = Date().timeIntervalSince(optimizedStart)
+
+    var baselineText = "Seed."
+    let baselineStart = Date()
+    for _ in 1...deltaCount {
+      baselineText += delta
+      _ = parseMarkdownBlocks(baselineText)
+    }
+    let baselineSeconds = Date().timeIntervalSince(baselineStart)
+
+    XCTAssertEqual(optimizedText, baselineText)
+    print(String(
+      format: "markdown parser streaming benchmark: %d deltas / %d chars; append-only %.1f ms, full-rescan baseline %.1f ms, speedup %.1fx",
+      deltaCount,
+      optimizedText.count,
       optimizedSeconds * 1000,
       baselineSeconds * 1000,
       baselineSeconds / max(optimizedSeconds, .leastNonzeroMagnitude)

--- a/apps/ios/ADETests/WorkMarkdownStreamingParsingTests.swift
+++ b/apps/ios/ADETests/WorkMarkdownStreamingParsingTests.swift
@@ -2,7 +2,7 @@ import SwiftUI
 import XCTest
 @testable import ADE
 
-/// Equivalence tests for the tail-only streaming markdown parser: replaying a
+/// Equivalence tests for the bounded streaming markdown parser: replaying a
 /// document as a stream of appended deltas must produce, at EVERY snapshot,
 /// exactly the same blocks (kinds and ids) as the whole-text parser.
 final class WorkMarkdownStreamingParsingTests: XCTestCase {
@@ -142,7 +142,7 @@ final class WorkMarkdownStreamingParsingTests: XCTestCase {
     assertStreamingMatchesFullParse(text, deltaSizes: [2, 5])
   }
 
-  /// An oversized paragraph becomes several blocks, and the tail-only parser
+  /// An oversized paragraph becomes several blocks, and the bounded parser
   /// has to agree with the whole-text parser about every one of them. It can:
   /// the split is a function of one paragraph's text, and a paragraph never
   /// crosses the blank line the streaming parser splits at, so both paths chunk
@@ -153,6 +153,26 @@ final class WorkMarkdownStreamingParsingTests: XCTestCase {
       .map { "\($0). The keeper walked the length of the gallery and counted the lamps again." }
       .joined(separator: " ")
     assertStreamingMatchesFullParse("Short opener.\n\n\(wall)\n\nShort closer.", deltaSizes: [23, 61])
+  }
+
+  func testStreamingDoesNotSplitInsideLongNestedLinkDestination() {
+    let destination = "<https://example.test/path (one_(two)) \(String(repeating: "segment", count: 260))>"
+    let text = "See [the long link](\(destination)) and then keep reading. "
+      + (1...90).map { "word\($0)" }.joined(separator: " ")
+    let chunks = workBoundedProseChunks(text)
+    let linkStart = text.firstIndex(of: "[")!
+    let linkEnd = text.range(of: ") and then")!.lowerBound
+
+    var boundary = text.startIndex
+    for chunk in chunks.dropLast() {
+      boundary = text.index(boundary, offsetBy: chunk.count)
+      XCTAssertFalse(
+        boundary > linkStart && boundary < linkEnd,
+        "A prose chunk must not end inside a Markdown link destination"
+      )
+    }
+    XCTAssertEqual(chunks.joined(), text)
+    assertStreamingMatchesFullParse(text, deltaSizes: [17, 43, 89])
   }
 
   func testStreamingRepeatedCallsWithSameTextReturnStableBlocks() {

--- a/apps/ios/ADETests/WorkMarkdownStreamingParsingTests.swift
+++ b/apps/ios/ADETests/WorkMarkdownStreamingParsingTests.swift
@@ -142,6 +142,19 @@ final class WorkMarkdownStreamingParsingTests: XCTestCase {
     assertStreamingMatchesFullParse(text, deltaSizes: [2, 5])
   }
 
+  /// An oversized paragraph becomes several blocks, and the tail-only parser
+  /// has to agree with the whole-text parser about every one of them. It can:
+  /// the split is a function of one paragraph's text, and a paragraph never
+  /// crosses the blank line the streaming parser splits at, so both paths chunk
+  /// the same text. Anything that broke that would show up as a block the two
+  /// paths number differently — the identity churn this parser exists to avoid.
+  func testStreamingMatchesFullParseWithAnOversizedParagraph() {
+    let wall = (1...70)
+      .map { "\($0). The keeper walked the length of the gallery and counted the lamps again." }
+      .joined(separator: " ")
+    assertStreamingMatchesFullParse("Short opener.\n\n\(wall)\n\nShort closer.", deltaSizes: [23, 61])
+  }
+
   func testStreamingRepeatedCallsWithSameTextReturnStableBlocks() {
     let text = "Para one.\n\n```swift\nlet a = 1\n```\n\nPara two."
     let first = parseMarkdownBlocksForStreaming(text, cacheKey: #function)
@@ -165,6 +178,102 @@ final class WorkMarkdownStreamingParsingTests: XCTestCase {
       parseMarkdownBlocksForStreaming(shrunk, cacheKey: key),
       parseMarkdownBlocks(shrunk)
     )
+  }
+}
+
+final class WorkStreamingMonospacedClassifierTests: XCTestCase {
+  func testAppendCanFlipAFalseClassificationWhenSecondAlignedRowArrives() {
+    var state = WorkStreamingMonospacedClassifierState()
+    state.append("left   value\n")
+    XCTAssertFalse(state.usesMonospacedRendering)
+
+    state.append("right   value")
+    XCTAssertTrue(state.usesMonospacedRendering)
+  }
+
+  func testAlignedRowsInsideFenceDoNotClassifyUntilFenceCloses() {
+    var state = WorkStreamingMonospacedClassifierState()
+    state.append("```text\nleft   value\nright   value\n")
+    XCTAssertFalse(state.usesMonospacedRendering)
+
+    state.append("```\nleft   value\nright   value")
+    XCTAssertTrue(state.usesMonospacedRendering)
+  }
+
+  func testClassifierMatchesWholeTextAcrossDeltaBoundaries() {
+    let text = "Intro\n\n```\nleft   value\nright   value\n```\n\nleft   value\nright   value"
+    var state = WorkStreamingMonospacedClassifierState()
+    var snapshot = ""
+    for character in text {
+      snapshot.append(character)
+      state.append(String(character))
+      XCTAssertEqual(
+        state.usesMonospacedRendering,
+        workAssistantMessageUsesMonospacedPreview(snapshot),
+        "classifier diverged at \(snapshot.count) characters"
+      )
+    }
+  }
+}
+
+/// Diagnostic benchmark for the path that previously rescanned the entire
+/// growing assistant response on every delta. It deliberately reports rather
+/// than asserts wall-clock numbers: CI hosts vary, but the optimized path must
+/// remain visible in test logs and in the simulator trace.
+final class WorkStreamingPreviewPerformanceTests: XCTestCase {
+  func testStreamingAssistantPreviewCostIsReported() {
+    let deltaCount = 500
+    var optimizedMessage = WorkChatMessage(
+      id: "assistant-preview-benchmark",
+      role: "assistant",
+      markdown: "Seed.",
+      timestamp: "2026-03-25T00:00:01.000Z",
+      turnId: "turn-1",
+      itemId: "item-1"
+    )
+    let optimizedCache = WorkAssistantPreviewCache()
+    let characterBudget = workAssistantMessageCharacterBudget(
+      forLineBudget: workAssistantMessageInitialLineBudget
+    )
+
+    let optimizedStart = Date()
+    for index in 1...deltaCount {
+      _ = workApplyStreamingAssistantText(
+        " Delta \(index): the keeper walked the length of the gallery and counted the lamps again.",
+        to: &optimizedMessage
+      )
+      _ = optimizedCache.preview(
+        for: optimizedMessage,
+        anchor: .tail,
+        lineBudget: workAssistantMessageInitialLineBudget,
+        characterBudget: characterBudget,
+        classification: nil
+      )
+    }
+    let optimizedSeconds = Date().timeIntervalSince(optimizedStart)
+
+    var baselineText = "Seed."
+    let baselineStart = Date()
+    for index in 1...deltaCount {
+      baselineText += " Delta \(index): the keeper walked the length of the gallery and counted the lamps again."
+      _ = workAssistantMessagePreview(
+        baselineText,
+        lineBudget: workAssistantMessageInitialLineBudget,
+        characterBudget: characterBudget,
+        anchor: .tail
+      )
+    }
+    let baselineSeconds = Date().timeIntervalSince(baselineStart)
+
+    XCTAssertEqual(optimizedMessage.markdown, baselineText)
+    print(String(
+      format: "assistant preview streaming benchmark: %d deltas / %d chars; optimized %.1f ms, full-rescan baseline %.1f ms, speedup %.1fx",
+      deltaCount,
+      baselineText.count,
+      optimizedSeconds * 1000,
+      baselineSeconds * 1000,
+      baselineSeconds / max(optimizedSeconds, .leastNonzeroMagnitude)
+    ))
   }
 }
 
@@ -759,5 +868,264 @@ final class WorkInlineMarkdownCacheTests: XCTestCase {
     workPurgeMarkdownRenderCaches()
     XCTAssertFalse(workMarkdownSharedCacheHolds(text))
   }
+
 }
 
+/// One assistant paragraph with no blank line in it used to render as a single
+/// row many screens tall. The transcript's `LazyVStack` estimates the height of
+/// every row it has not realized from the ones it has, so one outlier moves the
+/// estimate, the moved estimate changes which rows are realized, and the two
+/// never settle — the main thread pinned at 100% with the chat frozen mid-turn.
+///
+/// These tests hold the split to the three things that make it safe: rows stay
+/// inside the budget, the text survives, and a cut is never moved or withdrawn
+/// once the row carrying it has been rendered.
+final class WorkBoundedProseRowTests: XCTestCase {
+  private func wallOfProse(sentences: Int) -> String {
+    (1...sentences)
+      .map { "\($0). The keeper walked the length of the gallery and counted the lamps again." }
+      .joined(separator: " ")
+  }
+
+  /// Words in order, ignoring where the whitespace fell. This supplements the
+  /// lossless joined-string assertions with a readable failure if a cut ever
+  /// drops, duplicates, or reorders a token.
+  private func words(_ text: String) -> [String] {
+    text.components(separatedBy: .whitespacesAndNewlines).filter { !$0.isEmpty }
+  }
+
+  // MARK: - The budget
+
+  func testLongParagraphIsSplitIntoBoundedRows() {
+    let text = wallOfProse(sentences: 120)
+    let chunks = workBoundedProseChunks(text)
+    XCTAssertGreaterThan(chunks.count, 1, "a wall of prose has to become several rows")
+    for chunk in chunks {
+      XCTAssertLessThanOrEqual(
+        chunk.count,
+        workMarkdownProseRowCharacterLimit,
+        "every row must stay inside the layout budget"
+      )
+    }
+    XCTAssertEqual(
+      chunks.joined(),
+      text,
+      "splitting may only insert row boundaries, never change the text"
+    )
+  }
+
+  func testShortParagraphIsNotSplit() {
+    let text = "One sentence. Two sentences. That is the whole answer."
+    XCTAssertEqual(workBoundedProseChunks(text), [text])
+  }
+
+  /// The budget is counted in characters because row height follows glyphs. A
+  /// byte budget would let a Japanese paragraph run three times as tall as an
+  /// English one, and a script that does not put spaces between words offers no
+  /// word gap to cut at — so the cut has to fall back to the budget's own edge,
+  /// exactly as line breaking in those scripts already does.
+  func testParagraphWithNoWordGapsIsStillBounded() {
+    let text = String(repeating: "検索結果を確認してください。これは長い段落です。", count: 200)
+    let chunks = workBoundedProseChunks(text)
+    XCTAssertGreaterThan(text.utf8.count, text.count, "the fixture has to be multi-byte to mean anything")
+    XCTAssertGreaterThan(chunks.count, 1, "a script without word gaps still needs bounded rows")
+    for chunk in chunks {
+      XCTAssertLessThanOrEqual(chunk.count, workMarkdownProseRowCharacterLimit)
+    }
+    XCTAssertEqual(chunks.joined(), text, "a gapless script has no whitespace to lose")
+  }
+
+  func testHardWrappedParagraphKeepsEveryWord() {
+    let text = (1...90)
+      .map { "Line \($0) of a hard wrapped paragraph the agent never separated with a blank line." }
+      .joined(separator: "\n")
+    let chunks = workBoundedProseChunks(text)
+    XCTAssertGreaterThan(chunks.count, 1)
+    XCTAssertEqual(words(chunks.joined(separator: " ")), words(text))
+  }
+
+  func testGraphemeClustersAreNeverSplit() {
+    let text = Array(repeating: "👩‍👩‍👧‍👦 family", count: 400).joined(separator: " ")
+    let chunks = workBoundedProseChunks(text)
+    XCTAssertGreaterThan(chunks.count, 1)
+    XCTAssertEqual(words(chunks.joined(separator: " ")), words(text))
+  }
+
+  // MARK: - Cuts settle and stay settled
+
+  /// A paragraph that is still streaming must keep every already-rendered row
+  /// byte-identical: same text, same digest, same `markdown-block-<n>` id, and
+  /// a cache hit instead of a fresh `AttributedString(markdown:)` per row per
+  /// delta. Only the last row may change, and the row count may only grow.
+  func testGrowingParagraphKeepsEarlierChunksStable() {
+    var previous: [String] = []
+    for sentences in stride(from: 20, through: 200, by: 20) {
+      let chunks = workBoundedProseChunks(wallOfProse(sentences: sentences))
+      XCTAssertGreaterThanOrEqual(
+        chunks.count, previous.count,
+        "the row count may never drop — every id after the drop would change"
+      )
+      for (index, settled) in previous.dropLast().enumerated() {
+        XCTAssertEqual(
+          chunks[index], settled,
+          "row \(index) changed when the paragraph grew to \(sentences) sentences"
+        )
+      }
+      previous = chunks
+    }
+  }
+
+  /// The regression that matters most. An agent typing `` `configuration` ``
+  /// mid-paragraph leaves the backtick unclosed for a few deltas. Judging the
+  /// split as a whole made that tail retract every cut ahead of it: the
+  /// paragraph collapsed from four blocks to one and came back when the closing
+  /// backtick arrived, renumbering every block in the message twice — the exact
+  /// churn the split exists to remove. Cuts are decided one at a time, out of
+  /// text that has already arrived, so an unfinished span cannot reach back.
+  func testUnclosedInlineSpanInTheTailDoesNotRetractEarlierCuts() {
+    let base = wallOfProse(sentences: 80)
+    let deltas = [
+      "",
+      " Then he checked",
+      " Then he checked `configuration",
+      " Then he checked `configuration.reload()",
+      " Then he checked `configuration.reload()`",
+      " Then he checked `configuration.reload()` and left.",
+    ]
+    var previous: [String] = []
+    for delta in deltas {
+      let chunks = workBoundedProseChunks(base + delta)
+      XCTAssertGreaterThanOrEqual(
+        chunks.count, previous.count,
+        "an unclosed span collapsed the split at delta \(delta.debugDescription)"
+      )
+      for (index, settled) in previous.dropLast().enumerated() {
+        XCTAssertEqual(chunks[index], settled, "row \(index) moved at delta \(delta.debugDescription)")
+      }
+      previous = chunks
+    }
+    XCTAssertGreaterThan(previous.count, 1)
+  }
+
+  /// Replays a paragraph character group by character group, the way a real
+  /// turn arrives, over text carrying every inline construct the cut has an
+  /// opinion about.
+  func testCutsNeverMoveWhileAParagraphStreamsInSmallDeltas() {
+    let text = wallOfProse(sentences: 60)
+      + " He wrote `reload()` twice, then **stopped**, then noted [the ledger](x)"
+      + " and *left* at 2 * 3 o'clock. "
+      + wallOfProse(sentences: 60)
+    var previous: [String] = []
+    var cursor = text.startIndex
+    while cursor < text.endIndex {
+      cursor = text.index(cursor, offsetBy: 17, limitedBy: text.endIndex) ?? text.endIndex
+      let chunks = workBoundedProseChunks(String(text[..<cursor]))
+      XCTAssertGreaterThanOrEqual(chunks.count, previous.count)
+      for (index, settled) in previous.dropLast().enumerated() {
+        XCTAssertEqual(chunks[index], settled, "row \(index) moved at length \(text[..<cursor].count)")
+      }
+      previous = chunks
+    }
+    XCTAssertGreaterThan(previous.count, 1)
+    XCTAssertEqual(words(previous.joined(separator: " ")), words(text))
+  }
+
+  // MARK: - Inline markup
+
+  func testNoRowEndsInsideACodeSpanOrBoldRun() {
+    let text = wallOfProse(sentences: 40)
+      + " a `code span with several words in it` and **a bold run that also spans words** done. "
+      + wallOfProse(sentences: 40)
+    let chunks = workBoundedProseChunks(text)
+    XCTAssertGreaterThan(chunks.count, 1)
+    for chunk in chunks {
+      XCTAssertTrue(
+        (chunk.components(separatedBy: "`").count - 1).isMultiple(of: 2),
+        "a row ended inside a code span: \(chunk.suffix(40).debugDescription)"
+      )
+      XCTAssertTrue(
+        (chunk.components(separatedBy: "**").count - 1).isMultiple(of: 2),
+        "a row ended inside a bold run: \(chunk.suffix(40).debugDescription)"
+      )
+    }
+  }
+
+  /// One emphasis span opened at the very start and closed at the very end: no
+  /// interior boundary can leave a row balanced, so the paragraph stays whole.
+  /// A tall row is the lesser evil against a row rendering a stray `**`.
+  func testParagraphWrappedEntirelyInOneSpanIsLeftWhole() {
+    let text = "**" + wallOfProse(sentences: 120) + "**"
+    XCTAssertEqual(workBoundedProseChunks(text), [text])
+  }
+
+  /// Emphasis is only counted where it could actually open or close a span.
+  /// Reading arithmetic as markup would leave the parity wrong for the whole
+  /// rest of the paragraph, and one stray character would cost every later cut
+  /// — handing the transcript back the giant row this split exists to prevent.
+  func testStrayDelimitersDoNotDisableLaterCuts() {
+    for stray in [" the product is 2 * 3 and nothing more. ", " the value at index] was wrong. "] {
+      let text = wallOfProse(sentences: 30) + stray + wallOfProse(sentences: 60)
+      XCTAssertGreaterThan(
+        workBoundedProseChunks(text).count, 1,
+        "\(stray.debugDescription) stopped the paragraph from splitting"
+      )
+    }
+  }
+
+  // MARK: - Through the parser
+
+  /// The split has to survive the parser, not just the helper: an oversized
+  /// paragraph becomes several `.paragraph` blocks with the usual sequential
+  /// position-stable ids.
+  func testParserEmitsSeveralBlocksForOneOversizedParagraph() {
+    let text = (1...120)
+      .map { "The keeper walked the length of the gallery and counted lamp \($0) again." }
+      .joined(separator: " ")
+    let blocks = parseMarkdownBlocks(text)
+    XCTAssertGreaterThan(blocks.count, 1)
+    for (index, block) in blocks.enumerated() {
+      XCTAssertEqual(block.id, "markdown-block-\(index)")
+      guard case .paragraph = block.kind else {
+        return XCTFail("a wall of prose only ever produces paragraphs")
+      }
+    }
+  }
+
+  func testLongInlineNumberedNarrativeDoesNotBecomeOneListRow() {
+    let text = wallOfProse(sentences: 120)
+    XCTAssertTrue(workLooksLikeInlineNumberedProse(text))
+
+    let blocks = parseMarkdownBlocks(text)
+    XCTAssertGreaterThan(blocks.count, 1)
+    let paragraphs = blocks.compactMap { block -> String? in
+      guard case .paragraph(let text) = block.kind else { return nil }
+      return text
+    }
+    XCTAssertEqual(paragraphs.count, blocks.count, "the narrative should stay prose, not a giant ordered-list item")
+    XCTAssertEqual(paragraphs.joined(), text)
+    XCTAssertLessThanOrEqual(paragraphs.map(\.count).max() ?? 0, workMarkdownProseRowCharacterLimit)
+  }
+
+  func testLongSingleOrderedListItemContainingYearRemainsOrderedList() {
+    let text = "1. " + String(repeating: "The keeper recorded another calm observation. ", count: 80)
+      + "The log was archived in 2026. The next watch began at dusk."
+    let blocks = parseMarkdownBlocks(text)
+
+    XCTAssertEqual(blocks.count, 1)
+    guard case .orderedList(start: 1, let items) = blocks[0].kind else {
+      return XCTFail("a long real list item must keep its ordered-list semantics")
+    }
+    XCTAssertEqual(items.count, 1)
+    XCTAssertEqual(items[0], String(text.dropFirst(3)))
+  }
+
+  /// Splitting must not reach any other block kind. A fenced block is rendered
+  /// by its own view, and slicing one would break both the code-block ordinals
+  /// that Copy resolves through and the code itself.
+  func testOversizedFencedCodeIsLeftAsOneBlock() {
+    let code = (1...400).map { "let value\($0) = compute(\($0))" }.joined(separator: "\n")
+    let blocks = parseMarkdownBlocks("```swift\n\(code)\n```")
+    XCTAssertEqual(blocks.count, 1)
+    XCTAssertEqual(blocks.first?.kind, .code(language: "swift", code: code))
+  }
+}

--- a/apps/ios/ADETests/WorkMarkdownStreamingParsingTests.swift
+++ b/apps/ios/ADETests/WorkMarkdownStreamingParsingTests.swift
@@ -221,6 +221,25 @@ final class WorkStreamingMonospacedClassifierTests: XCTestCase {
 /// than asserts wall-clock numbers: CI hosts vary, but the optimized path must
 /// remain visible in test logs and in the simulator trace.
 final class WorkStreamingPreviewPerformanceTests: XCTestCase {
+  func testFenceMetadataSurvivesAnOpeningFenceSplitAcrossDeltas() {
+    var message = WorkChatMessage(
+      id: "assistant-split-fence",
+      role: "assistant",
+      markdown: "Intro\n\n",
+      timestamp: "2026-03-25T00:00:01.000Z",
+      turnId: "turn-1",
+      itemId: "item-1"
+    )
+
+    XCTAssertTrue(workApplyStreamingAssistantText("``", to: &message))
+    XCTAssertFalse(message.markdownContainsFence == true)
+    XCTAssertTrue(workApplyStreamingAssistantText("`swift\nroot\n", to: &message))
+
+    XCTAssertTrue(message.markdownContainsFence == true)
+    XCTAssertEqual(message.markdownOpenFenceMarker, "```swift")
+    XCTAssertEqual(message.markdownTrailingBacktickRun, 0)
+  }
+
   func testStreamingAssistantPreviewCostIsReported() {
     let deltaCount = 500
     var optimizedMessage = WorkChatMessage(

--- a/docs/features/sync-and-multi-device/ios-companion.md
+++ b/docs/features/sync-and-multi-device/ios-companion.md
@@ -688,6 +688,30 @@ transcript, so an expansion survives `LazyVStack` recycling. Expanding grows the
 message downward and holds the tapped row in place; it never re-pins the
 transcript to its bottom.
 
+**Expanding is a two-rung ladder, not an infinite one.** The first "Show more"
+expands in place as above. Anything still bounded after that step offers "Open
+full output" instead of another step (`workTruncatedOutputAffordance`), which
+presents `WorkOutputViewerScreen` — a monospaced, line-numbered, lazily laid out
+reader with a wrap toggle, occurrence-counting search, Copy all and the share
+sheet. The boxed renderers (`WorkStructuredOutputBlock`, `WorkDiffOutputBlock`,
+`WorkInlineDiffPreview`) clip at a fixed height with no inner scroller, so for
+them the second rung is not a preference: another in-place step would add text
+the box cuts away. `workOutputBoxOverflows` decides whether a box is clipping
+without scanning a long result to find out, and a clipping box opens the viewer
+from its header *or* by tapping the clipped region. The viewer is presented once
+per surface through `\.workOutputViewer` rather than by a `fullScreenCover` on
+every transcript row.
+
+**Copy is always the full content, never what is on screen.** The transcript
+renders bounded slices, so a Copy control that echoed its own view silently
+handed over a preview. Fenced code blocks resolve against the message they were
+sliced from by ordinal — counted from the front for a head-anchored preview and
+from the back for a tail-anchored one, which is also the case that carries a
+synthetic opening fence and so is the one most likely to hold a fragment
+(`WorkCodeBlockSource`). Resolution runs at tap time, never per render pass. The
+tool-result box displays its 500-character truncation while `copyText` carries
+the whole result.
+
 **Long replies cost O(tail), not O(message).** `parseMarkdownBlocksForStreaming`
 already split prose at a stable boundary; syntax highlighting now does the same,
 reusing an already-highlighted stable prefix split at the last line boundary

--- a/docs/features/sync-and-multi-device/ios-companion.md
+++ b/docs/features/sync-and-multi-device/ios-companion.md
@@ -430,8 +430,8 @@ apps/ios/
 │   │   │                            # WorkPromptStash (composer overflow +
 │   │   │                            #   per-project stash host),
 │   │   │                            # WorkContextUsageViews (turn-end meter),
-│   │   │                            # WorkChatComposerAndInputViews (compacted
-│   │   │                            #   icon-only staged-steer strip + the
+│   │   │                            # WorkChatComposerAndInputViews (always-open
+│   │   │                            #   icon-only queued-steer strip + the
 │   │   │                            #   structured-question card: pinned provider
 │   │   │                            #   row / tab strip above and freeform +
 │   │   │                            #   Send/Decline footer below a
@@ -3135,17 +3135,46 @@ the stats and shows update guidance.
   strings comes from the capability's `agentLabel` rather than hard-coded
   "Claude". The primary button's icon/label communicates the selected behavior,
   the chevron opens a custom SwiftUI popover, and selection dismisses it
-  immediately. The effective mode is derived from the pick rather than stored, so
-  switching providers mid-chat can never leave a mode selected that the new
-  provider cannot honor; queue-only providers (a single mode is not a choice)
-  keep the plain stage-behind-turn button, matching the desktop composer. When the host advertises
-  additive `chat.interruptWithQueueMode`, Claude Stop likewise becomes a split
-  control for **Stop & clear queue**
+  immediately. The pick is remembered per chat in `WorkActiveSendModeStore`
+  (App Group defaults, same bounded JSON-map mechanism as the composer drafts),
+  so a working habit survives backgrounding and relaunch; a turn starting or
+  ending does not reset it, and a provider change snaps back to that provider's
+  default only when the new provider cannot honor the remembered mode.
+  Queue-only providers (a single mode is not a choice) keep the plain
+  stage-behind-turn button, matching the desktop composer. When the host
+  advertises additive `chat.interruptWithQueueMode`, Claude Stop likewise
+  becomes a split control for **Stop & clear queue**
   and **Stop only**; the per-chat choice is stored in `UserDefaults`, carries
   VoiceOver labels and haptics, and falls back to legacy Stop against older
-  brains. Immediate send still stages once on the host before
-  `chat.dispatchSteer`; if dispatch fails, the one queued message remains and
-  the draft is not restored as a duplicate.
+  brains.
+- **Active-turn sends are atomic, so nothing flashes through the staged strip.**
+  `AgentChatSteerRequest` carries the desktop's `dispatchMode` field
+  (`"inline"` / `"interrupt"`, spelled exactly as the host validates it), and
+  `SyncService.steerChatSession` sends it with the steer itself. A host that can
+  honor it dispatches in the same round-trip and answers `queued: false`, so no
+  queued transcript row is written and no optimistic staged entry is created.
+  The mode is resolved once, before the send, so the branch that resends as a
+  steer after a "turn already active" rejection carries the same mode — losing
+  it there used to downgrade a *Send now* tap into a silently staged message.
+  `workChatAtomicSteerDispatchMode` returns nil for **Send after turn**, for a
+  provider with no such channel, and for a brain that does not advertise
+  `chat.dispatchSteer` — the same gate the staged strip's buttons read, so the
+  composer can never request a promotion the strip is hiding the recovery for.
+  A host old enough to advertise `chat.dispatchSteer` but too old to accept
+  `dispatchMode` on `chat.steer` answers `queued: true`; that one case falls
+  back to the legacy two-step promotion rather than dropping the user's choice,
+  and if the promotion fails the single queued message remains and the draft is
+  not restored as a duplicate.
+- **The staged strip is only ever "you queued this".** With active-turn sends
+  atomic, `WorkQueuedSteerStrip` renders exclusively messages the user chose to
+  queue, so it no longer hides behind an accordion: one queued message is a
+  single compact card — waiting glyph, one truncated line of the message, its
+  disposition beneath, and **Send now** / **Interrupt** / **Edit** / **Cancel**
+  as visible icon-only buttons with 44pt-tall touch areas. Only a pile-up gets
+  a slim `N queued` count above the rows. While a turn is running the clock
+  glyph breathes and the disposition reads "sends when turn ends"; on an idle
+  session it sits still and reads "after turn". The pulse goes through
+  `ADEMotion.pulse`, so Reduce Motion simply draws the glyph at full strength.
 - **The Work context meter treats completed compaction as a usage boundary.**
   `RemoteModels.swift`, `WorkEventMapping.swift`, and the persisted JSONL parser
   retain `context_compact.postTokens` plus the automatic `context_usage.state`.

--- a/docs/features/sync-and-multi-device/ios-companion.md
+++ b/docs/features/sync-and-multi-device/ios-companion.md
@@ -654,8 +654,39 @@ and is applied through `ScrollPosition` in a non-animated transaction.
 Deliberately not total content height: a reply streaming into the tail grows the
 content at the same time, and a reader scrolled back through history is exactly
 when that happens, so a total-height correction would add the tail's growth and
-overshoot. Bottom-follow, the jump-to-latest pill, and the initial force-pin are
-untouched.
+overshoot. Bottom-follow and the jump-to-latest pill are untouched.
+
+Three rules keep that correction from becoming a teleport. A probe sample that
+describes a *different* row than the armed anchor is no measurement at all, so
+it waits rather than falling through with a zero row shift — that would reduce
+the correction to the reader's own scroll delta and apply it twice. Overlapping
+prepends keep the *first* anchor rather than re-arming on the new leading row:
+its row was pushed down by both insertions, so the displacement measured on it
+already accumulates them. And a correction is a scroll write, so like every
+other one it defers to the reader for the whole interaction — finger-down
+through the end of the fling (`workChatMayWriteScrollOffset`, fed by
+`onScrollPhaseChange`, not by the drag gesture, which ends at finger-up).
+
+**A chat opens where it was left, not at a random offset.** The transcript opens
+at the tail through `defaultScrollAnchor(.bottom, for: .initialOffset)` —
+scoped to the initial offset because the `.sizeChanges` anchor is the
+total-height correction the paragraph above exists to avoid. The force-pin
+remains as belt-and-braces, but it now stays armed until the content size has
+been quiet for 600ms rather than firing on a fixed retry ladder, because
+hydration routinely lands after that ladder ends. It stands down early only for
+a deliberate drag (16pt — the 2pt stickiness deadband is finger jitter on a
+freshly-opened chat). A transcript shorter than the viewport renders from the
+top, desktop-style; a one-entry chat skips the pin entirely.
+
+**A message's truncation budget only ever grows.** The newest assistant message
+renders tail-anchored under a generous budget so a finishing turn is readable in
+place. When a newer message arrives it becomes head-anchored — and the budget it
+already rendered under becomes its floor, so "Show more" can never appear on a
+message the reader has already read in full. Both show-more paths (the split
+controls row and the message bubble) write one shared budget map on the
+transcript, so an expansion survives `LazyVStack` recycling. Expanding grows the
+message downward and holds the tapped row in place; it never re-pins the
+transcript to its bottom.
 
 **Long replies cost O(tail), not O(message).** `parseMarkdownBlocksForStreaming`
 already split prose at a stable boundary; syntax highlighting now does the same,
@@ -668,6 +699,16 @@ their own small cache instead of the shared 256-entry inline-markdown cache, so
 one long turn cannot evict every completed message and force a main-thread
 re-parse on scrollback; the final revision is promoted. All derived render
 caches drop on `applicationDidReceiveMemoryWarning`.
+
+Two properties make that O(tail) real rather than nominal. Markdown block ids
+are position-stable (`markdown-block-<index>`), not content-derived, so a
+delta does not hand the `LazyVStack` a new identity for a row that is still the
+same row; content changes travel in a separate `digest` field that change
+detection reads. And no derived text is recomputed per refresh: each message
+carries a digest stamped by the (off-main) snapshot fold, previews are cached
+per line budget, and the presentation signature hashes those digests plus each
+preview's shape instead of re-hashing the visible transcript's full text
+several times a second.
 
 Deployment target: iOS 26+. iPhone and iPad (adaptive layouts planned for
 Phase 7).

--- a/docs/features/sync-and-multi-device/ios-companion.md
+++ b/docs/features/sync-and-multi-device/ios-companion.md
@@ -3110,16 +3110,22 @@ the stats and shows update guidance.
   Codex and other adapters reuse compact tool cards; data URIs are never printed
   into the timeline, and stored/mobile compaction byte counts become a short
   "preview omitted" detail.
-- **Tool telemetry is disclosed from turn status, not repeated through the
-  mobile transcript.** `WorkChatSessionView` keeps assistant narration,
-  reasoning, provider-specific cards, and `WorkChangedFilesPanelView` rows in
-  chronological order, but filters normalized `toolGroup` rows from the visible
-  timeline. The live `WorkActivityIndicator` and each `WorkTurnEndMarkerView`
-  open the corresponding activity in `WorkTurnActivitySheet`. The live row uses
-  `ViewThatFits` so narrow phones retain the activity verb and monospaced elapsed
-  time without squeezing tool details into the same line. The association is
-  data-driven and never invents file changes for providers that did not emit
-  them.
+- **Tool telemetry keeps one chronological row, and is also disclosed from turn
+  status.** `WorkChatSessionView` draws assistant narration, reasoning,
+  provider-specific cards, `WorkToolCallsPanelView` clusters and
+  `WorkChangedFilesPanelView` rows in chronological order;
+  `workPresentedTimelineEntries` in `WorkTimelineHelpers.swift` is the seam that
+  decides what reaches the visible timeline. It used to drop every normalized
+  `toolGroup` row, which meant a turn whose only work was a `Read` and an
+  approved shell command left no trace in the transcript at all. That rule was
+  written when a cluster had no compact form; a finished cluster is now a single
+  44pt row in the same one-liner grammar the changed-files panel uses, so it
+  stays. The live `WorkActivityIndicator` and each `WorkTurnEndMarkerView` still
+  open the whole turn's activity in `WorkTurnActivitySheet`, where tapping a
+  member reveals its result or output. The live row uses `ViewThatFits` so
+  narrow phones retain the activity verb and monospaced elapsed time without
+  squeezing tool details into the same line. The association is data-driven and
+  never invents file changes for providers that did not emit them.
 - **Active-turn send and Stop use dismissing native popovers.** The in-session
   composer's delivery choices come from `WorkActiveSendCapability` in
   `WorkModels.swift` — a hand-mirrored copy of the desktop's canonical


### PR DESCRIPTION
## Summary

- Stabilize iOS Work transcript rendering during streamed assistant updates with incremental timeline, preview, and Markdown caches.
- Make transcript opening, history paging, latest-jump, Show More, and row identity deterministic.
- Preserve complete copy content and the expand-then-viewer path for large output.
- Finish mobile chat UX: collapsed ended-turn cards, CI/plan summaries, consolidated chips, atomic send modes, queued strip, and new-chat anchoring.
- Add regression coverage for streaming merge/grapheme correctness, timeline overlap/order, Markdown boundaries, card collapse, and performance.

## Verification

- `xcodebuild -project apps/ios/ADE.xcodeproj -scheme ADE -parallel-testing-enabled NO test`: 1,611 passed, 0 failed on the ADE Repro iPhone 15 Pro simulator.
- Streaming benchmark: append-only Markdown parser 84.2x faster than the full-rescan baseline.
- Streaming benchmark: assistant preview path 2.0x faster than the full-rescan baseline.
- Direct lane binary installed and launched with `xcrun simctl`; the PR chat opened at the tail and scrolling away exposed the Latest pill.
- Sync logs showed socket connect, chat subscription ACK, and 936 materialized transcript entries with no FOREIGN KEY or incoming-message errors.
- Reviewer-visible screenshots and the supporting sync log are attached in the ADE proof drawer.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a full-screen output viewer with search, copying, sharing, syntax highlighting, and diff support.
  * Added expandable and collapsible work cards with compact summaries, status indicators, progress, and accessibility labels.
  * Added improved assistant message previews with incremental “Show more” and full-output actions.
  * Active-turn message delivery modes are now remembered per chat and dispatched more reliably.

* **Bug Fixes**
  * Improved transcript scrolling, history loading, streaming updates, and queued-message presentation.
  * Preserved complete output when displayed content is truncated, including reliable copying.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->