### PR TITLE
ios(work): harden chat scroll performance

### DIFF
--- a/apps/ios/ADE/Views/Work/WorkChatSessionView+Actions.swift
+++ b/apps/ios/ADE/Views/Work/WorkChatSessionView+Actions.swift
@@ -1479,6 +1479,7 @@ extension WorkChatSessionView {
     else { return }
     guard workChatShouldContinueAutomaticOlderHistory(
       distanceFromBottom: scrollMetrics.distanceFromBottom,
+      contentFitsViewport: scrollMetrics.scrollableHeight <= 0.5,
       loading: olderHistoryLoadInFlight,
       hasError: olderHistoryLoadError != nil,
       hasBufferedEntries: hiddenTimelineCount > 0,
@@ -1530,11 +1531,9 @@ extension WorkChatSessionView {
 
   /// The reader took the transcript over, so the initial bottom pin stands down.
   ///
-  /// Split from `releaseBottomStickinessForUserScroll` because the two answer
-  /// different questions at different sensitivities: 2pt of travel is enough to
-  /// mean "stop following the stream", but cancelling the opening pin needs a
-  /// deliberate drag (`workChatInitialPinCancelDeadband`) — finger jitter on a
-  /// tap used to strand a freshly-opened chat mid-transcript.
+  /// A user-driven scroll phase is enough to stand down the opening pin. This
+  /// runs on the native scroll phase transition, so a small tap cannot strand a
+  /// freshly-opened chat while a real drag still cancels the pin immediately.
   @MainActor
   func cancelPendingInitialBottomPinForUserScroll() {
     guard pendingInitialBottomPinSessionId == session.id else { return }
@@ -1550,18 +1549,17 @@ extension WorkChatSessionView {
   }
 
   @MainActor
-  func allowBottomStickinessResumeFromUserScroll(reason: String) {
-    guard bottomStickinessReleasedByUser else { return }
-    bottomStickinessReleasedByUser = false
-  }
-
-  @MainActor
   func scrollToLatest(_ proxy: ScrollViewProxy, animated: Bool) {
     bottomStickinessReleasedByUser = false
-    let targetId = latestScrollTargetId
     if animated {
       withAnimation(ADEMotion.quick(reduceMotion: reduceMotion)) {
+        // Keep the ScrollPosition channel and the id-based reader in agreement.
+        // The reader is useful for older OS/layout paths, while the bound
+        // position is the authoritative tail jump when a LazyVStack has not
+        // materialized the sentinel in the current pass.
+        let targetId = latestScrollTargetId
         proxy.scrollTo(targetId, anchor: .bottom)
+        scrollPosition.scrollTo(edge: .bottom)
       }
       return
     }
@@ -1569,7 +1567,9 @@ extension WorkChatSessionView {
     var transaction = Transaction()
     transaction.animation = nil
     withTransaction(transaction) {
+      let targetId = latestScrollTargetId
       proxy.scrollTo(targetId, anchor: .bottom)
+      scrollPosition.scrollTo(edge: .bottom)
     }
   }
 

--- a/apps/ios/ADE/Views/Work/WorkChatSessionView.swift
+++ b/apps/ios/ADE/Views/Work/WorkChatSessionView.swift
@@ -15,7 +15,6 @@ let workChatTouchScrollDeadband: CGFloat = 2
 /// tap on a freshly-opened chat, and cancelling the pin there is what left
 /// transcripts parked at a random offset while hydration was still growing the
 /// content underneath.
-let workChatInitialPinCancelDeadband: CGFloat = 16
 let workChatBottomAnchorSpacerHeight: CGFloat = 1
 let workChatContentBottomGutterHeight: CGFloat = 2
 let workChatSubagentActivePopupHeight: CGFloat = 34
@@ -105,14 +104,29 @@ func workChatShouldRequestOlderHistory(
 /// there leaves buffered history unreachable by any gesture at all.
 func workChatShouldContinueAutomaticOlderHistory(
   distanceFromBottom: CGFloat,
+  contentFitsViewport: Bool,
   loading: Bool,
   hasError: Bool,
   hasBufferedEntries: Bool,
   hasHostHistory: Bool
 ) -> Bool {
-  guard distanceFromBottom <= workChatOlderHistoryScrollableDistance, !loading else { return false }
+  guard contentFitsViewport,
+        distanceFromBottom <= workChatOlderHistoryScrollableDistance,
+        !loading
+  else { return false }
   if hasBufferedEntries { return true }
   return !hasError && hasHostHistory
+}
+
+/// The prepend probe is only useful while the reader is close enough to the
+/// head for a history page to land. Keeping it installed on the first row for
+/// the whole transcript makes every ordinary scroll participate in SwiftUI's
+/// preference graph, even though there is no correction to perform.
+func workChatShouldInstallPrependProbe(
+  distanceFromTop: CGFloat,
+  hasPrependAnchor: Bool
+) -> Bool {
+  hasPrependAnchor || distanceFromTop <= workChatOlderHistoryTriggerDistance
 }
 
 /// Scroll state a prepend has to preserve: which row led the list, where that
@@ -139,6 +153,7 @@ struct WorkChatPrependAnchor {
 /// keeps its existing meaning.
 final class WorkChatScrollMetrics {
   var distanceFromBottom: CGFloat = 0
+  var distanceFromTop: CGFloat = 0
   var offsetY: CGFloat = 0
   var scrollableHeight: CGFloat = 0
   /// Position of the row currently being probed (the list's first row, or the
@@ -1002,7 +1017,14 @@ struct WorkChatSessionView: View {
   /// the armed row while a prepend is in flight (it is no longer first once the
   /// older page lands above it).
   var prependProbeRowId: String? {
-    scrollMetrics.prependAnchor?.rowId ?? timelinePresentation.visibleEntries.first?.id
+    let hasPrependAnchor = scrollMetrics.prependAnchor != nil
+    guard workChatShouldInstallPrependProbe(
+      distanceFromTop: scrollMetrics.distanceFromTop,
+      hasPrependAnchor: hasPrependAnchor
+    ) else {
+      return nil
+    }
+    return scrollMetrics.prependAnchor?.rowId ?? timelinePresentation.visibleEntries.first?.id
   }
 
   /// The last real probe measurement, replayed when a correction had to wait for
@@ -1249,7 +1271,15 @@ struct WorkChatSessionView: View {
       // or the probe silently never installs and the anchor never arms.
       let probeRenderRowId = visibleTimelineRenderEntries
         .first { $0.sourceEntryId == probeRowId }?.id
-      ForEach(visibleTimelineRenderEntries) { entry in
+      // Keep SwiftUI's identity pass over tiny values. Render entries carry
+      // full assistant payloads, so iterating them directly makes AttributeGraph
+      // copy long markdown responses just to read `id` during layout.
+      let renderEntries = visibleTimelineRenderEntries
+      let renderRowReferences = renderEntries.enumerated().map { index, entry in
+        WorkTimelineRenderRowReference(id: entry.id, index: index)
+      }
+      ForEach(renderRowReferences) { reference in
+        let entry = renderEntries[reference.index]
         timelineRenderEntryView(
           for: entry,
           proxy: proxy,
@@ -1595,7 +1625,15 @@ struct WorkChatSessionView: View {
             let userDriven = workChatScrollPhaseIsUserDriven(phase)
             guard timelineScrollPhaseUserDriven != userDriven else { return }
             timelineScrollPhaseUserDriven = userDriven
-            guard !userDriven else { return }
+            timelineDragActive = userDriven
+            if userDriven {
+              // Let the native ScrollView own the whole interaction. The old
+              // zero-distance simultaneous DragGesture competed with it and
+              // could leave a tail-pinned chat one gesture away from moving.
+              cancelPendingInitialBottomPinForUserScroll()
+              releaseBottomStickinessForUserScroll(reason: "scroll-phase")
+              return
+            }
             // A fling that ended may have left a prepend correction waiting.
             restorePrependAnchorIfNeeded(probed: lastPrependProbeSample)
           }
@@ -1606,6 +1644,7 @@ struct WorkChatSessionView: View {
             // reference box or to state that only changes at a threshold — no
             // list scans, and nothing that invalidates the transcript per frame.
             scrollMetrics.offsetY = sample.offsetY
+            scrollMetrics.distanceFromTop = sample.distanceFromTop
             scrollMetrics.scrollableHeight = sample.scrollableHeight
             guard sample.containerHeight > 1 else { return }
             updateBottomStickiness(distanceFromBottom: sample.distanceFromBottom, proxy: proxy)
@@ -1636,30 +1675,6 @@ struct WorkChatSessionView: View {
                   value: geometry.size.width
                 )
             }
-          )
-          .simultaneousGesture(
-            DragGesture(minimumDistance: 0)
-              .onChanged { value in
-                if !timelineDragActive {
-                  timelineDragActive = true
-                }
-                if abs(value.translation.height) > workChatInitialPinCancelDeadband {
-                  cancelPendingInitialBottomPinForUserScroll()
-                }
-                if value.translation.height > workChatTouchScrollDeadband {
-                  releaseBottomStickinessForUserScroll(reason: "drag")
-                } else if value.translation.height < -workChatTouchScrollDeadband {
-                  allowBottomStickinessResumeFromUserScroll(reason: "drag")
-                }
-              }
-              .onEnded { value in
-                let releasedBottomStickiness = value.translation.height > workChatTouchScrollDeadband
-                if timelineDragActive {
-                  timelineDragActive = false
-                }
-                guard !releasedBottomStickiness else { return }
-                updateBottomStickiness(distanceFromBottom: scrollMetrics.distanceFromBottom, proxy: proxy)
-              }
           )
           .overlay(alignment: .top) {
             WorkChatNavigationBackdrop()
@@ -1707,12 +1722,11 @@ struct WorkChatSessionView: View {
         .background(workChatCanvasBackground.ignoresSafeArea())
         .adeNavigationGlass()
         .onPreferenceChange(WorkChatViewportHeightPreferenceKey.self) { height in
-          let changed = abs(scrollViewportHeight - height) > 1
+          guard height > 0, abs(scrollViewportHeight - height) > 1 else { return }
           scrollViewportHeight = height
-          guard changed, isNearBottom else { return }
-          pinToLatestAfterLayout(proxy, reason: "viewport-height")
         }
         .onPreferenceChange(WorkChatViewportWidthPreferenceKey.self) { width in
+          guard width > 0, abs(scrollViewportWidth - width) > 1 else { return }
           scrollViewportWidth = width
         }
         .onPreferenceChange(WorkChatPrependProbePreferenceKey.self) { sample in
@@ -1731,8 +1745,6 @@ struct WorkChatSessionView: View {
         .onPreferenceChange(WorkChatComposerLayoutHeightPreferenceKey.self) { height in
           guard height > 0, abs(composerLayoutHeight - height) > 1 else { return }
           composerLayoutHeight = height
-          guard isNearBottom else { return }
-          pinToLatestAfterLayout(proxy, reason: "composer-height")
         }
   }
 
@@ -1990,6 +2002,19 @@ struct WorkChatSessionView: View {
       )
     }
   }
+}
+
+/// Lightweight identity passed to SwiftUI's `ForEach` for the transcript.
+///
+/// `WorkTimelineRenderEntry` intentionally carries the render payload, which
+/// can include an entire assistant response and its streaming classifier. If
+/// `ForEach` iterates that value type directly, SwiftUI copies the payload just
+/// to read `Identifiable.id` while reconciling rows. A long chat can therefore
+/// spend its layout budget copying markdown instead of drawing the viewport.
+/// Keep the heavy array captured once and reconcile only these tiny references.
+private struct WorkTimelineRenderRowReference: Identifiable {
+  let id: String
+  let index: Int
 }
 
 private extension WorkChatSessionView {

--- a/apps/ios/ADE/Views/Work/WorkMarkdownParsing.swift
+++ b/apps/ios/ADE/Views/Work/WorkMarkdownParsing.swift
@@ -549,6 +549,37 @@ private func workAppendPlainProse(
 /// characters, not bytes, because row height follows glyphs.
 let workMarkdownProseRowCharacterLimit = 1_600
 
+/// Maximum list items in one rendered markdown block.
+///
+/// A list is itself a SwiftUI `VStack` inside the transcript's lazy stack. A
+/// long numbered answer can therefore bypass the prose-row character budget
+/// and create one multi-screen child row, bringing back the lazy-placement
+/// feedback loop that the prose splitter prevents. Keeping the block to a
+/// small, predictable number of items preserves the list's reading order while
+/// giving the outer transcript several normal-sized rows to estimate.
+let workMarkdownListItemsPerRenderBlock = 16
+
+/// Splits a list into bounded render blocks without dropping or reordering
+/// items. Ordered-list numbering is applied by the parser from each chunk's
+/// offset, so the helper only needs to preserve item order.
+func workBoundedListItemChunks(
+  _ items: [String],
+  limit: Int = workMarkdownListItemsPerRenderBlock
+) -> [[String]] {
+  guard !items.isEmpty else { return [] }
+  guard limit > 0, items.count > limit else { return [items] }
+
+  var chunks: [[String]] = []
+  chunks.reserveCapacity((items.count + limit - 1) / limit)
+  var offset = 0
+  while offset < items.count {
+    let end = min(offset + limit, items.count)
+    chunks.append(Array(items[offset..<end]))
+    offset = end
+  }
+  return chunks
+}
+
 /// Splits one oversized paragraph into rows of comparable height.
 ///
 /// Every cut is decided from the front, out of text that is already present, so
@@ -810,6 +841,18 @@ private func parseMarkdownBlocksInternal(_ markdown: String) -> [WorkMarkdownBlo
     }
   }
 
+  func appendListBlocks(_ items: [String], orderedStart: Int? = nil) {
+    var itemOffset = 0
+    for chunk in workBoundedListItemChunks(items) {
+      if let orderedStart {
+        appendBlock(.orderedList(start: orderedStart + itemOffset, items: chunk))
+      } else {
+        appendBlock(.unorderedList(chunk))
+      }
+      itemOffset += chunk.count
+    }
+  }
+
   while index < lines.count {
     let line = lines[index]
     let trimmed = line.trimmingCharacters(in: .whitespaces)
@@ -871,7 +914,7 @@ private func parseMarkdownBlocksInternal(_ markdown: String) -> [WorkMarkdownBlo
     }
 
     if let unordered = parseList(startingAt: index, in: lines, ordered: false) {
-      appendBlock(.unorderedList(unordered.items))
+      appendListBlocks(unordered.items)
       index = unordered.nextIndex
       continue
     }
@@ -885,7 +928,7 @@ private func parseMarkdownBlocksInternal(_ markdown: String) -> [WorkMarkdownBlo
         // markers and let the prose splitter turn it into stable rows.
         appendParagraph([trimmed])
       } else {
-        appendBlock(.orderedList(start: ordered.startNumber ?? 1, items: ordered.items))
+        appendListBlocks(ordered.items, orderedStart: ordered.startNumber ?? 1)
       }
       index = ordered.nextIndex
       continue

--- a/apps/ios/ADE/Views/Work/WorkSessionDestinationView.swift
+++ b/apps/ios/ADE/Views/Work/WorkSessionDestinationView.swift
@@ -644,6 +644,9 @@ struct WorkSessionDestinationView: View {
   var navigationTitleOverride: String?
   /// Lanes forwarded to the chat composer for `@`-mention autocomplete.
   var lanes: [LaneSummary] = []
+  /// Lanes are immutable for this mounted destination. Compute the render
+  /// signature once instead of hashing every lane on each streaming update.
+  let lanesRenderSignature: Int
   /// Set when this chat is opened from the hub as a cross-project "quick look":
   /// the session lives in a project OTHER than the phone's active one and
   /// streams read-only without a project switch. Nil for the ordinary
@@ -696,6 +699,7 @@ struct WorkSessionDestinationView: View {
     self.showsLaneActions = showsLaneActions
     self.navigationTitleOverride = navigationTitleOverride
     self.lanes = lanes
+    self.lanesRenderSignature = workLaneListRenderSignature(lanes)
     self.crossProjectContext = crossProjectContext
     self.personalChat = personalChat
     self.compactComposer = compactComposer
@@ -777,8 +781,10 @@ struct WorkSessionDestinationView: View {
   @State var postSendRefreshTask: Task<Void, Never>?
   @State var optimisticPendingSteers: [WorkPendingSteerModel] = []
   @State var subagentSnapshots: [WorkSubagentSnapshot] = []
+  @State var subagentSnapshotsRenderSignature = 0
   @State var remoteSubagentSnapshots: [WorkSubagentSnapshot] = []
   @State var scheduledWorkSnapshots: [WorkScheduledWorkSnapshot] = []
+  @State var scheduledWorkSnapshotsRenderSignature = 0
   @State var subagentView: WorkSubagentSelection?
   @State var subagentTranscript: [WorkChatEnvelope] = []
   @State var subagentTranscriptRenderSignature = 0
@@ -1791,13 +1797,13 @@ struct WorkSessionDestinationView: View {
       onOpenParentSession: viewingSubagent ? nil : { openParentSession() },
       resolvedSessionStatus: resolvedSessionStatus,
       lanes: lanes,
-      lanesRenderSignature: workLaneListRenderSignature(lanes),
+      lanesRenderSignature: lanesRenderSignature,
       hasOlderTranscriptHistory: viewingSubagent ? false : hasOlderTranscriptHistory,
       onLoadOlderTranscript: loadOlderTranscriptAction,
       subagentSnapshots: subagentSnapshots,
-      subagentSnapshotsRenderSignature: workSubagentSnapshotsRenderSignature(subagentSnapshots),
+      subagentSnapshotsRenderSignature: subagentSnapshotsRenderSignature,
       scheduledWorkSnapshots: viewingSubagent ? [] : scheduledWorkSnapshots,
-      scheduledWorkSnapshotsRenderSignature: viewingSubagent ? 0 : workScheduledWorkSnapshotsRenderSignature(scheduledWorkSnapshots),
+      scheduledWorkSnapshotsRenderSignature: viewingSubagent ? 0 : scheduledWorkSnapshotsRenderSignature,
       selectedSubagentTaskId: subagentView?.taskId,
       // One chip, one destination: subagents, background work and schedules
       // all live in the Chat Info sheet. Timeline-row selection stays scoped
@@ -2994,6 +3000,7 @@ struct WorkSessionDestinationView: View {
     let next = mergeWorkSubagentSnapshots(local: local, remote: remoteSubagentSnapshots)
     if next != subagentSnapshots {
       subagentSnapshots = next
+      subagentSnapshotsRenderSignature = workSubagentSnapshotsRenderSignature(next)
     }
     if let subagentView,
        let updated = next.first(where: { snapshot in
@@ -3019,6 +3026,7 @@ struct WorkSessionDestinationView: View {
     )
     if next != scheduledWorkSnapshots {
       scheduledWorkSnapshots = next
+      scheduledWorkSnapshotsRenderSignature = workScheduledWorkSnapshotsRenderSignature(next)
     }
   }
 
@@ -3317,7 +3325,7 @@ extension WorkSessionDestinationView: Equatable {
       && lhs.navigationChrome == rhs.navigationChrome
       && lhs.showsLaneActions == rhs.showsLaneActions
       && lhs.navigationTitleOverride == rhs.navigationTitleOverride
-      && workLaneListRenderSignature(lhs.lanes) == workLaneListRenderSignature(rhs.lanes)
+      && lhs.lanesRenderSignature == rhs.lanesRenderSignature
       && lhs.crossProjectContext == rhs.crossProjectContext
       && lhs.personalChat == rhs.personalChat
   }

--- a/apps/ios/ADETests/ADETests.swift
+++ b/apps/ios/ADETests/ADETests.swift
@@ -15617,6 +15617,7 @@ final class ADETests: XCTestCase {
 
     XCTAssertTrue(workChatShouldContinueAutomaticOlderHistory(
       distanceFromBottom: 0,
+      contentFitsViewport: true,
       loading: false,
       hasError: false,
       hasBufferedEntries: false,
@@ -15624,6 +15625,7 @@ final class ADETests: XCTestCase {
     ))
     XCTAssertTrue(workChatShouldContinueAutomaticOlderHistory(
       distanceFromBottom: 0,
+      contentFitsViewport: true,
       loading: false,
       hasError: false,
       hasBufferedEntries: true,
@@ -15631,6 +15633,7 @@ final class ADETests: XCTestCase {
     ))
     XCTAssertFalse(workChatShouldContinueAutomaticOlderHistory(
       distanceFromBottom: 80,
+      contentFitsViewport: true,
       loading: false,
       hasError: false,
       hasBufferedEntries: false,
@@ -15638,6 +15641,7 @@ final class ADETests: XCTestCase {
     ))
     XCTAssertFalse(workChatShouldContinueAutomaticOlderHistory(
       distanceFromBottom: 0,
+      contentFitsViewport: true,
       loading: false,
       hasError: true,
       hasBufferedEntries: false,
@@ -15647,6 +15651,7 @@ final class ADETests: XCTestCase {
     // gesture that re-arms anything. Buffered rows have to stay reachable.
     XCTAssertTrue(workChatShouldContinueAutomaticOlderHistory(
       distanceFromBottom: 0,
+      contentFitsViewport: true,
       loading: false,
       hasError: true,
       hasBufferedEntries: true,
@@ -15654,6 +15659,7 @@ final class ADETests: XCTestCase {
     ))
     XCTAssertFalse(workChatShouldContinueAutomaticOlderHistory(
       distanceFromBottom: 0,
+      contentFitsViewport: true,
       loading: true,
       hasError: true,
       hasBufferedEntries: true,
@@ -15661,10 +15667,32 @@ final class ADETests: XCTestCase {
     ))
     XCTAssertFalse(workChatShouldContinueAutomaticOlderHistory(
       distanceFromBottom: 0,
+      contentFitsViewport: true,
       loading: false,
       hasError: false,
       hasBufferedEntries: false,
       hasHostHistory: false
+    ))
+    XCTAssertFalse(workChatShouldContinueAutomaticOlderHistory(
+      distanceFromBottom: 0,
+      contentFitsViewport: false,
+      loading: false,
+      hasError: false,
+      hasBufferedEntries: true,
+      hasHostHistory: true
+    ))
+
+    XCTAssertTrue(workChatShouldInstallPrependProbe(
+      distanceFromTop: 0,
+      hasPrependAnchor: false
+    ))
+    XCTAssertFalse(workChatShouldInstallPrependProbe(
+      distanceFromTop: workChatOlderHistoryTriggerDistance + 1,
+      hasPrependAnchor: false
+    ))
+    XCTAssertTrue(workChatShouldInstallPrependProbe(
+      distanceFromTop: workChatOlderHistoryTriggerDistance + 1,
+      hasPrependAnchor: true
     ))
 
     XCTAssertEqual(
@@ -19806,6 +19834,34 @@ final class ADETests: XCTestCase {
 
     XCTAssertEqual(first, second)
     XCTAssertEqual(first.map(\.id), second.map(\.id))
+  }
+
+  func testParseMarkdownListBlocksStayBoundedAndPreserveOrder() {
+    let itemCount = workMarkdownListItemsPerRenderBlock * 2 + 3
+    let expectedItems = (1...itemCount).map { "Item \($0)" }
+    let orderedMarkdown = (1...itemCount).map { "\($0). Item \($0)" }.joined(separator: "\n")
+    let orderedBlocks = parseMarkdownBlocks(orderedMarkdown)
+    let orderedListBlocks = orderedBlocks.compactMap { block -> (Int, [String])? in
+      guard case .orderedList(let start, let items) = block.kind else { return nil }
+      return (start, items)
+    }
+
+    XCTAssertEqual(
+      orderedListBlocks.map(\.0),
+      [1, workMarkdownListItemsPerRenderBlock + 1, workMarkdownListItemsPerRenderBlock * 2 + 1]
+    )
+    XCTAssertTrue(orderedListBlocks.dropLast().allSatisfy { $0.1.count == workMarkdownListItemsPerRenderBlock })
+    XCTAssertEqual(orderedListBlocks.last?.1.count, 3)
+    XCTAssertEqual(orderedListBlocks.flatMap(\.1), expectedItems)
+
+    let unorderedMarkdown = expectedItems.map { "- \($0)" }.joined(separator: "\n")
+    let unorderedBlocks = parseMarkdownBlocks(unorderedMarkdown)
+    let unorderedListBlocks = unorderedBlocks.compactMap { block -> [String]? in
+      guard case .unorderedList(let items) = block.kind else { return nil }
+      return items
+    }
+    XCTAssertTrue(unorderedListBlocks.allSatisfy { $0.count <= workMarkdownListItemsPerRenderBlock })
+    XCTAssertEqual(unorderedListBlocks.flatMap { $0 }, expectedItems)
   }
 
   func testParseMarkdownTableRowsPreservesBlankCells() {


### PR DESCRIPTION
Follow-up to #1148.\n\nWhat changed:\n- Keep buffered history reachable when automatic paging previously latched an error.\n- Remove per-frame gesture/preference churn and avoid copying full render payloads during SwiftUI identity reconciliation.\n- Make Latest use both supported scroll channels in the correct order.\n- Bound long ordered/unordered markdown lists into 16-item render blocks while preserving numbering and order.\n- Cache stable lane/subagent/scheduled render signatures instead of hashing on every streaming update.\n\nVerification:\n- Focused post-rebase XCTest: 21/21 passed. Parser benchmark: 89.1x faster than full rescans; preview benchmark: 2.3x faster.\n- Full iOS suite: 1,601/1,612 passed; 11 failures reproduce the clean-HEAD environment baseline (keychain entitlement -34018 and trust/recovery timing), with no Work-chat failures.\n- Signed simulator proof against the local brain: target chat opened at the tail, deep history scrolling stayed responsive, Latest returned to the tail, consolidated chips remained intact, and proof screenshots/logs are attached in ADE.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core transcript scroll, pinning, and history-prepend behavior; regressions could strand chats off-tail or break older-history loading, though logic is covered by new/updated unit tests.
> 
> **Overview**
> Hardens **Work chat** scrolling and layout so long transcripts stay responsive and tail/history behavior stays correct.
> 
> **Scroll & history:** Replaces the competing zero-distance `DragGesture` and 16pt pin-cancel deadband with native **`onScrollPhaseChange`** handling (user-driven phase cancels the opening bottom pin and releases stickiness). **Jump to latest** now drives both `ScrollViewProxy.scrollTo` and bound **`scrollPosition.scrollTo(edge: .bottom)`**. Automatic older-history continuation only runs when **`contentFitsViewport`** (non-scrollable transcript). The prepend displacement probe installs only near the top (or while a prepend anchor is armed), cutting preference-graph work on ordinary scrolls. Viewport/composer height preference updates no longer auto-pin to latest.
> 
> **Rendering cost:** Transcript `ForEach` reconciles lightweight **`WorkTimelineRenderRowReference`** ids instead of copying full render payloads. Lane/subagent/scheduled **render signatures** are computed once at destination init and refreshed only when snapshot arrays change.
> 
> **Markdown:** Long ordered/unordered lists split into **16-item** render blocks (order and numbering preserved), matching the existing prose row budget so one list cannot become a single giant lazy row.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a0c2394d6cba6b8f99a8fedde5b02a6686140380. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->