### PR TITLE
Independent Prompt Settings -> main

### DIFF
--- a/apps/ade-cli/src/tuiClient/__tests__/appInput.test.ts
+++ b/apps/ade-cli/src/tuiClient/__tests__/appInput.test.ts
@@ -2173,17 +2173,15 @@ describe("prompt editing helpers", () => {
     expect(cursorSourceForInterfaceMode("chat")).toBe("sdk");
     expect(cursorSourceForInterfaceMode("cli")).toBe("cli");
 
-    const toggled = reconcileCursorModelStateForInterface(
-      cursorModelState(),
-      "cli",
-      [sdkOnly, cliOnly],
-    );
-    expect(toggled).toMatchObject({
-      interfaceMode: "cli",
-      modelId: "cursor/cli-only",
-      model: "cli-only-default",
-      displayName: "CLI only",
+    const before = cursorModelState({
+      reasoningEffort: "high",
+      fastMode: true,
+      permissionMode: "full-auto",
+      interactionMode: "plan",
+      cursorModeId: "ask",
     });
+    const toggled = reconcileCursorModelStateForInterface(before, "cli");
+    expect(toggled).toEqual({ ...before, interfaceMode: "cli" });
 
     expect(() => resolveCursorCliModelForLaunch(cursorModelState(), [sdkOnly]))
       .toThrow(/available for chat only/i);

--- a/apps/ade-cli/src/tuiClient/app.tsx
+++ b/apps/ade-cli/src/tuiClient/app.tsx
@@ -73,7 +73,6 @@ import type { ChatTerminalPreviewResult, ChatTerminalSession, UsageSnapshot } fr
 import { rollupPrChecks } from "../../../desktop/src/shared/prChecksRollup";
 import type { GitHubPrStackMembership, PrChecksStatus } from "../../../desktop/src/shared/types/prs";
 import {
-  DEFAULT_CODEX_REASONING_EFFORT,
   approveToolUse,
   archiveChatSession,
   buildPtyContinuationLaunchFields,
@@ -281,14 +280,12 @@ import {
   modeAccentColor,
   modeDescription,
   modelCatalogRefreshCacheKey,
-  modelInfoSupportsFastMode,
   modelMemoryFromState,
   modelReasoningEfforts,
   modelStatePatchForModel,
   modelStatePatchFromMemory,
   permissionSummary,
   providerModelsCacheKey,
-  providerSettingsPatchFromMemory,
   reasoningEffortDisplayLabel,
   reconcileCursorModelStateForInterface,
   registryModelsForProvider,
@@ -353,7 +350,6 @@ import {
   saveAdeCodeModelMemory,
   saveAdeCodeProjectState,
   scopedAdeCodeModelMemory,
-  scopedAdeCodeProviderSettings,
   scopedAdeCodeState,
   type AdeCodeModelMemory,
 } from "./state";
@@ -3347,7 +3343,7 @@ function modelStatePatchForArg(
   provider: AdeCodeProvider,
   currentModels: AgentChatModelInfo[],
   value: string,
-): Pick<AdeCodeModelState, "provider" | "model" | "modelId" | "displayName" | "reasoningEffort"> {
+): Pick<AdeCodeModelState, "provider" | "model" | "modelId" | "displayName"> {
   const model = findModelForArg(provider, currentModels, value);
   if (model) return modelStatePatchForModel(provider, model);
   return {
@@ -3355,7 +3351,6 @@ function modelStatePatchForArg(
     model: value,
     modelId: value,
     displayName: value,
-    reasoningEffort: provider === "codex" ? DEFAULT_CODEX_REASONING_EFFORT : null,
   };
 }
 
@@ -7246,12 +7241,9 @@ export function AdeCodeApp({ project, forceEmbedded, requireSocket, socketPath, 
       const model = nextModels.find((entry) => entry.isDefault) ?? nextModels[0] ?? null;
       setModelState((prev) => {
         const patch = model ? modelStatePatchForModel(provider, model) : fallbackModelStatePatch(provider);
-        const fallbackDescriptor = !model && patch.modelId ? getModelById(patch.modelId) : undefined;
-        const fastSupported = model ? modelInfoSupportsFastMode(model) : modelSupportsFastMode(fallbackDescriptor);
         return {
           ...prev,
           ...patch,
-          fastMode: fastSupported ? prev.fastMode : false,
         };
       });
     }
@@ -9357,6 +9349,23 @@ export function AdeCodeApp({ project, forceEmbedded, requireSocket, socketPath, 
     }
     const normalized = { ...modelState, ...applyProviderPermissionMode(modelState) };
     const runtimeProvider = runtimeProviderForUiProvider(normalized.provider);
+    if (runtimeProvider === "cursor") {
+      const cursorModel = models.find((entry) => (
+        entry.id === normalized.modelId
+          || entry.modelId === normalized.modelId
+          || entry.id === normalized.model
+          || entry.modelId === normalized.model
+      )) ?? modelInfoFromDescriptor(normalized.modelId ?? normalized.model);
+      if (!cursorModel || !cursorModelAvailableForInterface(cursorModel, normalized.interfaceMode)) {
+        addNotice(
+          normalized.interfaceMode === "cli"
+            ? "This Cursor model is available for chat only. Choose a Cursor CLI model."
+            : "This Cursor model is available for CLI only. Switch Interface to CLI or choose a chat model.",
+          "error",
+        );
+        return null;
+      }
+    }
     const requestedTitle = pendingNewChatTitleRef.current;
     const created = await createChatSession({
       connection: conn,
@@ -13164,6 +13173,21 @@ export function AdeCodeApp({ project, forceEmbedded, requireSocket, socketPath, 
         }
         launched = true;
       } else {
+        if (runtimeProvider === "cursor") {
+          const cursorModel = models.find((entry) => (
+            entry.id === normalized.modelId
+              || entry.modelId === normalized.modelId
+              || entry.id === normalized.model
+              || entry.modelId === normalized.model
+          )) ?? modelInfoFromDescriptor(normalized.modelId ?? normalized.model);
+          if (!cursorModel || !cursorModelAvailableForInterface(cursorModel, normalized.interfaceMode)) {
+            throw new Error(
+              normalized.interfaceMode === "cli"
+                ? "This Cursor model is available for chat only. Choose a Cursor CLI model."
+                : "This Cursor model is available for CLI only. Switch Interface to CLI or choose a chat model.",
+            );
+          }
+        }
         const requestedTitle = pendingNewChatTitleRef.current;
         const created = await createChatSession({
           connection: conn,
@@ -13261,15 +13285,6 @@ export function AdeCodeApp({ project, forceEmbedded, requireSocket, socketPath, 
     });
   }, [scheduleModelStateCommit]);
 
-  // Wizard step 4 pre-fills from the last time this provider was used here.
-  const applyRememberedProviderSettings = useCallback((provider: AdeCodeProvider) => {
-    const remembered = scopedAdeCodeProviderSettings(loadAdeCodeState(), project.projectRoot, provider);
-    if (!remembered) return;
-    applyModelState((prev) => (prev.provider === provider
-      ? { ...prev, ...providerSettingsPatchFromMemory(remembered) }
-      : prev));
-  }, [applyModelState, project.projectRoot]);
-
   // Commit a model picked in the right-pane ModelPicker into the current chat
   // model state and push it onto the cross-surface recents list. Defined here
   // (after applyModelState) so the closure captures a live binding.
@@ -13323,12 +13338,9 @@ export function AdeCodeApp({ project, forceEmbedded, requireSocket, socketPath, 
 	        );
 	        return;
 	      }
-	      const nextModelState: AdeCodeModelState = {
-	        ...previousModelState,
+      const nextModelState: AdeCodeModelState = {
+        ...previousModelState,
         ...modelStatePatchForModel(provider, target),
-        fastMode: (target.serviceTiers?.some((tier) => tier.trim().toLowerCase() === "fast") || modelSupportsFastMode(descriptor))
-          ? previousModelState.fastMode
-          : false,
       };
       modelStateRef.current = nextModelState;
       setModelState(nextModelState);
@@ -13396,12 +13408,9 @@ export function AdeCodeApp({ project, forceEmbedded, requireSocket, socketPath, 
     const model = immediateModels.find((entry) => entry.isDefault) ?? immediateModels[0] ?? null;
     applyModelState((prev) => {
       const patch = model ? modelStatePatchForModel(provider, model) : fallbackModelStatePatch(provider);
-      const fallbackDescriptor = !model && patch.modelId ? getModelById(patch.modelId) : undefined;
-      const fastSupported = model ? modelInfoSupportsFastMode(model) : modelSupportsFastMode(fallbackDescriptor);
       return {
         ...prev,
         ...patch,
-        fastMode: fastSupported ? prev.fastMode : false,
       };
     });
     void loadProviderModels(provider, { applyDefault: false }).catch(() => undefined);
@@ -13427,9 +13436,6 @@ export function AdeCodeApp({ project, forceEmbedded, requireSocket, socketPath, 
     applyModelState((prev) => ({
       ...prev,
       ...modelStatePatchForModel(modelState.provider, nextModel),
-      fastMode: (nextModel.serviceTiers?.some((tier) => tier.trim().toLowerCase() === "fast") || modelSupportsFastMode(getModelById(nextModel.modelId ?? nextModel.id)))
-        ? prev.fastMode
-        : false,
     }));
   }, [applyModelState, modelState.modelId, modelState.provider, models]);
 
@@ -13517,19 +13523,17 @@ export function AdeCodeApp({ project, forceEmbedded, requireSocket, socketPath, 
       // rows only (disabled rows return above); a committed session's interface
       // is fixed by its type.
       const nextInterface = modelStateRef.current.interfaceMode === "cli" ? "chat" : "cli";
-      const cursorModels = providerModelsCacheRef.current.get(providerModelsCacheKey("cursor", nextInterface))
-        ?? (modelStateRef.current.provider === "cursor" ? models : registryModelsForProvider("cursor"));
       persistExplicitDraftKind(nextInterface);
-      applyModelState((prev) => reconcileCursorModelStateForInterface(prev, nextInterface, cursorModels));
+      applyModelState((prev) => reconcileCursorModelStateForInterface(prev, nextInterface));
       if (modelStateRef.current.provider === "cursor") {
         void loadProviderModels("cursor", {
           applyDefault: false,
           force: true,
           interfaceMode: nextInterface,
-        }).then((loaded) => {
+        }).then(() => {
           const current = modelStateRef.current;
           if (current.provider !== "cursor" || current.interfaceMode !== nextInterface) return;
-          applyModelState((prev) => reconcileCursorModelStateForInterface(prev, nextInterface, loaded));
+          applyModelState((prev) => reconcileCursorModelStateForInterface(prev, nextInterface));
         }).catch(() => undefined);
       }
       return;
@@ -15188,8 +15192,6 @@ export function AdeCodeApp({ project, forceEmbedded, requireSocket, socketPath, 
               return;
             }
             selectProvider(advance.provider);
-            // Step 4 pre-fills from the last time this provider was used here.
-            applyRememberedProviderSettings(advance.provider);
             applyWizardSelection(advance.selection);
             return;
           }
@@ -16971,7 +16973,6 @@ export function AdeCodeApp({ project, forceEmbedded, requireSocket, socketPath, 
                     return;
                   }
                   selectProvider(advance.provider);
-                  applyRememberedProviderSettings(advance.provider);
                   setRightPane({
                     ...wizard,
                     step: advance.selection.step,
@@ -17284,7 +17285,6 @@ export function AdeCodeApp({ project, forceEmbedded, requireSocket, socketPath, 
     models,
     multiView,
     openModelWizard,
-    applyRememberedProviderSettings,
     closeModelWizard,
     rememberModelChoice,
     runInlineCommand,

--- a/apps/ade-cli/src/tuiClient/modelState.ts
+++ b/apps/ade-cli/src/tuiClient/modelState.ts
@@ -88,10 +88,8 @@ export function providerSettingsMemoryFromState(state: AdeCodeModelState): AdeCo
 }
 
 /**
- * Settings-only patch (no model identity): what wizard step 4 pre-fills with
- * when a provider is picked, and what a new chat inherits for that provider.
- * Unknown persisted values are cast rather than dropped — the provider CLIs own
- * the vocabulary and reject anything they do not understand.
+ * Settings-only patch for persisted state. Live provider/model selection must
+ * not use this helper: every composer setting is independent of that choice.
  */
 export function providerSettingsPatchFromMemory(
   memory: AdeCodeProviderSettingsMemory,
@@ -99,7 +97,6 @@ export function providerSettingsPatchFromMemory(
   return {
     reasoningEffort: memory.reasoningEffort,
     fastMode: memory.fastMode,
-    interfaceMode: memory.interfaceMode,
     permissionMode: memory.permissionMode as AdeCodeModelState["permissionMode"],
     interactionMode: memory.interactionMode as AdeCodeModelState["interactionMode"],
     claudePermissionMode: memory.claudePermissionMode as AdeCodeModelState["claudePermissionMode"],
@@ -124,6 +121,7 @@ export function modelStatePatchFromMemory(memory: AdeCodeModelMemory): Partial<A
   return {
     ...providerSettingsPatchFromMemory(memory),
     provider,
+    interfaceMode: memory.interfaceMode,
     ...(hasModelIdentity
       ? {
           modelId: memory.modelId,
@@ -167,29 +165,7 @@ export function cliProviderForModelStateProvider(provider: AdeCodeProvider): Cli
     : null;
 }
 
-function firstReasoningEffortForModel(model: AgentChatModelInfo | null | undefined, provider: AdeCodeProvider): string | null {
-  const modelId = `${model?.modelId ?? ""} ${model?.id ?? ""} ${model?.displayName ?? ""}`.toLowerCase();
-  const efforts = model?.reasoningEfforts
-    ?.map((entry) => entry.effort)
-    .filter(Boolean) ?? [];
-  const advertisedDefault = model?.defaultReasoningEffort?.trim().toLowerCase() ?? null;
-  if (modelId.includes("fable") && efforts.includes("high")) return "high";
-  if (advertisedDefault && efforts.includes(advertisedDefault)) return advertisedDefault;
-  if (efforts.includes(DEFAULT_CODEX_REASONING_EFFORT)) return DEFAULT_CODEX_REASONING_EFFORT;
-  if (efforts.length) return efforts[0] ?? null;
-  const descriptor = model?.modelId || model?.id ? getModelById(model.modelId ?? model.id) : undefined;
-  const descriptorEfforts = descriptor?.reasoningTiers ?? [];
-  const descriptorId = `${descriptor?.id ?? ""} ${descriptor?.providerModelId ?? ""} ${descriptor?.displayName ?? ""}`.toLowerCase();
-  if (descriptorId.includes("fable") && descriptorEfforts.includes("high")) return "high";
-  if (descriptor?.defaultReasoningEffort && descriptorEfforts.includes(descriptor.defaultReasoningEffort)) {
-    return descriptor.defaultReasoningEffort;
-  }
-  if (descriptorEfforts.includes(DEFAULT_CODEX_REASONING_EFFORT)) return DEFAULT_CODEX_REASONING_EFFORT;
-  if (descriptorEfforts.length) return descriptorEfforts[0] ?? null;
-  return provider === "codex" ? DEFAULT_CODEX_REASONING_EFFORT : null;
-}
-
-export function modelStatePatchForModel(provider: AdeCodeProvider, model: AgentChatModelInfo): Pick<AdeCodeModelState, "provider" | "model" | "modelId" | "displayName" | "reasoningEffort"> {
+export function modelStatePatchForModel(provider: AdeCodeProvider, model: AgentChatModelInfo): Pick<AdeCodeModelState, "provider" | "model" | "modelId" | "displayName"> {
   const modelId = model.modelId ?? model.id;
   const descriptor = getModelById(modelId);
   const resolvedProvider = descriptor ? normalizeProvider(resolveProviderGroupForModel(descriptor)) : provider;
@@ -199,7 +175,6 @@ export function modelStatePatchForModel(provider: AdeCodeProvider, model: AgentC
     model: descriptor ? getRuntimeModelRefForDescriptor(descriptor, runtimeProvider) : model.id,
     modelId,
     displayName: model.displayName,
-    reasoningEffort: firstReasoningEffortForModel(model, resolvedProvider),
   };
 }
 
@@ -247,7 +222,7 @@ export function modelCatalogRefreshCacheKey(
   return provider === "cursor" ? `cursor:${cursorSource ?? "sdk"}` : provider;
 }
 
-export function fallbackModelStatePatch(provider: AdeCodeProvider): Pick<AdeCodeModelState, "provider" | "model" | "modelId" | "displayName" | "reasoningEffort"> {
+export function fallbackModelStatePatch(provider: AdeCodeProvider): Pick<AdeCodeModelState, "provider" | "model" | "modelId" | "displayName"> {
   const registryProvider = provider === "ollama" || provider === "lmstudio" ? "opencode" : provider;
   const descriptor = getDefaultModelDescriptor(registryProvider)
     ?? listModelDescriptorsForProvider(registryProvider)[0]
@@ -257,11 +232,6 @@ export function fallbackModelStatePatch(provider: AdeCodeProvider): Pick<AdeCode
     model: descriptor ? getRuntimeModelRefForDescriptor(descriptor, registryProvider) : "gpt-5.6-sol",
     modelId: descriptor?.id ?? null,
     displayName: descriptor?.displayName ?? providerLabel(provider),
-    reasoningEffort: descriptor?.id.includes("fable") && descriptor.reasoningTiers?.includes("high")
-      ? "high"
-      : descriptor?.defaultReasoningEffort
-        ?? descriptor?.reasoningTiers?.[0]
-        ?? (provider === "codex" ? DEFAULT_CODEX_REASONING_EFFORT : null),
   };
 }
 
@@ -280,14 +250,6 @@ export function registryModelsForProvider(provider: AdeCodeProvider): AgentChatM
   }));
 }
 
-function compatibleCursorModelForInterface(
-  models: readonly AgentChatModelInfo[],
-  interfaceMode: AdeCodeInterfaceMode,
-): AgentChatModelInfo | null {
-  const compatible = models.filter((model) => cursorModelAvailableForInterface(model, interfaceMode));
-  return compatible.find((model) => model.isDefault) ?? compatible[0] ?? null;
-}
-
 function modelInfoMatchesModelState(model: AgentChatModelInfo, state: AdeCodeModelState): boolean {
   const selected = (state.modelId ?? state.model).trim().toLowerCase();
   if (!selected) return false;
@@ -299,60 +261,11 @@ function modelInfoMatchesModelState(model: AgentChatModelInfo, state: AdeCodeMod
 export function reconcileCursorModelStateForInterface(
   state: AdeCodeModelState,
   interfaceMode: AdeCodeInterfaceMode,
-  models: readonly AgentChatModelInfo[],
 ): AdeCodeModelState {
-  if (state.provider !== "cursor") return { ...state, interfaceMode };
-  const currentModel = models.find((model) => modelInfoMatchesModelState(model, state)) ?? null;
-  const descriptor = state.modelId ? getModelById(state.modelId) : undefined;
-  const availability = cursorAvailabilityForModel(currentModel, descriptor);
-  const currentAllowed = availability
-    ? (interfaceMode === "cli" ? availability.cli === true : availability.sdk === true)
-    : false;
-  if (currentAllowed && descriptor?.family === "cursor") {
-    const supportsFast = modelSupportsFastMode(descriptor);
-    return {
-      ...state,
-      interfaceMode,
-      model: interfaceMode === "cli"
-        ? resolveCursorCliModelVariant(descriptor, {
-            reasoningEffort: state.reasoningEffort,
-            fastMode: supportsFast && state.fastMode,
-          })
-        : getRuntimeModelRefForDescriptor(descriptor, "cursor"),
-      fastMode: supportsFast ? state.fastMode : false,
-    };
-  }
-  if (currentAllowed) return { ...state, interfaceMode };
-  const fallback = compatibleCursorModelForInterface(models, interfaceMode);
-  if (!fallback) {
-    return {
-      ...state,
-      interfaceMode,
-      model: "",
-      modelId: null,
-      displayName: providerLabel("cursor"),
-      reasoningEffort: null,
-      fastMode: false,
-    };
-  }
-  const patch = modelStatePatchForModel("cursor", fallback);
-  const fallbackDescriptor = patch.modelId ? getModelById(patch.modelId) : undefined;
-  const launchDescriptor = fallbackDescriptor?.family === "cursor" && fallback.cursorCliVariants?.length
-    ? { ...fallbackDescriptor, cursorCliVariants: fallback.cursorCliVariants }
-    : fallbackDescriptor;
-  const supportsFast = modelInfoSupportsFastMode(fallback);
-  return {
-    ...state,
-    ...patch,
-    interfaceMode,
-    model: interfaceMode === "cli" && launchDescriptor?.family === "cursor"
-      ? resolveCursorCliModelVariant(launchDescriptor, {
-          reasoningEffort: patch.reasoningEffort,
-          fastMode: supportsFast && state.fastMode,
-        })
-      : patch.model,
-    fastMode: supportsFast ? state.fastMode : false,
-  };
+  // Interface is a routing choice. It must not rewrite the selected model or
+  // any model setting; launch validation reports an incompatible Cursor model
+  // at the point where it matters.
+  return { ...state, interfaceMode };
 }
 
 export function resolveCursorCliModelForLaunch(

--- a/apps/desktop/src/main/services/chat/agentChatService.test.ts
+++ b/apps/desktop/src/main/services/chat/agentChatService.test.ts
@@ -3676,13 +3676,14 @@ describe("createAgentChatService", () => {
         fastMode: true,
       });
 
-      // Sonnet 5 has no "fast" service tier, so the toggle must be dropped.
+      // The raw preference survives the model switch; runtime capability gates
+      // whether the current provider can use it.
       await service.updateSession({
         sessionId: session.id,
         modelId: "anthropic/claude-sonnet-5",
       });
 
-      expect((await service.getSessionSummary(session.id))?.fastMode).not.toBe(true);
+      expect((await service.getSessionSummary(session.id))?.fastMode).toBe(true);
     });
 
     it("handles Claude /fast commands inline and persists the ADE fast setting", async () => {
@@ -14674,6 +14675,39 @@ describe("createAgentChatService", () => {
       expect(updated.provider).toBe("codex");
       expect(persisted.pendingTranscriptReplay).toContain("Seamless replay-fork on model change.");
       expect(persisted.pendingTranscriptReplay).toContain("verbatim replay");
+    });
+
+    it("changes only the model when switching models with independent settings selected", async () => {
+      const { service } = createService();
+      const session = await service.createSession({
+        laneId: "lane-1",
+        provider: "codex",
+        model: "gpt-5.5",
+        modelId: "openai/gpt-5.5",
+        reasoningEffort: "high",
+        fastMode: true,
+        permissionMode: "plan",
+        codexApprovalPolicy: "on-failure",
+        codexSandbox: "workspace-write",
+        codexConfigSource: "flags",
+      });
+      const before = {
+        reasoningEffort: session.reasoningEffort,
+        fastMode: session.fastMode,
+        permissionMode: session.permissionMode,
+        codexApprovalPolicy: session.codexApprovalPolicy,
+        codexSandbox: session.codexSandbox,
+        codexConfigSource: session.codexConfigSource,
+      };
+
+      const updated = await service.updateSession({
+        sessionId: session.id,
+        modelId: "anthropic/claude-sonnet-5",
+      });
+
+      expect(updated.provider).toBe("claude");
+      expect(updated.modelId).toBe("anthropic/claude-sonnet-5");
+      expect(updated).toMatchObject(before);
     });
 
     it("does not broadcast mode fields when no mode field is updated", async () => {
@@ -32181,7 +32215,7 @@ describe("createAgentChatService", () => {
       expect(afterMessages.length).toBe(beforeNoticeCount + 1);
     });
 
-    it("clears fast mode when switching a session away from Codex", async () => {
+    it("preserves fast mode when switching a session away from Codex", async () => {
       const { service } = createService();
       const session = await service.createSession({
         laneId: "lane-1",
@@ -32196,9 +32230,9 @@ describe("createAgentChatService", () => {
       });
 
       expect(updated.provider).toBe("claude");
-      expect(updated.fastMode).toBeUndefined();
-      expect((await service.getSessionSummary(session.id))?.fastMode).toBe(false);
-      expect(readPersistedChatState(session.id).fastMode).toBeUndefined();
+      expect(updated.fastMode).toBe(true);
+      expect((await service.getSessionSummary(session.id))?.fastMode).toBe(true);
+      expect(readPersistedChatState(session.id).fastMode).toBe(true);
     });
 
     it("re-resumes Codex threads when fast mode changes mid-session", async () => {

--- a/apps/desktop/src/main/services/chat/agentChatService.ts
+++ b/apps/desktop/src/main/services/chat/agentChatService.ts
@@ -7390,25 +7390,17 @@ function normalizeSessionNativePermissionControls(
   if (session.provider === "claude") {
     session.interactionMode = resolveSessionClaudeInteractionMode(session);
     session.claudePermissionMode = resolveSessionClaudePermissionMode(session, config.claudePermissionMode);
-    delete session.codexApprovalPolicy;
-    delete session.codexSandbox;
-    delete session.codexConfigSource;
-    delete session.opencodePermissionMode;
-    delete session.droidPermissionMode;
   } else if (session.provider === "codex") {
     if (orchestrationMode) session.interactionMode = orchestrationMode;
     else delete session.interactionMode;
     session.codexConfigSource = resolveSessionCodexConfigSource(session);
     if (session.codexConfigSource === "config-toml") {
-      delete session.codexApprovalPolicy;
-      delete session.codexSandbox;
+      // Keep the last flag-based values so switching back from config-toml does
+      // not erase the user's independent approval and sandbox choices.
     } else {
       session.codexApprovalPolicy = resolveSessionCodexApprovalPolicy(session, config.codexApprovalPolicy);
       session.codexSandbox = resolveSessionCodexSandbox(session, config.codexSandboxMode);
     }
-    delete session.claudePermissionMode;
-    delete session.opencodePermissionMode;
-    delete session.droidPermissionMode;
   } else if (session.provider === "droid") {
     session.interactionMode = orchestrationMode ?? (session.interactionMode === "plan" || session.permissionMode === "plan"
       ? "plan"
@@ -7419,29 +7411,13 @@ function normalizeSessionNativePermissionControls(
     const chosenDroidMode = resolveSessionDroidPermissionModeOrNull(session);
     if (chosenDroidMode) session.droidPermissionMode = chosenDroidMode;
     else delete session.droidPermissionMode;
-    delete session.claudePermissionMode;
-    delete session.codexApprovalPolicy;
-    delete session.codexSandbox;
-    delete session.codexConfigSource;
-    delete session.opencodePermissionMode;
   } else if (session.provider === "pi") {
     if (orchestrationMode) session.interactionMode = orchestrationMode;
     else delete session.interactionMode;
-    delete session.claudePermissionMode;
-    delete session.codexApprovalPolicy;
-    delete session.codexSandbox;
-    delete session.codexConfigSource;
-    delete session.opencodePermissionMode;
-    delete session.droidPermissionMode;
   } else {
     if (orchestrationMode) session.interactionMode = orchestrationMode;
     else delete session.interactionMode;
     session.opencodePermissionMode = resolveSessionOpenCodePermissionMode(session, config.opencodePermissionMode);
-    delete session.claudePermissionMode;
-    delete session.codexApprovalPolicy;
-    delete session.codexSandbox;
-    delete session.codexConfigSource;
-    delete session.droidPermissionMode;
   }
 
   session.permissionMode = syncLegacyPermissionMode(session);
@@ -31135,11 +31111,10 @@ export function createAgentChatService(args: {
           rawEffort,
           resolvedDescriptor,
         );
-    const initialFastMode = requestedFastMode === true
-      && (
-        effectiveProvider !== "claude"
-        || (resolvedDescriptor ? modelSupportsFastMode(resolvedDescriptor) : true)
-      );
+    // Fast mode is a user setting, not a model-selection side effect. Keep the
+    // raw preference on the session even when the selected runtime cannot use
+    // a fast service tier; runtime request builders decide whether to send it.
+    const initialFastMode = requestedFastMode === true;
     const normalizedCursorModeId = typeof requestedCursorModeId === "string"
       ? (requestedCursorModeId.trim() || null)
       : requestedCursorModeId === null
@@ -31605,9 +31580,7 @@ export function createAgentChatService(args: {
       modelId: targetDescriptor.id,
       sessionProfile: managed.session.sessionProfile,
       reasoningEffort: targetReasoningEffort,
-      fastMode: modelSupportsFastMode(targetDescriptor)
-        ? args.fastMode ?? args.codexFastMode ?? managed.session.fastMode === true
-        : undefined,
+      fastMode: args.fastMode ?? args.codexFastMode ?? managed.session.fastMode === true,
       claudePermissionMode: args.claudePermissionMode ?? managed.session.claudePermissionMode,
       codexApprovalPolicy: args.codexApprovalPolicy ?? managed.session.codexApprovalPolicy,
       codexSandbox: args.codexSandbox ?? managed.session.codexSandbox,
@@ -33143,7 +33116,7 @@ export function createAgentChatService(args: {
         title: capsule.source.title ? `Handoff · ${capsule.source.title}` : `Handoff · ${capsule.source.laneName}`,
         sessionProfile: "workflow",
         reasoningEffort: pickHandoffReasoningEffort(targetDescriptor, capsule.target.reasoningEffort),
-        fastMode: modelSupportsFastMode(targetDescriptor) ? capsule.target.fastMode : undefined,
+        fastMode: capsule.target.fastMode,
         claudePermissionMode: capsule.target.claudePermissionMode,
         codexApprovalPolicy: capsule.target.codexApprovalPolicy,
         codexSandbox: capsule.target.codexSandbox,
@@ -44191,6 +44164,17 @@ export function createAgentChatService(args: {
     const prevClaudeFastModeSetting = managed.session.provider === "claude"
       ? sessionEffectiveFastMode(managed.session)
       : false;
+    const hasExplicitNativeModeUpdate =
+      permissionMode !== undefined
+      || interactionMode !== undefined
+      || claudePermissionMode !== undefined
+      || codexApprovalPolicy !== undefined
+      || codexSandbox !== undefined
+      || codexConfigSource !== undefined
+      || opencodePermissionMode !== undefined
+      || droidPermissionMode !== undefined
+      || cursorModeId !== undefined
+      || cursorConfigValues !== undefined;
 
     if (modelId !== undefined) {
       const nextModelId = String(modelId ?? "").trim();
@@ -44253,9 +44237,6 @@ export function createAgentChatService(args: {
         delete managed.session.piSessionId;
         delete managed.session.piSessionFile;
       }
-      if (nextProvider === "claude" && !modelSupportsFastMode(descriptor)) {
-        delete managed.session.fastMode;
-      }
       managed.session.capabilityMode = inferCapabilityMode(nextProvider);
       if (previousProvider !== nextProvider) {
         delete managed.session.threadId;
@@ -44290,8 +44271,16 @@ export function createAgentChatService(args: {
         );
         applyLegacyPermissionModeToNativeControls(managed.session, managed.session.permissionMode);
       }
-      enforceManagedLocalHarnessPermissionMode(managed, descriptor);
-      normalizeSessionNativePermissionControls(managed.session, chatConfig);
+      // A model/provider choice is independent from the access settings. Keep
+      // the raw settings untouched for a model-only update; the runtime
+      // resolves provider-specific fallbacks at launch. Explicit mode fields
+      // still take the normal policy-normalization path below.
+      if (hasExplicitNativeModeUpdate) {
+        enforceManagedLocalHarnessPermissionMode(managed, descriptor);
+        normalizeSessionNativePermissionControls(managed.session, chatConfig);
+      } else {
+        enforceManagedLocalHarnessPermissionMode(managed, descriptor);
+      }
 
       // Apply reasoningEffort BEFORE pre-warming so the query is created
       // with the correct thinking configuration.
@@ -44302,12 +44291,6 @@ export function createAgentChatService(args: {
           : nextProvider === "claude"
             ? validateReasoningEffortForDescriptor("claude", requested, descriptor)
             : validateRuntimeReasoningEffortForDescriptor(requested, descriptor);
-      } else if (modelChanged && nextProvider === "codex") {
-        managed.session.reasoningEffort = validateReasoningEffortForDescriptor(
-          "codex",
-          managed.session.reasoningEffort,
-          descriptor,
-        ) ?? resolveCodexReasoningEffortForRuntime(null, null, descriptor);
       }
 
       // Pre-warm the Claude query when the user selects an Anthropic model.
@@ -44439,14 +44422,6 @@ export function createAgentChatService(args: {
         delete managed.session.fastMode;
       }
     }
-    if (
-      managed.session.provider === "claude"
-      && managed.session.fastMode === true
-      && !sessionSupportsFastMode(managed.session)
-    ) {
-      delete managed.session.fastMode;
-    }
-
     const nextClaudeFastModeSetting = managed.session.provider === "claude"
       ? sessionEffectiveFastMode(managed.session)
       : false;
@@ -44475,17 +44450,7 @@ export function createAgentChatService(args: {
       }
     }
 
-    const modeFieldsTouched =
-      permissionMode !== undefined
-      || interactionMode !== undefined
-      || claudePermissionMode !== undefined
-      || codexApprovalPolicy !== undefined
-      || codexSandbox !== undefined
-      || codexConfigSource !== undefined
-      || opencodePermissionMode !== undefined
-      || droidPermissionMode !== undefined
-      || cursorModeId !== undefined
-      || cursorConfigValues !== undefined;
+    const modeFieldsTouched = hasExplicitNativeModeUpdate;
     if (modeFieldsTouched) {
       enforceManagedLocalHarnessPermissionMode(managed);
       normalizeSessionNativePermissionControls(managed.session, chatConfig);

--- a/apps/desktop/src/renderer/components/app/BatchLaunchModal.tsx
+++ b/apps/desktop/src/renderer/components/app/BatchLaunchModal.tsx
@@ -20,9 +20,6 @@ import {
   type SessionLaunchModelConfig,
 } from "../shared/SessionLaunchModelControls";
 import { useModelRecents } from "../shared/ModelPicker/useModelRecents";
-import { useReasoningByFamily } from "../shared/ModelPicker/useReasoningByFamily";
-import { resolveModelDescriptorWithRuntimeCatalog } from "../shared/ModelPicker/modelCatalog";
-import { getModelById } from "../../../shared/modelRegistry";
 import { Button } from "../ui/Button";
 import { cn } from "../ui/cn";
 
@@ -293,17 +290,6 @@ export function BatchLaunchModal({
     }));
   }, []);
 
-  const { getReasoningForFamily } = useReasoningByFamily();
-
-  const resolveDisplayedReasoning = useCallback(
-    (explicit: string | null, modelId: string): string | null => {
-      if (explicit) return explicit;
-      const desc = resolveModelDescriptorWithRuntimeCatalog(modelId) ?? getModelById(modelId);
-      return desc?.family ? getReasoningForFamily(desc.family) : null;
-    },
-    [getReasoningForFamily],
-  );
-
   const applyDefaultField = useCallback(
     <K extends keyof PerIssueState>(key: K, value: PerIssueState[K]) => {
       setPerIssue((current) => {
@@ -380,12 +366,10 @@ export function BatchLaunchModal({
       const existingLaneId =
         !laneOnly && laneTarget === "existing" ? state.existingLaneId?.trim() || null : null;
       if (!laneOnly && laneTarget === "existing" && !existingLaneId) continue;
-      const reasoningEffort = resolveDisplayedReasoning(config.reasoningEffort, config.modelId);
       entries.push({
         issue,
         config: {
           ...config,
-          reasoningEffort,
           existingLaneId,
           laneOnly,
           nativeControls,
@@ -394,7 +378,7 @@ export function BatchLaunchModal({
     }
     if (!entries.length) return;
     onLaunch(entries);
-  }, [issues, perIssue, onLaunch, laneOnly, resolveDisplayedReasoning, multiIssue, defaultConfig]);
+  }, [issues, perIssue, onLaunch, laneOnly, multiIssue, defaultConfig]);
 
   if (!issues.length) return null;
 

--- a/apps/desktop/src/renderer/components/chat/AgentChatPane.test.tsx
+++ b/apps/desktop/src/renderer/components/chat/AgentChatPane.test.tsx
@@ -6111,7 +6111,7 @@ describe("AgentChatPane submit recovery", () => {
     });
   });
 
-  it("keeps Auto-create selected while routing Work tools through Primary", async () => {
+  it("keeps Auto-create selected without changing the lane", async () => {
     installAdeMocks({ sessions: [] });
     const onLaneChange = vi.fn();
     renderAutoCreateDraftPane({ onLaneChange });
@@ -6119,7 +6119,7 @@ describe("AgentChatPane submit recovery", () => {
     fireEvent.click(await screen.findByRole("button", { name: "Select lane" }));
     fireEvent.click(await screen.findByRole("option", { name: /Auto-create lane/i }));
 
-    expect(onLaneChange).toHaveBeenCalledWith("lane-primary");
+    expect(onLaneChange).not.toHaveBeenCalled();
     expect(await screen.findByText("Auto-create lane")).toBeTruthy();
   });
 
@@ -6143,7 +6143,7 @@ describe("AgentChatPane submit recovery", () => {
     expect(list.mock.calls.every(([args]) => args.laneId === "lane-1")).toBe(true);
   });
 
-  it("falls back to the first available Work tools lane when Auto-create has no Primary lane", async () => {
+  it("keeps Auto-create selected when the available lanes have no Primary lane", async () => {
     installAdeMocks({ sessions: [] });
     const onLaneChange = vi.fn();
     renderAutoCreateDraftPane({
@@ -6162,10 +6162,10 @@ describe("AgentChatPane submit recovery", () => {
     fireEvent.click(await screen.findByRole("button", { name: "Select lane" }));
     fireEvent.click(await screen.findByRole("option", { name: /Auto-create lane/i }));
 
-    expect(onLaneChange).toHaveBeenCalledWith("lane-worktree");
+    expect(onLaneChange).not.toHaveBeenCalled();
   });
 
-  it("recovers a bare Auto-create selection from an unavailable persisted machine", async () => {
+  it("keeps machine and lane unchanged for Auto-create on an unavailable machine", async () => {
     installAdeMocks({ sessions: [] });
     const onDraftMachineChange = vi.fn();
     const onLaneChange = vi.fn();
@@ -6178,9 +6178,8 @@ describe("AgentChatPane submit recovery", () => {
     fireEvent.click(await screen.findByRole("button", { name: "Select lane" }));
     fireEvent.click(await screen.findByRole("option", { name: /Auto-create lane/i }));
 
-    expect(onDraftMachineChange).toHaveBeenCalledWith(null);
-    expect(onLaneChange).toHaveBeenCalledWith("lane-primary");
-    expect(screen.queryByText(/selected machine is not currently available/i)).toBeNull();
+    expect(onDraftMachineChange).not.toHaveBeenCalled();
+    expect(onLaneChange).not.toHaveBeenCalled();
   });
 
   it("auto-creates on this computer from a remote-bound tab without rebinding the project", async () => {

--- a/apps/desktop/src/renderer/components/chat/AgentChatPane.test.tsx
+++ b/apps/desktop/src/renderer/components/chat/AgentChatPane.test.tsx
@@ -1222,6 +1222,7 @@ function renderAutoCreateDraftPane(args?: {
   onDraftMachineChange?: React.ComponentProps<typeof AgentChatPane>["onDraftMachineChange"];
   onImportedSession?: React.ComponentProps<typeof AgentChatPane>["onImportedSession"];
   initialDraftMachineId?: string | null;
+  laneId?: string | null;
   lanes?: any[];
   project?: { rootPath: string; displayName?: string };
   projectBinding?: OpenProjectBinding;
@@ -1258,7 +1259,7 @@ function renderAutoCreateDraftPane(args?: {
           element={(
             <>
               <AgentChatPane
-                laneId="lane-1"
+                laneId={args?.laneId ?? "lane-1"}
                 forceDraftMode
                 embeddedWorkLayout
                 workDraftKind={args?.workDraftKind}
@@ -6180,6 +6181,35 @@ describe("AgentChatPane submit recovery", () => {
 
     expect(onDraftMachineChange).not.toHaveBeenCalled();
     expect(onLaneChange).not.toHaveBeenCalled();
+  });
+
+  it("rejects an unavailable draft lane instead of launching against the bound project", async () => {
+    seedRuntimeModelCatalog();
+    const { create } = installAdeMocks({ sessions: [] });
+    const onSessionCreated = vi.fn();
+    renderAutoCreateDraftPane({
+      laneId: "lane-only-on-another-machine",
+      onSessionCreated,
+    });
+
+    const modelTrigger = await screen.findByRole("button", { name: /^Select model/ });
+    const codexLabel = getModelById("openai/gpt-5.4")?.displayName ?? "GPT-5.4";
+    fireEvent.pointerDown(modelTrigger, { button: 0 });
+    fireEvent.click(modelTrigger);
+    fireEvent.click(await screen.findByRole("tab", { name: /^OpenAI$/i }));
+    await clickEnabledModelOption(new RegExp(escapeRegExp(codexLabel), "i"));
+
+    const textbox = await screen.findByRole("textbox");
+    fireEvent.change(textbox, { target: { value: "Do not launch this unavailable lane." } });
+    fireEvent.click(await screen.findByRole("button", { name: "Send" }));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("draft-launch-job").textContent).toContain(
+        "Selected lane is not available on the selected machine",
+      );
+    });
+    expect(create).not.toHaveBeenCalled();
+    expect(onSessionCreated).not.toHaveBeenCalled();
   });
 
   it("auto-creates on this computer from a remote-bound tab without rebinding the project", async () => {

--- a/apps/desktop/src/renderer/components/chat/AgentChatPane.tsx
+++ b/apps/desktop/src/renderer/components/chat/AgentChatPane.tsx
@@ -9206,14 +9206,29 @@ export function AgentChatPane({
           ? (availableLanes ?? lanes).find((candidate) => candidate.id === laneId)
           : undefined
       );
-    if (!launchLane && draftExecutionMachineIdRef.current !== draftBoundMachineIdRef.current) {
+    // A direct Work draft can arrive before its lane catalog has hydrated; in
+    // that case the existing lane id is still a valid launch target. Once a
+    // catalog is known, however, a missing lane is an unavailable selection
+    // and must not fall back to the project's root worktree.
+    const laneCatalogLoaded = availableLanes !== undefined || lanes.length > 0;
+    if (
+      !launchLane
+      && (
+        draftExecutionMachineIdRef.current !== draftBoundMachineIdRef.current
+        || laneCatalogLoaded
+      )
+    ) {
       throw new Error("Selected lane is not available on the selected machine. Choose a lane for that machine.");
     }
+    const launchWorktreePath =
+      launchLane && "worktreePath" in launchLane && typeof launchLane.worktreePath === "string"
+        ? launchLane.worktreePath
+        : null;
     const laneName = launchLane?.name ?? laneDisplayLabel ?? laneId;
     return {
       laneId,
       laneName,
-      worktreePath: routedLaunchLane?.worktreePath ?? projectRoot ?? null,
+      worktreePath: launchWorktreePath ?? projectRoot ?? null,
       autoCreated: false,
     };
   }, [

--- a/apps/desktop/src/renderer/components/chat/AgentChatPane.tsx
+++ b/apps/desktop/src/renderer/components/chat/AgentChatPane.tsx
@@ -97,7 +97,6 @@ import {
   getLocalModelIdTail,
   getLocalProviderDefaultEndpoint,
   getModelById,
-  getModelDescriptorForPermissionMode,
   getRuntimeModelRefForDescriptor,
   modelSupportsFastMode,
   parseLocalProviderFromModelId,
@@ -105,7 +104,6 @@ import {
   resolveCliProviderForModel,
   resolveProviderGroupForModel,
   resolveModelDescriptorForProvider,
-  selectSupportedReasoningEffort,
   type LocalProviderFamily,
   type ModelDescriptor,
   type ProviderFamily,
@@ -1035,25 +1033,6 @@ function formatLocalModelLabel(modelId: string): string {
   return tail.length ? tail : modelId;
 }
 
-function recommendedOpenCodePermissionModeForModel(
-  descriptor: ModelDescriptor | null | undefined,
-): AgentChatOpenCodePermissionMode | null {
-  if (!descriptor?.authTypes.includes("local")) return null;
-  return descriptor.harnessProfile === "guarded" || descriptor.harnessProfile === "read_only"
-    ? "plan"
-    : null;
-}
-
-function shouldResetOpenCodePermissionForModelSwitch(
-  previous: ModelDescriptor | null | undefined,
-  next: ModelDescriptor | null | undefined,
-): boolean {
-  const prevRec = recommendedOpenCodePermissionModeForModel(previous);
-  const nextRec = recommendedOpenCodePermissionModeForModel(next);
-  if (prevRec == null && nextRec == null) return false;
-  return prevRec !== nextRec;
-}
-
 type LocalRuntimeNoticeShape = {
   tone: "success" | "warning";
   title: string;
@@ -1898,19 +1877,6 @@ function writeLastUsedModelId(modelId: string) {
   }
 }
 
-function readLastUsedReasoningEffort(args: {
-  laneId: string | null;
-  modelId: string;
-}): string | null {
-  if (!args.laneId) return null;
-  try {
-    const raw = window.localStorage.getItem(`${LAST_REASONING_KEY_PREFIX}:${args.laneId}:${args.modelId}`);
-    return raw && raw.trim().length ? raw.trim() : null;
-  } catch {
-    return null;
-  }
-}
-
 function writeLastUsedReasoningEffort(args: {
   laneId: string | null;
   modelId: string;
@@ -1936,23 +1902,6 @@ function resolveScopedModelDescriptor(
   const id = modelId?.trim();
   if (!id) return undefined;
   return resolveModelDescriptorWithRuntimeCatalog(id, scopeKey) ?? getModelById(id);
-}
-
-function selectReasoningEffort(args: {
-  tiers: string[];
-  preferred: string | null;
-  modelId?: string | null;
-  catalogScopeKey: string;
-}): string | null {
-  const descriptor = args.modelId
-    ? resolveScopedModelDescriptor(args.modelId, args.catalogScopeKey)
-    : undefined;
-  return selectSupportedReasoningEffort({
-    tiers: args.tiers,
-    preferred: args.preferred,
-    advertisedDefault: descriptor?.defaultReasoningEffort,
-    fallback: args.modelId?.toLowerCase().includes("fable") ? "high" : null,
-  });
 }
 
 function resolveAssistantLabel(
@@ -2461,17 +2410,15 @@ function nativeControlsFromLaunchSource(
 function buildLastLaunchConfig(
   source: Partial<LaunchConfigSessionSource>,
   defaults: NativeControlState,
-  catalogScopeKey: string,
   updatedAt = new Date().toISOString(),
 ): LastLaunchConfig | null {
   const modelId = source.modelId ?? resolveRegistryModelId(source.model);
   if (!modelId) return null;
-  const desc = resolveScopedModelDescriptor(modelId, catalogScopeKey);
   return {
     version: 1,
     modelId,
     reasoningEffort: source.reasoningEffort ?? null,
-    fastMode: modelSupportsFastMode(desc) && source.fastMode === true,
+    fastMode: source.fastMode === true,
     executionMode: pickStringEnum(source.executionMode, EXECUTION_MODES, "focused"),
     controls: nativeControlsFromLaunchSource(source, defaults),
     updatedAt,
@@ -3395,7 +3342,9 @@ export function AgentChatPane({
   const showWorkspaceChrome = !hideWorkspaceChrome;
   const workDraftStorageKind = normalizeWorkDraftStorageKind();
   const isWorkDraftComposer = forceDraft && embeddedWorkLayout && !lockSessionId && !initialSessionId;
-  const draftLaunchConfigLaneScopeId = isWorkDraftComposer ? WORK_START_DRAFT_LAUNCH_SCOPE_ID : laneId;
+  // Draft settings belong to the composer, not to the lane or machine that
+  // happens to be selected for its next launch.
+  const draftLaunchConfigLaneScopeId = forceDraft ? WORK_START_DRAFT_LAUNCH_SCOPE_ID : laneId;
   const initialWorkDraftLaneIdRef = useRef<string | null>(isWorkDraftComposer ? laneId : null);
   const legacyWorkDraftLaneId = isWorkDraftComposer ? initialWorkDraftLaneIdRef.current : null;
   const initialNativeControls = useMemo(() => defaultNativeControls(surfaceProfile), [surfaceProfile]);
@@ -3582,7 +3531,6 @@ export function AgentChatPane({
   const [codexConfigSource, setCodexConfigSource] = useState<AgentChatCodexConfigSource>(initialNativeControls.codexConfigSource);
   const [opencodePermissionMode, setOpenCodePermissionMode] = useState<AgentChatOpenCodePermissionMode>(initialNativeControls.opencodePermissionMode);
   const [droidPermissionMode, setDroidPermissionMode] = useState<AgentChatDroidPermissionMode>(initialNativeControls.droidPermissionMode);
-  const prevModelDescRef = useRef<ModelDescriptor | null | undefined>(undefined);
   const [cursorModeId, setCursorModeId] = useState<string | null>(initialNativeControls.cursorModeId);
   const [cursorConfigValues, setCursorConfigValues] = useState<Record<string, AgentChatCursorConfigValue>>(initialNativeControls.cursorConfigValues);
   const [aiStatus, setAiStatus] = useState<AiStatusSnapshot | null>(seedAiStatus);
@@ -3915,6 +3863,8 @@ export function AgentChatPane({
   const pendingFastModeUpdateRef = useRef<{ sessionId: string; updateId: number; promise: Promise<void> } | null>(null);
   const pendingEventQueueRef = useRef<AgentChatEventEnvelope[]>([]);
   const draftExecutionLanesRef = useRef<RoutedDraftLane[]>([]);
+  const draftExecutionMachineIdRef = useRef<string | null>(null);
+  const draftBoundMachineIdRef = useRef<string | null>(null);
   const draftExecutionBindingRef = useRef<OpenProjectBinding | null>(null);
   const draftExecutionBindingRequiredRef = useRef(false);
   const draftMachineUnavailableRef = useRef(false);
@@ -5244,10 +5194,6 @@ export function AgentChatPane({
     localRuntimeState?.endpoint,
   ]);
 
-  useEffect(() => {
-    prevModelDescRef.current = getModelDescriptorForPermissionMode(modelId);
-  }, [modelId]);
-
   const surfaceMode = presentation?.mode ?? "standard";
   const identitySessionSettingsBusy = isPersistentIdentitySurface && sessionMutationKind !== null;
 
@@ -5422,17 +5368,9 @@ export function AgentChatPane({
   );
 
   const applyLaunchConfigToComposer = useCallback((config: LastLaunchConfig) => {
-    const desc = resolveScopedModelDescriptor(config.modelId, modelCatalogScopeKey);
-    if (!cursorModelAllowedForDraftKind(desc, workDraftKind)) return;
-    const tiers = desc?.reasoningTiers ?? [];
     setModelId(config.modelId);
-    setReasoningEffort(selectReasoningEffort({
-      tiers,
-      preferred: config.reasoningEffort,
-      modelId: config.modelId,
-      catalogScopeKey: modelCatalogScopeKey,
-    }));
-    setFastModeState(modelSupportsFastMode(desc) && config.fastMode);
+    setReasoningEffort(config.reasoningEffort);
+    setFastModeState(config.fastMode);
     setExecutionMode(config.executionMode);
     setInteractionMode(config.controls.interactionMode);
     setClaudePermissionMode(config.controls.claudePermissionMode);
@@ -5443,7 +5381,7 @@ export function AgentChatPane({
     setDroidPermissionMode(config.controls.droidPermissionMode);
     setCursorModeId(config.controls.cursorModeId);
     setCursorConfigValues({ ...config.controls.cursorConfigValues });
-  }, [setFastModeState, workDraftKind, modelCatalogScopeKey]);
+  }, [setFastModeState]);
 
   const syncComposerToSession = useCallback((session: AgentChatSessionSummary | null) => {
     if (!session) {
@@ -5603,7 +5541,16 @@ export function AgentChatPane({
     () => effectiveAvailableModelIds.filter((id) => id.startsWith("cursor/")),
     [effectiveAvailableModelIds],
   );
+  const draftCursorModelSelectionError = useMemo(() => {
+    if (!forceDraft || selectedSessionId || lockSessionId || initialSessionId || !modelId) return null;
+    const descriptor = resolveScopedModelDescriptor(modelId, modelCatalogScopeKey);
+    if (descriptor?.family !== "cursor" || cursorModelAllowedForDraftKind(descriptor, workDraftKind)) return null;
+    return workDraftKind === "cli"
+      ? "This Cursor model is available for chat only. Choose a Cursor CLI model."
+      : "This Cursor model is available for CLI only. Choose a Cursor chat model.";
+  }, [forceDraft, initialSessionId, lockSessionId, modelCatalogScopeKey, modelId, selectedSessionId, workDraftKind]);
   const constrainedModelSelectionError = useMemo(() => {
+    if (draftCursorModelSelectionError) return draftCursorModelSelectionError;
     if (!modelSelectionConstrained) return null;
     if (!effectiveAvailableModelIds.length) {
       return "No models are available for this chat surface.";
@@ -5612,7 +5559,7 @@ export function AgentChatPane({
       return "Select an available model for this chat surface before sending.";
     }
     return null;
-  }, [effectiveAvailableModelIds, modelId, modelSelectionConstrained]);
+  }, [draftCursorModelSelectionError, effectiveAvailableModelIds, modelId, modelSelectionConstrained]);
   const cursorCloudApiAvailable = providerConnections?.cursor?.runtimeAvailable === true
     || aiStatus?.availableProviders?.cursor === true;
   const cursorCloudAvailable = Boolean(laneId)
@@ -6833,7 +6780,7 @@ export function AgentChatPane({
     if (draftLaunchConfigTouchedKeyRef.current === draftLaunchConfigScopeKey) return;
     const draftKey = draftLaunchConfigScopeKey;
     const latestSessionConfig = sessions[0]
-      ? buildLastLaunchConfig(sessions[0], initialNativeControls, modelCatalogScopeKey)
+      ? buildLastLaunchConfig(sessions[0], initialNativeControls)
       : null;
     const sessionHydrationKey = `${draftKey}:session`;
     if (latestSessionConfig) {
@@ -6948,15 +6895,6 @@ export function AgentChatPane({
     if (selectableModelIds.includes(modelId)) return;
     if (modelSelectionConstrained) return;
     const modelDesc = resolveScopedModelDescriptor(modelId, modelCatalogScopeKey);
-    if (modelDesc?.family === "cursor" && !cursorModelAllowedForDraftKind(modelDesc, workDraftKind)) {
-      if (selectedSessionModelId && effectiveAvailableModelIds.includes(selectedSessionModelId)) {
-        setModelId(selectedSessionModelId);
-        return;
-      }
-      const preferred = readLastUsedModelId();
-      setModelId(preferred && effectiveAvailableModelIds.includes(preferred) ? preferred : effectiveAvailableModelIds[0] ?? "");
-      return;
-    }
     // Runtime catalog can surface Cursor/Droid SDK models before ai status catches up.
     if (isKnownSelectableChatModelId(modelId) || modelDesc) return;
     if (selectedSessionModelId && selectableModelIds.includes(selectedSessionModelId)) {
@@ -6969,26 +6907,7 @@ export function AgentChatPane({
     } else {
       setModelId(selectableModelIds[0]!);
     }
-  }, [loading, availableModelIds, effectiveAvailableModelIds, modelId, modelSelectionConstrained, selectedSessionModelId, workDraftKind, modelCatalogScopeKey]);
-
-  useEffect(() => {
-    if (!reasoningTiers.length) {
-      if (reasoningEffort !== null) setReasoningEffort(null);
-      return;
-    }
-    if (reasoningEffort && reasoningTiers.includes(reasoningEffort)) return;
-    const preferred = readLastUsedReasoningEffort({ laneId, modelId });
-    setReasoningEffort(selectReasoningEffort({ tiers: reasoningTiers, preferred, modelId, catalogScopeKey: modelCatalogScopeKey }));
-  }, [laneId, modelId, reasoningEffort, reasoningTiers, modelCatalogScopeKey]);
-
-  useEffect(() => {
-    if (!executionModeOptions.length) {
-      if (executionMode !== "focused") setExecutionMode("focused");
-      return;
-    }
-    if (executionModeOptions.some((option) => option.value === executionMode)) return;
-    setExecutionMode(executionModeOptions[0]!.value);
-  }, [executionMode, executionModeOptions]);
+  }, [loading, availableModelIds, effectiveAvailableModelIds, modelId, modelSelectionConstrained, selectedSessionModelId, modelCatalogScopeKey]);
 
   useEffect(() => {
     selectedSessionIdRef.current = selectedSessionId;
@@ -8627,46 +8546,21 @@ export function AgentChatPane({
     };
   }, []);
   const buildModelSelectionSnapshot = useCallback((nextModelId: string) => {
-    const previousDesc = prevModelDescRef.current;
     const nextDesc = resolveScopedModelDescriptor(nextModelId, modelCatalogScopeKey);
-    const nextPermissionDesc = getModelDescriptorForPermissionMode(nextModelId);
     const nextProvider = resolveChatRuntimeProvider(nextDesc);
     const nextModel = nextProvider === "opencode" ? nextModelId : runtimeFacingModelId(nextDesc, nextModelId);
-    const tiers = nextDesc?.reasoningTiers ?? [];
-    const preferred = readLastUsedReasoningEffort({ laneId, modelId: nextModelId });
-    const nextReasoningEffort = selectReasoningEffort({
-      tiers,
-      preferred,
-      modelId: nextModelId,
-      catalogScopeKey: modelCatalogScopeKey,
-    });
-    const nextRec = recommendedOpenCodePermissionModeForModel(nextPermissionDesc);
     return {
       nextDesc,
       nextModelId,
       nextModel,
       nextProvider,
-      nextReasoningEffort,
-      nextOpenCodePermissionMode: nextRec,
-      resetOpenCodePermissionToDefault: shouldResetOpenCodePermissionForModelSwitch(previousDesc, nextPermissionDesc),
     };
-  }, [laneId, modelCatalogScopeKey]);
+  }, [modelCatalogScopeKey]);
   const applyModelSelectionSnapshot = useCallback((snapshot: {
     nextModelId: string;
-    nextReasoningEffort: string | null;
-    nextOpenCodePermissionMode?: AgentChatOpenCodePermissionMode | null;
-    resetOpenCodePermissionToDefault?: boolean;
   }) => {
     setModelId(snapshot.nextModelId);
-    setReasoningEffort(snapshot.nextReasoningEffort);
-    const nextOpenCodeMode = snapshot.nextOpenCodePermissionMode ?? null;
-    const targetOpenCodeMode = snapshot.resetOpenCodePermissionToDefault
-      ? (nextOpenCodeMode ?? initialNativeControls.opencodePermissionMode)
-      : nextOpenCodeMode;
-    if (targetOpenCodeMode != null) {
-      setOpenCodePermissionMode(targetOpenCodeMode);
-    }
-  }, [initialNativeControls.opencodePermissionMode]);
+  }, []);
   const notifySessionCreated = useCallback((session: AgentChatSession, options?: AgentChatSessionCreatedOptions) => {
     if (!onSessionCreated) return;
     // Call synchronously so the parent's lane/session focus state setters land
@@ -8736,19 +8630,10 @@ export function AgentChatPane({
       const launchExecutionMode = options.launchState?.executionMode ?? executionMode;
       const baseNativeControls = options.launchState?.nativeControls ?? currentNativeControls;
       const desc = resolveScopedModelDescriptor(launchModelId, modelCatalogScopeKey);
-      const permissionDesc = getModelDescriptorForPermissionMode(launchModelId);
       const provider = resolveChatRuntimeProvider(desc);
       const model = provider === "opencode" ? launchModelId : runtimeFacingModelId(desc, launchModelId);
       const sessionProfile = resolveChatSessionProfile();
-      const harnessPermissionMode = provider === "opencode"
-        ? recommendedOpenCodePermissionModeForModel(permissionDesc)
-        : null;
-      const launchControls = harnessPermissionMode
-        ? {
-            ...baseNativeControls,
-            opencodePermissionMode: harnessPermissionMode,
-          }
-        : baseNativeControls;
+      const launchControls = baseNativeControls;
       const nativeControlPayload = {
         ...summarizeNativeControls(provider, launchControls),
         ...(provider === "cursor" ? { cursorConfigValues: launchControls.cursorConfigValues } : {}),
@@ -8766,7 +8651,7 @@ export function AgentChatPane({
         modelId: launchModelId,
         sessionProfile,
         reasoningEffort: launchReasoningEffort,
-        ...(modelSupportsFastMode(desc) ? { fastMode: launchFastMode } : {}),
+        fastMode: launchFastMode,
         ...nativeControlPayload,
         ...orchestratorOverrides,
       };
@@ -8821,7 +8706,7 @@ export function AgentChatPane({
         model: created.model,
         modelId: created.modelId ?? launchModelId,
         reasoningEffort: launchReasoningEffort,
-        fastMode: modelSupportsFastMode(desc) && launchFastMode,
+        fastMode: launchFastMode,
         executionMode: launchExecutionMode,
         permissionMode: nativeControlPayload.permissionMode,
         interactionMode: launchControls.interactionMode,
@@ -8833,7 +8718,7 @@ export function AgentChatPane({
         droidPermissionMode: launchControls.droidPermissionMode,
         cursorModeId: launchControls.cursorModeId,
         cursorConfigValues: launchControls.cursorConfigValues,
-      }, initialNativeControls, modelCatalogScopeKey);
+      }, initialNativeControls);
       if (launchConfig) writeLastLaunchConfig(lastLaunchConfigStorageKey, launchConfig);
       loadedHistoryRef.current.delete(created.id);
       optimisticSessionIdsRef.current.add(created.id);
@@ -9314,17 +9199,26 @@ export function AgentChatPane({
       };
     }
     if (!laneId) throw new Error("Select a lane before launching.");
-    const launchLane = draftExecutionLanesRef.current.find((candidate) => candidate.id === laneId)
-      ?? lanes.find((candidate) => candidate.id === laneId);
+    const routedLaunchLane = draftExecutionLanesRef.current.find((candidate) => candidate.id === laneId);
+    const launchLane = routedLaunchLane
+      ?? (
+        draftExecutionMachineIdRef.current === draftBoundMachineIdRef.current
+          ? (availableLanes ?? lanes).find((candidate) => candidate.id === laneId)
+          : undefined
+      );
+    if (!launchLane && draftExecutionMachineIdRef.current !== draftBoundMachineIdRef.current) {
+      throw new Error("Selected lane is not available on the selected machine. Choose a lane for that machine.");
+    }
     const laneName = launchLane?.name ?? laneDisplayLabel ?? laneId;
     return {
       laneId,
       laneName,
-      worktreePath: launchLane?.worktreePath ?? projectRoot ?? null,
+      worktreePath: routedLaunchLane?.worktreePath ?? projectRoot ?? null,
       autoCreated: false,
     };
   }, [
     canRefreshPinnedProject,
+    availableLanes,
     draftLaunchTargetIsAutoCreate,
     laneDisplayLabel,
     laneId,
@@ -10515,7 +10409,7 @@ export function AgentChatPane({
             modelId: slot.modelId,
             sessionProfile: resolveChatSessionProfile(),
             reasoningEffort: slot.reasoningEffort,
-            ...(modelSupportsFastMode(desc) ? { fastMode: slot.fastMode } : {}),
+            fastMode: slot.fastMode,
             ...buildNativeControlPayloadForSlot(slot, provider),
           }, launchBinding);
           sessionByLane.set(childLane.id, created.id);
@@ -10863,8 +10757,7 @@ export function AgentChatPane({
         && selectedSessionModelId !== modelId;
       const selectedFastModeChanged =
         Boolean(selectedSessionId)
-        && selectedSession?.provider === "codex"
-        && (selectedSession.fastMode === true) !== fastMode;
+        && (selectedSession?.fastMode === true) !== fastMode;
       const selectedAttachments = isLiteralSlashCommand ? [] : attachmentsSnapshot;
       const selectedContextAttachments = isLiteralSlashCommand ? [] : contextAttachmentsSnapshot;
       const optimisticEnvelope = (nextSessionId: string): AgentChatEventEnvelope => ({
@@ -10890,14 +10783,12 @@ export function AgentChatPane({
         || shouldPromoteLightSession
       )) {
         setOptimisticIfAllowed(sessionId);
-        const desc = resolveScopedModelDescriptor(modelId, modelCatalogScopeKey);
-        const provider = resolveChatRuntimeProvider(desc);
+        const modelUpdate = selectedModelChanged ? { modelId } : {};
+        const fastModeUpdate = selectedFastModeChanged ? { fastMode } : {};
         await window.ade.agentChat.updateSession({
           sessionId,
-          modelId,
-          reasoningEffort,
-          ...(modelSupportsFastMode(desc) ? { fastMode } : {}),
-          ...buildNativeControlPayload(provider),
+          ...modelUpdate,
+          ...fastModeUpdate,
         }, chatRuntimePinRef.current);
         void refreshSessions().catch(() => {});
       } else if (!sessionId) {
@@ -11658,10 +11549,7 @@ export function AgentChatPane({
   // machine-qualified option ids the combined selector needed.
   // Auto-create means the same thing on Cursor Cloud as it does here — ADE makes the lane, the
   // agent works in it — so the lane picker is identical either way. Only the machine differs.
-  const draftShelfLanes = useMemo(
-    () => [AUTO_CREATE_LANE_OPTION, ...draftExecutionLanes],
-    [draftExecutionLanes],
-  );
+  const draftShelfLanes = draftLaneSelectorLanes;
   const draftShelfLaneValue = draftLaunchTargetIsAutoCreate
     ? AUTO_CREATE_LANE_OPTION.id
     : (laneId ?? "");
@@ -11714,6 +11602,8 @@ export function AgentChatPane({
     handleDraftMachineChange(nextMachineId);
   }, [handleDraftMachineChange, setCursorCloudMode]);
   draftExecutionLanesRef.current = draftExecutionLanes;
+  draftExecutionMachineIdRef.current = selectedDraftMachineId;
+  draftBoundMachineIdRef.current = boundLaneMachineId;
   draftExecutionBindingRef.current = draftExecutionBinding;
   draftExecutionBindingRequiredRef.current = showDraftLaunchControls;
   draftMachineUnavailableRef.current = draftMachineUnavailable;
@@ -13073,23 +12963,10 @@ export function AgentChatPane({
               }
 
               setSessionMutationKind("model");
-              const nextOpenCodeModeForPayload = snapshot.resetOpenCodePermissionToDefault
-                ? (snapshot.nextOpenCodePermissionMode ?? initialNativeControls.opencodePermissionMode)
-                : snapshot.nextOpenCodePermissionMode;
-              const nextNativeControlPayload = snapshot.nextProvider === "opencode" && nextOpenCodeModeForPayload != null
-                ? {
-                    ...summarizeNativeControls("opencode", {
-                      ...currentNativeControls,
-                      opencodePermissionMode: nextOpenCodeModeForPayload,
-                    }),
-                  }
-                : buildNativeControlPayload(snapshot.nextProvider);
               void window.ade.agentChat.updateSession({
                 sessionId: selectedSessionId,
                 modelId: nextModelId,
-                reasoningEffort: snapshot.nextReasoningEffort,
-                ...(modelSupportsFastMode(snapshot.nextDesc) ? { fastMode: fastModeRef.current } : {}),
-                ...nextNativeControlPayload,
+                ...(options ? { fastMode: fastModeRef.current } : {}),
               }, chatRuntimePinRef.current).then((updatedSession) => {
                 applyModelSelectionSnapshot(snapshot);
                 patchSessionSummary(selectedSessionId, {
@@ -13127,7 +13004,7 @@ export function AgentChatPane({
                 void refreshSessions().catch(() => {});
               }).catch((err) => {
                 setModelId(previousModelId);
-                setFastModeState(previousFastMode);
+                if (options) setFastModeState(previousFastMode);
                 void refreshSessions().catch(() => {});
                 setError(err instanceof Error ? err.message : String(err));
               }).finally(() => {
@@ -13333,35 +13210,9 @@ export function AgentChatPane({
             }}
             onParallelSlotModelChange={(index, nextModelId, options) => {
               if (modelSelectionConstrained && !effectiveAvailableModelIds.includes(nextModelId)) return;
-              const desc = resolveScopedModelDescriptor(nextModelId, modelCatalogScopeKey);
-              const tiers = desc?.reasoningTiers ?? [];
-              const preferred = readLastUsedReasoningEffort({ laneId, modelId: nextModelId });
-              const nextEffort = selectReasoningEffort({
-                tiers,
-                preferred,
-                modelId: nextModelId,
-                catalogScopeKey: modelCatalogScopeKey,
-              });
-              const previousPermissionDesc = getModelDescriptorForPermissionMode(parallelModelSlots[index]?.modelId ?? "");
-              const nextPermissionDesc = getModelDescriptorForPermissionMode(nextModelId);
-              const nextRecommendedOpenCodeMode = recommendedOpenCodePermissionModeForModel(nextPermissionDesc);
-              const resetOpenCodePermissionToDefault = shouldResetOpenCodePermissionForModelSwitch(
-                previousPermissionDesc,
-                nextPermissionDesc,
-              );
-              const nextExecOpts = getExecutionModeOptions(desc);
               patchParallelSlot(index, {
                 modelId: nextModelId,
-                reasoningEffort: nextEffort,
                 ...(options ? { fastMode: options.fastMode } : {}),
-                executionMode: nextExecOpts.some((o) => o.value === parallelModelSlots[index]?.executionMode)
-                  ? parallelModelSlots[index]!.executionMode
-                  : (nextExecOpts[0]?.value ?? "focused"),
-                ...(resetOpenCodePermissionToDefault
-                  ? {
-                    opencodePermissionMode: nextRecommendedOpenCodeMode ?? initialNativeControls.opencodePermissionMode,
-                  }
-                  : {}),
               });
             }}
             onParallelSlotReasoningChange={(index, effort) => {

--- a/apps/desktop/src/renderer/components/chat/ChatModelSelectionPendingCard.tsx
+++ b/apps/desktop/src/renderer/components/chat/ChatModelSelectionPendingCard.tsx
@@ -114,7 +114,6 @@ export const ChatModelSelectionPendingCard = memo(function ChatModelSelectionPen
     filesHint: metadata?.filesHint ?? [],
     dependsOn: metadata?.dependsOn ?? [],
   });
-
   const descriptor = resolveModelDescriptorWithRuntimeCatalog(
     modelId,
     catalogScopeKey ?? DEFAULT_RUNTIME_CATALOG_SCOPE,
@@ -127,12 +126,6 @@ export const ChatModelSelectionPendingCard = memo(function ChatModelSelectionPen
     setReasoningEffort(null);
     setFastMode(false);
   }, [fallbackProvider, requestKey]);
-
-  // Clear fast mode when the picked model doesn't support it, so a stale toggle
-  // can't be submitted after switching to an unsupported model.
-  useEffect(() => {
-    if (!fastModeSupported && fastMode) setFastMode(false);
-  }, [fastModeSupported, fastMode]);
 
   // When the user picks a different model, infer the new provider from the
   // model registry or runtime-catalog prefix so the dispatched ModelSelection
@@ -149,7 +142,7 @@ export const ChatModelSelectionPendingCard = memo(function ChatModelSelectionPen
       provider,
       modelId,
       ...(reasoningEffort !== null ? { reasoningEffort } : {}),
-      ...(fastMode && fastModeSupported ? { fastMode: true } : {}),
+      ...(fastMode ? { fastMode: true } : {}),
     };
     onConfirm(selection);
   }, [provider, modelId, reasoningEffort, fastMode, fastModeSupported, onConfirm]);

--- a/apps/desktop/src/renderer/components/chat/useDraftMachineRouting.ts
+++ b/apps/desktop/src/renderer/components/chat/useDraftMachineRouting.ts
@@ -11,9 +11,7 @@ import {
   AUTO_CREATE_LANE_OPTION_ID,
   autoCreateLaneOptionId,
   isAutoCreateLaneOptionId,
-  machineIdFromAutoCreateLaneOptionId,
   machineLaneFromOptionId,
-  machineLaneOptionId,
   type LaneComboboxLane,
   type LaneComboboxMachine,
 } from "../terminals/LaneCombobox";
@@ -235,23 +233,26 @@ export function useDraftMachineRouting({
     );
   }, [boundMachineId, chooseMachine, initialDraftMachineId, machineId, machineOptions]);
 
+  const executionLanes = lanesByMachineId.get(machineId) ?? [];
+  const preservedLane = laneId
+    ? Array.from(lanesByMachineId.values()).flat().find((candidate) => candidate.id === laneId) ?? {
+        id: laneId,
+        name: laneId,
+        color: null,
+        branchRef: null,
+      }
+    : null;
   const selectorLanes = useMemo<RoutedDraftLane[]>(() => {
     if (!enabled) return (availableLanes ?? lanes) as RoutedDraftLane[];
-    const routed = machineOptions.flatMap(
-      (machine) => lanesByMachineId.get(machine.id) ?? [],
-    );
-    return [AUTO_CREATE_DRAFT_LANE_OPTION, ...routed];
-  }, [availableLanes, enabled, lanes, lanesByMachineId, machineOptions]);
+    const unavailableLane = preservedLane && !executionLanes.some((candidate) => candidate.id === preservedLane.id)
+      ? [{
+          ...preservedLane,
+          name: `${preservedLane.name} (unavailable on selected machine)`,
+        }]
+      : [];
+    return [AUTO_CREATE_DRAFT_LANE_OPTION, ...unavailableLane, ...executionLanes];
+  }, [availableLanes, enabled, executionLanes, lanes, preservedLane]);
 
-  const primaryLaneForMachine = useCallback((candidateMachineId: string) => {
-    const machineLanes = lanesByMachineId.get(candidateMachineId) ?? [];
-    return machineLanes.find((candidate) => candidate.laneType === "primary")
-      ?? machineLanes.find((candidate) => candidate.name.trim().toLowerCase() === "primary")
-      ?? machineLanes[0]
-      ?? null;
-  }, [lanesByMachineId]);
-
-  const executionLanes = lanesByMachineId.get(machineId) ?? [];
   const selectedLane = executionLanes.find((candidate) => candidate.id === laneId) ?? null;
   const selectedLaneIsPrimary = selectedLane?.laneType === "primary"
     || selectedLane?.name.trim().toLowerCase() === "primary";
@@ -305,102 +306,42 @@ export function useDraftMachineRouting({
   ]);
 
   const selectorValue = draftLaunchTargetIsAutoCreate
-    ? autoCreateLaneOptionId(
-      selectorMachines.length < 2 || machineId === selectorMachines[0]?.id
-        ? null
-        : machineId,
-    )
+    ? autoCreateLaneOptionId(null)
     : (
-      laneId && selectorMachines.length > 0
-        ? machineLaneOptionId(machineId, laneId)
-        : (laneId ?? "")
+      laneId && (executionLanes.some((candidate) => candidate.id === laneId) || preservedLane?.id === laneId)
+        ? laneId
+        : ""
     );
 
-  /**
-   * Switching machines re-points the lane, but how far depends on what was
-   * selected. Auto-create and the primary lane are the two targets ADE
-   * guarantees exist on every machine running it, so a selection sitting on
-   * either is still meaningful after the switch and is preserved — primary
-   * re-points to the new machine's own primary (same role, different lane id),
-   * and auto-create needs no re-pointing at all. Any other lane is specific to
-   * the machine it was created on and cannot follow, so it lands on that
-   * machine's primary instead of leaving the picker pointing at a lane that
-   * does not exist there.
-   */
   const handleMachineChange = useCallback((nextMachineId: string) => {
     const nextMachine = machineOptions.find((candidate) => candidate.id === nextMachineId);
     if (!nextMachine) return;
     setError(null);
-    const wasAutoCreate = draftLaunchTargetIsAutoCreate;
     chooseMachine(nextMachineId);
-
-    const fallback = primaryLaneForMachine(nextMachineId);
-    if (fallback) {
-      onLaneChange?.(fallback.id);
-    }
-    // Re-assert auto-create *after* re-pointing the lane. `onLaneChange` moves
-    // the lane pointer to the new machine's primary, and a bare lane pointer
-    // reads as "a specific lane is selected" — which would silently convert an
-    // auto-create draft into a primary-lane draft, change the composer's draft
-    // key, and discard whatever the user had typed. A machine with no lanes at
-    // all lands here too: auto-create is the one target always launchable.
-    if (wasAutoCreate || !fallback) {
-      setDraftLaunchTargetId(AUTO_CREATE_LANE_OPTION_ID);
-    }
   }, [
     chooseMachine,
-    draftLaunchTargetIsAutoCreate,
     machineOptions,
-    onLaneChange,
-    primaryLaneForMachine,
-    setDraftLaunchTargetId,
     setError,
   ]);
 
   const handleLaneSelectionChange = useCallback((nextLaneId: string) => {
     if (isAutoCreateLaneOptionId(nextLaneId)) {
       setDraftLaunchTargetId(AUTO_CREATE_LANE_OPTION_ID);
-      // A bare auto-create id carries no machine. That used to mean "the first
-      // machine", which was right when one grouped list owned both choices —
-      // every auto-create row was machine-qualified. The shelf now picks the
-      // machine in its own control and passes bare ids, so defaulting here
-      // would silently drag the selection back to the bound machine. Keep
-      // whatever the machine picker already chose.
-      const explicitMachineId = machineIdFromAutoCreateLaneOptionId(nextLaneId);
-      const machineIsAvailable = (candidate: string | null | undefined) =>
-        Boolean(candidate && machineOptions.some((option) => option.id === candidate));
-      const nextMachineId = machineIsAvailable(explicitMachineId)
-        ? explicitMachineId!
-        : machineIsAvailable(machineId)
-          ? machineId
-          : (
-              machineOptions.find((option) => option.isBound)?.id
-              ?? machineOptions[0]?.id
-              ?? boundMachineId
-            );
-      chooseMachine(nextMachineId);
-      const primary = primaryLaneForMachine(nextMachineId);
-      if (primary) onLaneChange?.(primary.id);
       return;
     }
     const routed = machineLaneFromOptionId(nextLaneId);
     const actualLaneId = routed?.laneId ?? nextLaneId;
-    const selectedMachineId = routed?.machineId ?? machineId;
-    const nextLane = lanesByMachineId.get(selectedMachineId)?.find(
+    if (routed?.machineId && routed.machineId !== machineId) return;
+    const nextLane = lanesByMachineId.get(machineId)?.find(
       (candidate) => candidate.id === actualLaneId,
     );
     if (!nextLane) return;
-    chooseMachine(selectedMachineId);
     setDraftLaunchTargetId(null);
     onLaneChange?.(actualLaneId);
   }, [
-    chooseMachine,
-    boundMachineId,
     lanesByMachineId,
     machineId,
-    machineOptions,
     onLaneChange,
-    primaryLaneForMachine,
     setDraftLaunchTargetId,
   ]);
 

--- a/apps/desktop/src/renderer/components/cto/CtoPage.tsx
+++ b/apps/desktop/src/renderer/components/cto/CtoPage.tsx
@@ -173,11 +173,14 @@ export function CtoPage({ active = true }: { active?: boolean } = {}) {
     setError(null);
     try {
       if (session) {
+        const modelUpdate = selection.modelId === session.modelId
+          ? { reasoningEffort: selection.reasoningEffort }
+          : {};
         const updated = await window.ade.agentChat.updateSession({
           sessionId: session.id,
           modelId: selection.modelId,
-          reasoningEffort: selection.reasoningEffort,
-          fastMode: selection.supportsFastMode && currentFastMode,
+          ...modelUpdate,
+          fastMode: currentFastMode,
         });
         ctoPrimarySession = updated;
         setSession(updated);

--- a/apps/desktop/src/renderer/components/cto/CtoSettingsPanel.tsx
+++ b/apps/desktop/src/renderer/components/cto/CtoSettingsPanel.tsx
@@ -8,7 +8,6 @@ import { CtoPromptPreview } from "./CtoPromptPreview";
 import { TimelineEntry } from "./shared/TimelineEntry";
 import { ModelPicker } from "../shared/ModelPicker/ModelPicker";
 import { ReasoningEffortPicker } from "../shared/ModelPicker/ReasoningEffortPicker";
-import { resolveModelSelection } from "./useCtoModelOptions";
 
 function Section({
   title,
@@ -80,8 +79,7 @@ export function CtoSettingsPanel({
             fastModeActive={currentFastMode}
             onFastModeToggle={onFastModeChange}
             onChange={(modelId) => {
-              const selection = resolveModelSelection(modelId, currentReasoningEffort);
-              onModelChange(modelId, selection?.reasoningEffort ?? null);
+              onModelChange(modelId, currentReasoningEffort);
             }}
             onOpenSignIn={onOpenProviderSettings}
           />

--- a/apps/desktop/src/renderer/components/cto/ctoUi.test.tsx
+++ b/apps/desktop/src/renderer/components/cto/ctoUi.test.tsx
@@ -161,8 +161,7 @@ describe("CtoPage settings", () => {
     expect(updateSession).toHaveBeenCalledWith({
       sessionId: "cto-session",
       modelId: "anthropic/claude-opus-4-8",
-      reasoningEffort: null,
-      fastMode: false,
+      fastMode: true,
     });
   });
 

--- a/apps/desktop/src/renderer/components/cto/useCtoModelOptions.ts
+++ b/apps/desktop/src/renderer/components/cto/useCtoModelOptions.ts
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
-import { getModelById, modelSupportsFastMode, selectSupportedReasoningEffort } from "../../../shared/modelRegistry";
+import { getModelById, modelSupportsFastMode } from "../../../shared/modelRegistry";
 import { deriveConfiguredModelIds } from "../../lib/modelOptions";
 import { settingsRouteFor } from "../settings/settingsManifest";
 
@@ -11,20 +11,6 @@ export type CtoModelSelection = {
   reasoningEffort: string | null;
   supportsFastMode: boolean;
 };
-
-/** Reasoning tier the model supports closest to the caller's preference. */
-export function pickReasoningEffort(
-  modelId: string | null | undefined,
-  preferred: string | null | undefined,
-): string | null {
-  const descriptor = modelId ? getModelById(modelId) : undefined;
-  const tiers = descriptor?.reasoningTiers ?? [];
-  return selectSupportedReasoningEffort({
-    tiers,
-    preferred,
-    advertisedDefault: descriptor?.defaultReasoningEffort,
-  });
-}
 
 /** Resolve a full model selection (provider/model/reasoning) from a model id. */
 export function resolveModelSelection(
@@ -37,7 +23,9 @@ export function resolveModelSelection(
     provider: descriptor.family,
     model: descriptor.shortId ?? descriptor.id.split("/").pop() ?? descriptor.id,
     modelId: descriptor.id,
-    reasoningEffort: pickReasoningEffort(descriptor.id, preferredReasoning),
+    // A model choice must not rewrite the selected thinking level. Runtime
+    // capability handling belongs to launch; the raw preference stays visible.
+    reasoningEffort: preferredReasoning ?? null,
     supportsFastMode: modelSupportsFastMode(descriptor),
   };
 }

--- a/apps/desktop/src/renderer/components/personalChats/PersonalChatsPage.tsx
+++ b/apps/desktop/src/renderer/components/personalChats/PersonalChatsPage.tsx
@@ -17,7 +17,6 @@ import type {
 import {
   getModelById,
   getRuntimeModelRefForDescriptor,
-  modelSupportsFastMode,
   resolveProviderGroupForModel,
   type ModelDescriptor,
 } from "../../../shared/modelRegistry";
@@ -518,7 +517,7 @@ export function PersonalChatsPage({ standalone = false }: { standalone?: boolean
   }, [selectedSession?.sessionId]);
 
   useEffect(() => {
-    if (availableModelIds.includes(modelId)) return;
+    if (modelId.trim().length > 0) return;
     const fallback = availableModelIds[0];
     if (fallback) setModelId(fallback);
   }, [availableModelIds, modelId]);
@@ -553,7 +552,7 @@ export function PersonalChatsPage({ standalone = false }: { standalone?: boolean
       modelId: descriptor.id,
       reasoningEffort,
       permissionMode,
-      fastMode: modelSupportsFastMode(descriptor) ? fastMode : false,
+      fastMode,
       title: null,
     });
     await refreshSessions();

--- a/apps/desktop/src/renderer/components/prs/shared/PrResolverLaunchControls.test.tsx
+++ b/apps/desktop/src/renderer/components/prs/shared/PrResolverLaunchControls.test.tsx
@@ -100,7 +100,7 @@ describe("PrResolverLaunchControls", () => {
     expect(props.onPermissionModeChange).toHaveBeenCalledWith("config-toml");
   });
 
-  it("normalizes reasoning and permissions when switching models", async () => {
+  it("changes only the model when switching models", async () => {
     const user = userEvent.setup();
     const props = renderControls({
       modelId: "anthropic/claude-opus-4-8",
@@ -111,7 +111,7 @@ describe("PrResolverLaunchControls", () => {
     await user.click(screen.getByRole("button", { name: "Pick Sonnet" }));
 
     expect(props.onModelChange).toHaveBeenCalledWith("anthropic/claude-sonnet-5");
-    expect(props.onReasoningEffortChange).toHaveBeenCalledWith("medium");
-    expect(props.onPermissionModeChange).toHaveBeenCalledWith("default");
+    expect(props.onReasoningEffortChange).not.toHaveBeenCalled();
+    expect(props.onPermissionModeChange).not.toHaveBeenCalled();
   });
 });

--- a/apps/desktop/src/renderer/components/prs/shared/PrResolverLaunchControls.tsx
+++ b/apps/desktop/src/renderer/components/prs/shared/PrResolverLaunchControls.tsx
@@ -2,7 +2,6 @@ import React from "react";
 import {
   getModelById,
   resolveProviderGroupForModel,
-  selectSupportedReasoningEffort,
   type ModelDescriptor,
   type ModelProviderGroup,
 } from "../../../../shared/modelRegistry";
@@ -35,15 +34,6 @@ type PrResolverLaunchControlsProps = PrResolverLaunchControlsBaseProps & (
       onPermissionModeChange: (mode: AiPermissionMode) => void;
     }
 );
-
-function selectReasoningEffortForModel(descriptor: ModelDescriptor | undefined, current: string): string {
-  const tiers = descriptor?.reasoningTiers ?? [];
-  return selectSupportedReasoningEffort({
-    tiers,
-    preferred: current,
-    advertisedDefault: descriptor?.defaultReasoningEffort,
-  }) ?? "";
-}
 
 function permissionOptionsForModel(descriptor: ModelDescriptor | undefined, valueMode: "chat" | "legacy" = "chat") {
   const family = descriptor?.family ?? "opencode";
@@ -170,21 +160,8 @@ export function PrResolverLaunchControls({
   }, [onPermissionModeChange, permissionValueMode, providerGroup]);
 
   const handleModelChange = React.useCallback((nextModelId: string) => {
-    const nextDescriptor = getModelById(nextModelId);
-    const nextReasoning = selectReasoningEffortForModel(nextDescriptor, reasoningEffort);
-    const nextAgentPermission = normalizePermissionModeForModel(permissionMode, nextDescriptor, permissionValueMode);
-    const nextPermission = permissionValueMode === "legacy"
-      ? toLegacyPermissionMode(nextAgentPermission, nextDescriptor ? resolveProviderGroupForModel(nextDescriptor) : "opencode")
-      : nextAgentPermission;
-
     onModelChange(nextModelId);
-    if (nextReasoning !== reasoningEffort) {
-      onReasoningEffortChange(nextReasoning);
-    }
-    if (nextPermission !== permissionMode) {
-      onPermissionModeChange(nextPermission as AiPermissionMode & PrAgentPermissionMode);
-    }
-  }, [onModelChange, onPermissionModeChange, onReasoningEffortChange, permissionMode, permissionValueMode, reasoningEffort]);
+  }, [onModelChange]);
 
   return (
     <div className={cn("flex flex-wrap items-center gap-3", className)}>

--- a/apps/desktop/src/renderer/components/shared/ModelPicker/ModelPicker.test.tsx
+++ b/apps/desktop/src/renderer/components/shared/ModelPicker/ModelPicker.test.tsx
@@ -801,7 +801,7 @@ describe("ModelPicker", () => {
     expect(trigger.getAttribute("aria-expanded")).toBe("true");
   });
 
-  it("clears a stale fast bit when a different model is picked by a plain row click", async () => {
+  it("preserves fast mode when a different model is picked by a plain row click", async () => {
     const user = userEvent.setup();
     const onChange = vi.fn();
     const onFastModeChange = vi.fn();
@@ -823,7 +823,7 @@ describe("ModelPicker", () => {
     await user.click(slowRow);
 
     expect(onChange).toHaveBeenCalledTimes(1);
-    expect(onChange).toHaveBeenCalledWith(SLOW_GPT.id, { fastMode: false });
+    expect(onChange).toHaveBeenCalledWith(SLOW_GPT.id);
     expect(onFastModeChange).not.toHaveBeenCalled();
   });
 

--- a/apps/desktop/src/renderer/components/shared/ModelPicker/ModelPickerContent.tsx
+++ b/apps/desktop/src/renderer/components/shared/ModelPicker/ModelPickerContent.tsx
@@ -551,13 +551,9 @@ export const ModelPickerContent = memo(function ModelPickerContent({
   const handleRowSelect = useCallback(
     (modelId: string) => {
       recordUsage(modelId);
-      // Fast mode belongs to the model it was enabled for, so a plain switch to
-      // a different model starts clean instead of inheriting the previous
-      // model's bit. The fast chip re-enables it explicitly (see
-      // `handleFastChipChange`).
-      onSelect(modelId, modelId !== value && fastMode ? { fastMode: false } : undefined);
+      onSelect(modelId);
     },
-    [fastMode, onSelect, recordUsage, value],
+    [onSelect, recordUsage],
   );
 
   const handleListKeyDown = useCallback(

--- a/apps/desktop/src/renderer/components/shared/ModelSelector.tsx
+++ b/apps/desktop/src/renderer/components/shared/ModelSelector.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useMemo } from "react";
 import type { ModelConfig, ModelProvider, ThinkingLevel } from "../../../shared/types";
-import { getModelById, resolveModelDescriptor, selectSupportedReasoningEffort } from "../../../shared/modelRegistry";
+import { getModelById, resolveModelDescriptor } from "../../../shared/modelRegistry";
 import { ModelPicker } from "./ModelPicker/ModelPicker";
 import { ReasoningEffortPicker } from "./ModelPicker/ReasoningEffortPicker";
 
@@ -51,19 +51,12 @@ export function ModelSelector({
   const handleModelChange = useCallback((modelId: string) => {
     const normalizedId = normalizeModelId(modelId);
     const provider = providerFromFamily(normalizedId);
-    const descriptor = getModelById(normalizedId);
-    const tiers = descriptor?.reasoningTiers ?? [];
-    const currentThinking = toThinkingLevel(selectSupportedReasoningEffort({
-      tiers,
-      preferred: value.thinkingLevel,
-      advertisedDefault: descriptor?.defaultReasoningEffort,
-    }));
     onChange({
+      ...value,
       modelId: normalizedId,
-      ...(currentThinking ? { thinkingLevel: currentThinking } : {}),
       ...(provider ? { provider } : {}),
     });
-  }, [onChange, value.thinkingLevel]);
+  }, [onChange, value]);
 
   const handleReasoningChange = useCallback((nextReasoning: string | null) => {
     const provider = providerFromFamily(resolvedModelId);

--- a/apps/desktop/src/renderer/components/shared/ReviewLaunchModelControls.test.tsx
+++ b/apps/desktop/src/renderer/components/shared/ReviewLaunchModelControls.test.tsx
@@ -22,7 +22,7 @@ afterEach(() => {
 });
 
 describe("ReviewLaunchModelControls", () => {
-  it("clamps Sol Ultra to Luna's medium default when the model changes", () => {
+  it("preserves Sol Ultra when the model changes", () => {
     (window as unknown as { ade: unknown }).ade = {
       ai: { getStatus: vi.fn().mockResolvedValue(null) },
     };
@@ -41,7 +41,6 @@ describe("ReviewLaunchModelControls", () => {
 
     expect(onModelChange).toHaveBeenCalledTimes(1);
     expect(onModelChange).toHaveBeenCalledWith("openai/gpt-5.6-luna");
-    expect(onReasoningEffortChange).toHaveBeenCalledTimes(1);
-    expect(onReasoningEffortChange).toHaveBeenCalledWith("medium");
+    expect(onReasoningEffortChange).not.toHaveBeenCalled();
   });
 });

--- a/apps/desktop/src/renderer/components/shared/ReviewLaunchModelControls.tsx
+++ b/apps/desktop/src/renderer/components/shared/ReviewLaunchModelControls.tsx
@@ -1,6 +1,5 @@
 import React from "react";
 import type { AiSettingsStatus } from "../../../shared/types";
-import { resolveModelDescriptor, selectSupportedReasoningEffort } from "../../../shared/modelRegistry";
 import { deriveConfiguredModelIds } from "../../lib/modelOptions";
 import { ModelPicker } from "./ModelPicker/ModelPicker";
 import { ReasoningEffortPicker } from "./ModelPicker/ReasoningEffortPicker";
@@ -30,16 +29,8 @@ export function ReviewLaunchModelControls({
   const [availableModelIds, setAvailableModelIds] = React.useState<string[]>([]);
 
   const handleModelChange = React.useCallback((nextModelId: string) => {
-    const descriptor = resolveModelDescriptor(nextModelId);
-    const tiers = descriptor?.reasoningTiers ?? [];
-    const nextReasoning = selectSupportedReasoningEffort({
-      tiers,
-      preferred: reasoningEffort,
-      advertisedDefault: descriptor?.defaultReasoningEffort,
-    }) ?? "";
     onModelChange(nextModelId);
-    if (nextReasoning !== reasoningEffort) onReasoningEffortChange(nextReasoning);
-  }, [onModelChange, onReasoningEffortChange, reasoningEffort]);
+  }, [onModelChange]);
 
   React.useEffect(() => {
     let cancelled = false;

--- a/apps/desktop/src/renderer/components/terminals/WorkStartSurface.tsx
+++ b/apps/desktop/src/renderer/components/terminals/WorkStartSurface.tsx
@@ -71,11 +71,6 @@ export function WorkStartSurface({
   const boundMachineId = projectBinding?.kind === "remote"
     ? projectBinding.targetId
     : "this-mac";
-  const draftMachinePending = Boolean(
-    draftMachineId
-    && draftMachineId !== boundMachineId
-    && !crossMachineLanesByMachineId[draftMachineId],
-  );
   const laneForMachine = useCallback((machineId: string | null, laneId: string) => {
     const resolvedMachineId = machineId ?? boundMachineId;
     if (resolvedMachineId === boundMachineId) {
@@ -91,10 +86,7 @@ export function WorkStartSurface({
     [draftMachineId, laneForMachine],
   );
   const [selectedLaneId, setSelectedLaneId] = useState<string>(() => {
-    if (isKnownLaneId(draftLaneId)) {
-      return draftLaneId;
-    }
-    if (draftMachinePending && draftLaneId) {
+    if (draftLaneId) {
       return draftLaneId;
     }
     if (isKnownLaneId(globallySelectedLaneId)) {
@@ -105,9 +97,9 @@ export function WorkStartSurface({
   const [launchBusy, setLaunchBusy] = useState(false);
   const selectedLane = useMemo(
     () => laneForMachine(draftMachineId, selectedLaneId)
-      ?? (draftMachinePending ? null : lanes[0])
+      ?? (selectedLaneId ? null : lanes[0])
       ?? null,
-    [draftMachineId, draftMachinePending, laneForMachine, lanes, selectedLaneId],
+    [draftMachineId, laneForMachine, lanes, selectedLaneId],
   );
 
   const setLaneAndSync = useCallback((laneId: string) => {
@@ -123,18 +115,14 @@ export function WorkStartSurface({
       setSelectedLaneId("");
       return;
     }
-    if (draftLaneId && draftLaneId !== selectedLaneId && isKnownLaneId(draftLaneId)) {
+    if (draftLaneId && draftLaneId !== selectedLaneId) {
       setSelectedLaneId(draftLaneId);
       if (!draftMachineId || draftMachineId === boundMachineId) {
         selectLaneGlobal(draftLaneId);
       }
       return;
     }
-    if (draftMachinePending && draftLaneId) {
-      if (selectedLaneId !== draftLaneId) setSelectedLaneId(draftLaneId);
-      return;
-    }
-    if (!selectedLaneId || !isKnownLaneId(selectedLaneId)) {
+    if (!selectedLaneId) {
       const fallbackLaneId =
         draftLaneId && isKnownLaneId(draftLaneId)
           ? draftLaneId
@@ -150,7 +138,6 @@ export function WorkStartSurface({
   }, [
     draftLaneId,
     draftMachineId,
-    draftMachinePending,
     boundMachineId,
     globallySelectedLaneId,
     isKnownLaneId,

--- a/apps/ios/ADE/Views/Cto/CtoSettingsScreen.swift
+++ b/apps/ios/ADE/Views/Cto/CtoSettingsScreen.swift
@@ -101,12 +101,14 @@ struct CtoSettingsScreen: View {
           lanes: [],
           commandScope: .project,
           isBusy: modelUpdateInFlight,
-          onSelect: { option, reasoningEffort, _, fastMode in
+          onSelect: { option, pickedReasoning, _, pickedFastMode in
             Task { @MainActor in
+              let currentReasoning = currentReasoningEffort
+              let nextReasoning = pickedReasoning ?? ""
               await updateModel(
                 modelId: option.id,
-                reasoningEffort: reasoningEffort ?? "",
-                fastMode: option.supportsCodexFastMode ? fastMode : false
+                reasoningEffort: nextReasoning == currentReasoning ? nil : nextReasoning,
+                fastMode: pickedFastMode == currentFastMode ? nil : pickedFastMode
               )
             }
           }
@@ -215,7 +217,7 @@ struct CtoSettingsScreen: View {
   }
 
   @MainActor
-  private func updateModel(modelId: String, reasoningEffort: String, fastMode: Bool) async {
+  private func updateModel(modelId: String, reasoningEffort: String?, fastMode: Bool?) async {
     guard !modelUpdateInFlight else { return }
     modelUpdateInFlight = true
     errorMessage = nil

--- a/apps/ios/ADE/Views/Hub/HubComposerDrawer.swift
+++ b/apps/ios/ADE/Views/Hub/HubComposerDrawer.swift
@@ -120,8 +120,8 @@ struct HubInlineComposer: View {
     // in CLI — otherwise open on chat without discarding the preference. Seeding
     // the initial @State here keeps the sessionMode onChange from resetting
     // runtimeMode to the provider default. Switching the destination project
-    // inside the open drawer reloads this per-project mode (see
-    // `reloadSessionMode(forProjectId:)`).
+    // only updates the destination lane; the independent composer settings stay
+    // untouched until the user changes them.
     _sessionMode = State(initialValue: WorkNewSessionModePreferences.resolvedMode(
       stored: WorkNewSessionModePreferences.load(projectId: restoredProjectId),
       modelId: restoredModelId,
@@ -295,29 +295,6 @@ struct HubInlineComposer: View {
             !isDictating else { return }
       collapse()
     }
-    .onChange(of: provider) { _, newProvider in
-      runtimeMode = workDefaultRuntimeMode(provider: newProvider)
-      if !hubChatModelBelongs(modelId, to: hubNormalizedChatProvider(newProvider)) {
-        modelId = hubDefaultChatModelId(provider: newProvider)
-      }
-      if !modelSupportsReasoning(modelId: modelId, provider: newProvider) {
-        reasoningEffort = ""
-      }
-      if !fastModeSupported {
-        codexFastMode = false
-      }
-    }
-    .onChange(of: sessionMode) { _, newMode in
-      normalizeSelection(for: newMode)
-    }
-    .onChange(of: modelId) { _, newModel in
-      if !modelSupportsReasoning(modelId: newModel, provider: provider) {
-        reasoningEffort = ""
-      }
-      if !fastModeSupported {
-        codexFastMode = false
-      }
-    }
     .onChange(of: composerSelection) { _, newValue in
       WorkComposerPreferences.save(newValue)
     }
@@ -340,9 +317,9 @@ struct HubInlineComposer: View {
           provider = sessionMode == .chat
             ? hubNormalizedChatProvider(runtimeProvider)
             : workResolveCliProvider(for: option.id, provider: runtimeProvider)
-          reasoningEffort = pickedReasoning ?? ""
-          codexFastMode = option.supportsCodexFastMode ? pickedFastMode : false
-          runtimeMode = workDefaultRuntimeMode(provider: provider)
+          let nextReasoning = pickedReasoning ?? ""
+          if nextReasoning != reasoningEffort { reasoningEffort = nextReasoning }
+          if pickedFastMode != codexFastMode { codexFastMode = pickedFastMode }
         }
       )
       .environmentObject(syncService)
@@ -506,12 +483,8 @@ struct HubInlineComposer: View {
     return Button {
       guard project.id != pickedProjectId else { return }
       pickedProjectId = project.id
-      // Switching projects resets the lane to that project's default; the user
-      // can still tap a specific lane (or auto-create) below to confirm.
+      // Switching projects resets only that project's lane selection.
       selectedLaneId = defaultLaneId(forProjectId: project.id)
-      // …and restores that project's own last Chat/CLI choice so `submit` never
-      // branches on a stale mode from the previously targeted project.
-      reloadSessionMode(forProjectId: project.id)
     } label: {
       HStack(spacing: 9) {
         HubProjectIcon(iconDataUrl: project.iconDataUrl, isActive: isSelected)
@@ -758,14 +731,6 @@ struct HubInlineComposer: View {
 
   @MainActor
   private func onAppearSetup() {
-    // A restored selection (see init) can carry a model only valid in the mode
-    // it was last used in (e.g. a CLI-only Cursor model). The composer starts in
-    // .chat, so normalize only when the restored model is actually disallowed —
-    // a valid restored selection keeps its runtimeMode.
-    let availabilityMode: WorkCursorAvailabilityMode = sessionMode == .cli ? .cli : .chat
-    if !workModelAllowedForAvailabilityMode(modelId: modelId, provider: provider, mode: availabilityMode) {
-      normalizeSelection(for: sessionMode)
-    }
     if runtimeMode.isEmpty {
       runtimeMode = workDefaultRuntimeMode(provider: provider)
     }
@@ -799,6 +764,13 @@ struct HubInlineComposer: View {
     let rawText = rawOpener.trimmingCharacters(in: .whitespacesAndNewlines)
     let opener = workChatOutgoingText(rawOpener, attachmentCount: readyAttachments.count)
     guard canStart, !opener.isEmpty, !modelId.isEmpty else { return false }
+    let availabilityMode: WorkCursorAvailabilityMode = sessionMode == .cli ? .cli : .chat
+    guard workModelAllowedForAvailabilityMode(modelId: modelId, provider: provider, mode: availabilityMode) else {
+      errorMessage = sessionMode == .cli
+        ? "This model is available for chat only. Choose a CLI-capable model."
+        : "This model is available for CLI only. Choose a chat-capable model."
+      return false
+    }
     guard readyAttachments.isEmpty || canUploadAttachments else {
       errorMessage = "Reconnect to attach images."
       return false
@@ -898,9 +870,9 @@ struct HubInlineComposer: View {
           provider: provider,
           model: modelId,
           reasoningEffort: normalizedReasoning.isEmpty ? nil : normalizedReasoning,
-          // Send an explicit true/false when fast mode applies so the user's
-          // choice (including an explicit OFF) is honored; nil only when N/A.
-          codexFastMode: fastModeSupported ? codexFastMode : nil,
+          // Preserve the independent preference. Runtime capability checks
+          // belong at request construction, not in the composer state.
+          codexFastMode: codexFastMode,
           piProfileId: piMetadata?.profileId,
           piProviderId: piMetadata?.providerId,
           piModelId: piMetadata?.modelId,
@@ -1108,9 +1080,6 @@ struct HubInlineComposer: View {
       let resolvedProjectId = syncService.activeProject?.id ?? projects[0].id
       pickedProjectId = resolvedProjectId
       selectedLaneId = defaultLaneId(forProjectId: resolvedProjectId)
-      // The seeded mode was for the (now invalid) restored project; realign it
-      // with the project we actually fell back to.
-      reloadSessionMode(forProjectId: resolvedProjectId)
       return
     }
     if !isAutoCreateLane {
@@ -1118,22 +1087,6 @@ struct HubInlineComposer: View {
       if selectedLaneId.isEmpty || !lanes.contains(where: { $0.id == selectedLaneId }) {
         selectedLaneId = defaultLaneId(forProjectId: pickedProjectId)
       }
-    }
-  }
-
-  /// Reloads the per-project Chat/CLI interface when the destination project
-  /// changes, so the switcher and the mode `submit` branches on always reflect
-  /// the project actually being targeted (e.g. project A saved Chat, project B
-  /// saved CLI). Applies the same session-only availability fallback as init and
-  /// never writes the store — only an explicit switcher tap persists a choice.
-  private func reloadSessionMode(forProjectId projectId: String) {
-    let resolved = WorkNewSessionModePreferences.resolvedMode(
-      stored: WorkNewSessionModePreferences.load(projectId: projectId),
-      modelId: modelId,
-      provider: provider
-    )
-    if resolved != sessionMode {
-      sessionMode = resolved
     }
   }
 
@@ -1159,32 +1112,6 @@ struct HubInlineComposer: View {
     ADESharedContainer.defaults.set(data, forKey: HubInlineComposer.lastDestinationKey)
   }
 
-  // MARK: Composer normalization (self-contained mirrors of the new-chat screen)
-
-  private func normalizeSelection(for mode: WorkNewSessionMode) {
-    let availabilityMode: WorkCursorAvailabilityMode = mode == .cli ? .cli : .chat
-    if !workModelAllowedForAvailabilityMode(modelId: modelId, provider: provider, mode: availabilityMode),
-       let replacement = workDefaultModelIdForAvailabilityMode(preferredProvider: provider, mode: availabilityMode) {
-      modelId = replacement.modelId
-      provider = mode == .chat
-        ? hubNormalizedChatProvider(replacement.provider)
-        : workResolveCliProvider(for: replacement.modelId, provider: replacement.provider)
-    } else if mode == .chat {
-      provider = hubNormalizedChatProvider(provider)
-      if !hubChatModelBelongs(modelId, to: provider) {
-        modelId = hubDefaultChatModelId(provider: provider)
-      }
-    } else {
-      provider = workResolveCliProvider(for: modelId, provider: provider)
-    }
-    runtimeMode = workDefaultRuntimeMode(provider: provider)
-    if !modelSupportsReasoning(modelId: modelId, provider: provider) {
-      reasoningEffort = ""
-    }
-    if !fastModeSupported {
-      codexFastMode = false
-    }
-  }
 }
 
 // MARK: - File-private helpers (mirror the private new-chat-screen helpers)
@@ -1194,26 +1121,6 @@ struct HubInlineComposer: View {
 /// runtimes instead of silently routing to Claude.
 private func hubNormalizedChatProvider(_ provider: String) -> String {
   workNormalizedChatProvider(provider)
-}
-
-private func hubChatModelBelongs(_ modelId: String, to provider: String) -> Bool {
-  let trimmed = modelId.trimmingCharacters(in: .whitespacesAndNewlines)
-  guard !trimmed.isEmpty else { return false }
-  return workModelCatalogGroupKey(for: trimmed, currentProvider: provider) == provider
-}
-
-private func hubDefaultChatModelId(provider: String) -> String {
-  let family = providerFamilyKey(provider)
-  if let defaultModel = workDefaultCatalogModelId(provider: family) {
-    return defaultModel
-  }
-  switch hubNormalizedChatProvider(provider) {
-  case "codex": return workDefaultCatalogModelId(provider: "codex") ?? "gpt-5.6-sol"
-  case "cursor": return "auto"
-  case "opencode": return "opencode/anthropic/claude-sonnet-5"
-  case "pi": return ""
-  default: return "claude-sonnet-5"
-  }
 }
 
 /// CLI runtimes that accept a reasoning-effort selection (mirrors the new-chat

--- a/apps/ios/ADE/Views/Linear/LinearLaunchScreen.swift
+++ b/apps/ios/ADE/Views/Linear/LinearLaunchScreen.swift
@@ -113,17 +113,11 @@ struct LinearLaunchScreen: View {
           provider = sessionType == .cli
             ? workResolveCliProvider(for: option.id, provider: runtimeProvider)
             : runtimeProvider
-          reasoningEffort = pickedReasoning ?? ""
-          runtimeMode = workDefaultRuntimeMode(provider: provider)
-          codexFastMode = option.supportsCodexFastMode ? pickedFastMode : false
+          let nextReasoning = pickedReasoning ?? ""
+          if nextReasoning != reasoningEffort { reasoningEffort = nextReasoning }
+          if pickedFastMode != codexFastMode { codexFastMode = pickedFastMode }
         }
       )
-    }
-    .onAppear {
-      normalizeSelection(for: sessionType, resetRuntimeMode: false)
-    }
-    .onChange(of: sessionType) { _, newType in
-      normalizeSelection(for: newType)
     }
   }
 
@@ -219,42 +213,19 @@ struct LinearLaunchScreen: View {
     )
   }
 
-  private func normalizeSelection(for type: LinearLaunchSessionType, resetRuntimeMode: Bool = true) {
-    guard type.needsAgentConfig else {
-      codexFastMode = false
-      return
-    }
-
-    let availabilityMode: WorkCursorAvailabilityMode = type == .cli ? .cli : .chat
-    var replacedModel = false
-    if !workModelAllowedForAvailabilityMode(modelId: modelId, provider: provider, mode: availabilityMode),
-       let replacement = workDefaultModelIdForAvailabilityMode(preferredProvider: provider, mode: availabilityMode) {
-      modelId = replacement.modelId
-      modelName = linearPrettyModelName(replacement.modelId)
-      provider = type == .cli
-        ? workResolveCliProvider(for: replacement.modelId, provider: replacement.provider)
-        : replacement.provider
-      selectedModelOption = nil
-      replacedModel = true
-    } else if type == .cli {
-      provider = workResolveCliProvider(for: modelId, provider: provider)
-    }
-
-    if resetRuntimeMode || replacedModel || runtimeMode.isEmpty {
-      runtimeMode = workDefaultRuntimeMode(provider: provider)
-    }
-    if !modelSupportsReasoning(modelId: modelId, provider: provider) {
-      reasoningEffort = ""
-    }
-    if !fastModeSupported {
-      codexFastMode = false
-    }
-  }
-
   // MARK: Launch
 
   private func performLaunch() async {
     guard !busy else { return }
+    if sessionType.needsAgentConfig {
+      let availabilityMode: WorkCursorAvailabilityMode = sessionType == .cli ? .cli : .chat
+      guard workModelAllowedForAvailabilityMode(modelId: modelId, provider: provider, mode: availabilityMode) else {
+        errorMessage = sessionType == .cli
+          ? "This model is available for chat only. Choose a CLI-capable model."
+          : "This model is available for CLI only. Choose a chat-capable model."
+        return
+      }
+    }
     busy = true
     errorMessage = nil
     ADEHaptics.light()
@@ -283,7 +254,7 @@ struct LinearLaunchScreen: View {
           model: cfg.modelId,
           kickoffText: cfg.kickoff,
           reasoningEffort: cfg.reasoningEffort.isEmpty ? nil : cfg.reasoningEffort,
-          codexFastMode: fastSupported ? cfg.codexFastMode : nil,
+          codexFastMode: cfg.codexFastMode,
           permissionMode: wire.permissionMode,
           interactionMode: wire.interactionMode,
           claudePermissionMode: wire.claudePermissionMode,

--- a/apps/ios/ADE/Views/PersonalChats/PersonalChatsScreen.swift
+++ b/apps/ios/ADE/Views/PersonalChats/PersonalChatsScreen.swift
@@ -495,13 +495,13 @@ struct PersonalChatNewScreen: View {
         lanes: [],
         commandScope: .personal,
         isBusy: busy,
-        onSelect: { option, effort, runtimeProvider, fastMode in
+        onSelect: { option, pickedReasoning, runtimeProvider, pickedFastMode in
           selectedModelOption = option
           modelId = option.id
           provider = workNormalizedChatProvider(runtimeProvider)
-          reasoningEffort = effort ?? ""
-          codexFastMode = fastMode
-          runtimeMode = workDefaultRuntimeMode(provider: provider)
+          let nextReasoning = pickedReasoning ?? ""
+          if nextReasoning != reasoningEffort { reasoningEffort = nextReasoning }
+          if pickedFastMode != codexFastMode { codexFastMode = pickedFastMode }
           WorkComposerPreferences.save(
             provider: provider,
             modelId: modelId,
@@ -592,7 +592,7 @@ struct PersonalChatNewScreen: View {
         model: modelId,
         kickoffText: prompt,
         reasoningEffort: reasoningEffort.isEmpty ? nil : reasoningEffort,
-        codexFastMode: workComposerSupportsFastMode(modelId: modelId, provider: provider) ? codexFastMode : nil,
+        codexFastMode: codexFastMode,
         piProfileId: piMetadata?.profileId,
         piProviderId: piMetadata?.providerId,
         piModelId: piMetadata?.modelId,

--- a/apps/ios/ADE/Views/Work/WorkChatComposerAndInputViews.swift
+++ b/apps/ios/ADE/Views/Work/WorkChatComposerAndInputViews.swift
@@ -1833,8 +1833,13 @@ struct WorkModelSelectionPendingCard: View {
           selectedModel = option
           selectedModelId = option.id
           selectedProvider = provider
-          selectedReasoningEffort = pickedReasoning ?? ""
-          selectedCodexFastMode = option.supportsCodexFastMode ? pickedFastMode : false
+          let nextReasoning = pickedReasoning ?? ""
+          if nextReasoning != selectedReasoningEffort {
+            selectedReasoningEffort = nextReasoning
+          }
+          if pickedFastMode != selectedCodexFastMode {
+            selectedCodexFastMode = pickedFastMode
+          }
         }
       )
       .environmentObject(syncService)

--- a/apps/ios/ADE/Views/Work/WorkChatSessionView.swift
+++ b/apps/ios/ADE/Views/Work/WorkChatSessionView.swift
@@ -1976,8 +1976,8 @@ struct WorkChatSessionView: View {
                   await onSelectEffort(nextReasoning)
                 }
                 guard !Task.isCancelled else { return }
-                if option.supportsCodexFastMode || chatSummaryContext.effectiveFastMode != pickedFastMode {
-                  _ = await onSelectCodexFastMode(option.supportsCodexFastMode ? pickedFastMode : false)
+                if chatSummaryContext.effectiveFastMode != pickedFastMode {
+                  _ = await onSelectCodexFastMode(pickedFastMode)
                 }
               }
             }

--- a/apps/ios/ADE/Views/Work/WorkModelPickerSheet.swift
+++ b/apps/ios/ADE/Views/Work/WorkModelPickerSheet.swift
@@ -630,18 +630,8 @@ struct WorkModelPickerSheet: View {
   private func select(model: WorkModelOption) {
     guard model.isAvailable else { return }
 
-    let changedModel = !workModelIdsEquivalent(model.id, selectedModelId)
     selectedModelId = model.id
     selectedRuntimeProvider = runtimeProvider(for: model)
-    if changedModel {
-      selectedReasoningEffort = defaultReasoningEffort(for: model) ?? ""
-      selectedCodexFastMode = false
-    } else if !modelSupportsReasoningEffort(model, selectedReasoningEffort) {
-      selectedReasoningEffort = defaultReasoningEffort(for: model) ?? ""
-    }
-    if !model.supportsCodexFastMode {
-      selectedCodexFastMode = false
-    }
 
     if commandScope == .project { picker.pushRecent(model.id, syncService: syncService) }
     emitSelection(model)
@@ -652,7 +642,6 @@ struct WorkModelPickerSheet: View {
     if !workModelIdsEquivalent(model.id, selectedModelId) {
       selectedModelId = model.id
       selectedRuntimeProvider = runtimeProvider(for: model)
-      selectedCodexFastMode = false
     }
     selectedReasoningEffort = reasoningEffort.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
     if commandScope == .project { picker.pushRecent(model.id, syncService: syncService) }
@@ -664,9 +653,8 @@ struct WorkModelPickerSheet: View {
     if !workModelIdsEquivalent(model.id, selectedModelId) {
       selectedModelId = model.id
       selectedRuntimeProvider = runtimeProvider(for: model)
-      selectedReasoningEffort = defaultReasoningEffort(for: model) ?? ""
     }
-    selectedCodexFastMode = model.supportsCodexFastMode ? enabled : false
+    selectedCodexFastMode = enabled
     if commandScope == .project { picker.pushRecent(model.id, syncService: syncService) }
     emitSelection(model)
   }
@@ -680,36 +668,8 @@ struct WorkModelPickerSheet: View {
       model,
       effortPayload,
       runtimeProvider(for: model),
-      model.supportsCodexFastMode ? selectedCodexFastMode : false
+      selectedCodexFastMode
     )
-  }
-
-  private func defaultReasoningEffort(for model: WorkModelOption) -> String? {
-    let tiers = supportedReasoningTiers(for: model)
-    guard !tiers.isEmpty else { return nil }
-    let advertisedDefault = model.defaultReasoningEffort?
-      .trimmingCharacters(in: .whitespacesAndNewlines)
-      .lowercased()
-    if let advertisedDefault, tiers.contains(advertisedDefault) {
-      return advertisedDefault
-    }
-    if tiers.contains("medium") { return "medium" }
-    return tiers[tiers.count / 2]
-  }
-
-  private func modelSupportsReasoningEffort(_ model: WorkModelOption, _ effort: String) -> Bool {
-    let normalized = effort.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
-    guard !normalized.isEmpty else { return false }
-    return supportedReasoningTiers(for: model).contains(normalized)
-  }
-
-  private func supportedReasoningTiers(for model: WorkModelOption) -> [String] {
-    var seen = Set<String>()
-    return model.reasoningEfforts.compactMap { effort in
-      let tier = effort.effort.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
-      guard !tier.isEmpty, seen.insert(tier).inserted else { return nil }
-      return tier
-    }
   }
 }
 

--- a/apps/ios/ADE/Views/Work/WorkNewChatScreen.swift
+++ b/apps/ios/ADE/Views/Work/WorkNewChatScreen.swift
@@ -805,16 +805,6 @@ struct WorkNewChatScreen: View {
       }
     }
     .onAppear {
-      // A restored selection (see init) can carry a model only valid in the mode
-      // it was last used in — e.g. a CLI-only Cursor model. normalizeSelection
-      // only runs on a sessionMode *change*, which never fires for the seeded
-      // initial state, so a model disallowed for the (possibly restored) mode
-      // would otherwise reach Send. Normalize here, but only when the model is
-      // actually disallowed, so a valid restored selection keeps its runtimeMode.
-      let availabilityMode: WorkCursorAvailabilityMode = sessionMode == .cli ? .cli : .chat
-      if !workModelAllowedForAvailabilityMode(modelId: modelId, provider: provider, mode: availabilityMode) {
-        normalizeSelection(for: sessionMode)
-      }
       if selectedLaneId.isEmpty {
         selectedLaneId = defaultNewSessionLane?.id ?? ""
       }
@@ -822,33 +812,8 @@ struct WorkNewChatScreen: View {
         runtimeMode = workDefaultRuntimeMode(provider: provider)
       }
     }
-    .onChange(of: provider) { _, newProvider in
-      runtimeMode = workDefaultRuntimeMode(provider: newProvider)
-      if !workNewChatModel(modelId, belongsTo: workNormalizedChatProvider(newProvider)) {
-        modelId = workDefaultNewChatModelId(provider: newProvider)
-      }
-      if !modelSupportsReasoning(modelId: modelId, provider: newProvider) {
-        reasoningEffort = ""
-      }
-      if !fastModeSupported {
-        codexFastMode = false
-      }
-    }
-    .onChange(of: sessionMode) { _, newMode in
-      normalizeSelection(for: newMode)
-    }
-    .onChange(of: modelId) { _, newModel in
-      if !modelSupportsReasoning(modelId: newModel, provider: provider) {
-        reasoningEffort = ""
-      }
-      if !fastModeSupported {
-        codexFastMode = false
-      }
-    }
     .onChange(of: composerSelection) { _, newValue in
-      // Persist every model / access-mode change so the next New Chat restores
-      // it. Captures the full tuple atomically — a single field change here
-      // already reflects any cascading provider/model normalization above.
+      // Persist the full selection without deriving one setting from another.
       WorkComposerPreferences.save(newValue)
     }
     .sheet(isPresented: $modelPickerPresented) {
@@ -866,9 +831,9 @@ struct WorkNewChatScreen: View {
           provider = sessionMode == .chat
             ? workNormalizedChatProvider(runtimeProvider)
             : workResolveCliProvider(for: option.id, provider: runtimeProvider)
-          reasoningEffort = pickedReasoning ?? ""
-          runtimeMode = workDefaultRuntimeMode(provider: provider)
-          codexFastMode = option.supportsCodexFastMode ? pickedFastMode : false
+          let nextReasoning = pickedReasoning ?? ""
+          if nextReasoning != reasoningEffort { reasoningEffort = nextReasoning }
+          if pickedFastMode != codexFastMode { codexFastMode = pickedFastMode }
         }
       )
     }
@@ -1078,6 +1043,13 @@ struct WorkNewChatScreen: View {
     let opener = workChatOutgoingText(openingMessage, attachmentCount: readyAttachments.count)
     guard !busy && !shellLaunchBusy && (isAutoCreateLane || !selectedLaneId.isEmpty) else { return false }
     guard !opener.isEmpty && !modelId.isEmpty else { return false }
+    let availabilityMode: WorkCursorAvailabilityMode = sessionMode == .cli ? .cli : .chat
+    guard workModelAllowedForAvailabilityMode(modelId: modelId, provider: provider, mode: availabilityMode) else {
+      errorMessage = sessionMode == .cli
+        ? "This model is available for chat only. Choose a CLI-capable model."
+        : "This model is available for CLI only. Choose a chat-capable model."
+      return false
+    }
     guard readyAttachments.isEmpty || canUploadAttachments else {
       errorMessage = "Reconnect to attach images."
       return false
@@ -1211,10 +1183,9 @@ struct WorkNewChatScreen: View {
         provider: provider,
         model: modelId,
         reasoningEffort: normalizedReasoning.isEmpty ? nil : normalizedReasoning,
-        // Send an explicit true/false when the model supports fast mode so the
-        // user's choice (including an explicit OFF) is honored rather than
-        // falling back to the host default; nil only when fast mode is N/A.
-        codexFastMode: fastModeSupported ? codexFastMode : nil,
+        // Preserve the independent preference. Runtime capability checks
+        // belong at request construction, not in the composer state.
+        codexFastMode: codexFastMode,
         piProfileId: piMetadata?.profileId,
         piProviderId: piMetadata?.providerId,
         piModelId: piMetadata?.modelId,
@@ -1365,50 +1336,6 @@ struct WorkNewChatScreen: View {
     }
   }
 
-  private func normalizeSelection(for mode: WorkNewSessionMode) {
-    let availabilityMode: WorkCursorAvailabilityMode = mode == .cli ? .cli : .chat
-    if !workModelAllowedForAvailabilityMode(modelId: modelId, provider: provider, mode: availabilityMode),
-       let replacement = workDefaultModelIdForAvailabilityMode(preferredProvider: provider, mode: availabilityMode) {
-      modelId = replacement.modelId
-      provider = mode == .chat
-        ? workNormalizedChatProvider(replacement.provider)
-        : workResolveCliProvider(for: replacement.modelId, provider: replacement.provider)
-    } else if mode == .chat {
-      provider = workNormalizedChatProvider(provider)
-      if !workNewChatModel(modelId, belongsTo: provider) {
-        modelId = workDefaultNewChatModelId(provider: provider)
-      }
-    } else {
-      provider = workResolveCliProvider(for: modelId, provider: provider)
-    }
-    runtimeMode = workDefaultRuntimeMode(provider: provider)
-    if !modelSupportsReasoning(modelId: modelId, provider: provider) {
-      reasoningEffort = ""
-    }
-    if !fastModeSupported {
-      codexFastMode = false
-    }
-  }
-}
-
-private func workNewChatModel(_ modelId: String, belongsTo provider: String) -> Bool {
-  let trimmed = modelId.trimmingCharacters(in: .whitespacesAndNewlines)
-  guard !trimmed.isEmpty else { return false }
-  return workModelCatalogGroupKey(for: trimmed, currentProvider: provider) == provider
-}
-
-private func workDefaultNewChatModelId(provider: String) -> String {
-  let family = providerFamilyKey(provider)
-  if let defaultModel = workDefaultCatalogModelId(provider: family) {
-    return defaultModel
-  }
-  switch workNormalizedChatProvider(provider) {
-  case "codex": return workDefaultCatalogModelId(provider: "codex") ?? "gpt-5.6-sol"
-  case "cursor": return "auto"
-  case "opencode": return "opencode/anthropic/claude-sonnet-5"
-  case "pi": return ""
-  default: return "claude-sonnet-5"
-  }
 }
 
 private func workCliSupportsReasoningSelection(provider: String) -> Bool {

--- a/apps/ios/ADE/Views/Work/WorkNewChatSheet.swift
+++ b/apps/ios/ADE/Views/Work/WorkNewChatSheet.swift
@@ -37,7 +37,7 @@ struct WorkNewChatSheet: View {
   }
 
   var canStartChat: Bool {
-    !busy && !isDictating && !selectedLaneId.isEmpty && !selectedModelId.isEmpty && !trimmedInitialMessage.isEmpty
+    !busy && !isDictating && !selectedLaneId.isEmpty && selectedModel != nil && !trimmedInitialMessage.isEmpty
   }
 
   var startDisabledReason: String? {
@@ -45,6 +45,7 @@ struct WorkNewChatSheet: View {
     if isDictating { return "Finish dictation before starting." }
     if selectedLaneId.isEmpty { return "Choose a lane." }
     if selectedModelId.isEmpty { return "Choose a model." }
+    if selectedModel == nil { return "The selected model is unavailable for \(providerLabel(provider))." }
     if trimmedInitialMessage.isEmpty { return "Enter an opening prompt." }
     return nil
   }
@@ -406,21 +407,9 @@ struct WorkNewChatSheet: View {
           .disabled(!canStartChat)
         }
       }
-      .onChange(of: selectedModelId) { _, _ in
-        let reasoningEfforts = workVisibleReasoningEfforts(for: selectedModel)
-        if !reasoningEfforts.isEmpty {
-          if !reasoningEfforts.contains(where: { $0.effort == selectedReasoningEffort }) {
-            selectedReasoningEffort = ""
-          }
-        } else {
-          selectedReasoningEffort = ""
-        }
-      }
       .task(id: provider) {
         models = []
-        selectedModelId = ""
-        selectedReasoningEffort = ""
-        await loadModels(resetSelection: true)
+        await loadModels(resetSelection: false)
       }
       .onAppear {
         if selectedLaneId.isEmpty {
@@ -451,7 +440,7 @@ struct WorkNewChatSheet: View {
       let matchingSelection = scopedModels.first {
         workModelIdsEquivalent($0.id, selectedModelId) || workModelIdsEquivalent($0.modelId, selectedModelId)
       }
-      if resetSelection || matchingSelection == nil {
+      if resetSelection || (selectedModelId.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty && matchingSelection == nil) {
         if let preferred = scopedModels.first(where: \.isDefault) ?? scopedModels.first {
           selectedModelId = preferred.id
           selectedReasoningEffort = ""
@@ -461,14 +450,12 @@ struct WorkNewChatSheet: View {
         }
       } else if let matchingSelection, selectedModelId != matchingSelection.id {
         selectedModelId = matchingSelection.id
-        selectedReasoningEffort = ""
       }
       errorMessage = nil
     } catch {
       ADEHaptics.error()
       errorMessage = error.localizedDescription
       models = []
-      selectedModelId = ""
     }
   }
 
@@ -477,6 +464,10 @@ struct WorkNewChatSheet: View {
     let openingMessage = trimmedInitialMessage
     guard !openingMessage.isEmpty else {
       errorMessage = "Enter an opening message before starting a chat."
+      return
+    }
+    guard selectedModel != nil else {
+      errorMessage = "The selected model is unavailable for \(providerLabel(provider)). Choose a model for this provider."
       return
     }
     do {
@@ -491,11 +482,7 @@ struct WorkNewChatSheet: View {
         laneId: selectedLaneId,
         provider: provider,
         model: selectedModelId,
-        reasoningEffort: {
-          guard !selectedReasoningEffort.isEmpty else { return nil }
-          guard workVisibleReasoningEfforts(for: selectedModel).contains(where: { $0.effort == selectedReasoningEffort }) else { return nil }
-          return selectedReasoningEffort
-        }(),
+        reasoningEffort: selectedReasoningEffort.isEmpty ? nil : selectedReasoningEffort,
         piProfileId: piMetadata?.profileId,
         piProviderId: piMetadata?.providerId,
         piModelId: piMetadata?.modelId

--- a/apps/ios/ADE/Views/Work/WorkSessionDestinationView+Actions.swift
+++ b/apps/ios/ADE/Views/Work/WorkSessionDestinationView+Actions.swift
@@ -412,19 +412,15 @@ extension WorkSessionDestinationView {
       // Codex model), so re-derive the provider from the picked model rather
       // than persisting the chat's old provider — otherwise restore would seed a
       // mismatched provider/model pair the New Chat init does not reconcile.
-      // When the provider actually changes, the chat's access mode and
-      // sub-settings no longer apply, so reset them to the new provider default.
+      // Keep the independent composer settings when the model changes provider.
       if let summary = chatSummary {
         let resolvedProvider = workComposerRuntimeProvider(forModelId: modelId, currentProvider: summary.provider)
-        let providerChanged = resolvedProvider != summary.provider
         WorkComposerPreferences.save(
           provider: resolvedProvider,
           modelId: modelId,
-          runtimeMode: providerChanged
-            ? workDefaultRuntimeMode(provider: resolvedProvider)
-            : workInitialRuntimeMode(summary),
-          reasoningEffort: providerChanged ? "" : (summary.reasoningEffort ?? ""),
-          codexFastMode: providerChanged ? false : summary.effectiveFastMode
+          runtimeMode: workInitialRuntimeMode(summary),
+          reasoningEffort: summary.reasoningEffort ?? "",
+          codexFastMode: summary.effectiveFastMode
         )
       }
       ADEHaptics.light()

--- a/apps/ios/ADE/Views/Work/WorkSessionSettingsSheet+Actions.swift
+++ b/apps/ios/ADE/Views/Work/WorkSessionSettingsSheet+Actions.swift
@@ -32,20 +32,14 @@ extension WorkSessionSettingsSheet {
         ?? storedIdMatch
         ?? storedNameMatch
         ?? displayNameMatch
-        ?? defaultMatch
-        ?? firstMatch
-        ?? ""
+        ?? (selectedModelId.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ? (defaultMatch ?? firstMatch ?? "") : selectedModelId)
 
       selectedModelId = matchedModelId
-      if !workVisibleReasoningEfforts(for: selectedModel).contains(where: { $0.effort == selectedReasoningEffort }) {
-        selectedReasoningEffort = ""
-      }
       errorMessage = nil
     } catch {
       ADEHaptics.error()
       errorMessage = error.localizedDescription
       models = []
-      selectedModelId = ""
     }
   }
 
@@ -63,7 +57,7 @@ extension WorkSessionSettingsSheet {
     let normalizedReasoning = selectedReasoningEffort.trimmingCharacters(in: .whitespacesAndNewlines)
     let reasoningPayload = normalizedReasoning.isEmpty ? "" : normalizedReasoning
     let reasoningChanged = reasoningPayload != resolvedInitialReasoningEffort
-    let effectiveCodexFastMode = supportsCodexFastModeToggle ? selectedCodexFastMode : false
+    let effectiveCodexFastMode = selectedCodexFastMode
     let codexFastModeChanged = effectiveCodexFastMode != resolvedInitialCodexFastMode
     let initialRuntimeMode = workInitialRuntimeMode(summary)
 

--- a/apps/ios/ADE/Views/Work/WorkSessionSettingsSheet.swift
+++ b/apps/ios/ADE/Views/Work/WorkSessionSettingsSheet.swift
@@ -293,19 +293,6 @@ struct WorkSessionSettingsSheet: View {
           .disabled(busy || selectedModelId.isEmpty)
         }
       }
-      .onChange(of: selectedModelId) { _, _ in
-        let reasoningEfforts = workVisibleReasoningEfforts(for: selectedModel)
-        if !reasoningEfforts.isEmpty {
-          if !reasoningEfforts.contains(where: { $0.effort == selectedReasoningEffort }) {
-            selectedReasoningEffort = ""
-          }
-        } else {
-          selectedReasoningEffort = ""
-        }
-        if !supportsCodexFastModeToggle {
-          selectedCodexFastMode = false
-        }
-      }
       .task {
         await loadModels()
       }


### PR DESCRIPTION


<!-- ade:link v=1 type=pr repo=arul28/ADE branch=ade%2Findependent-prompt-settings num=1153 -->
<p>
  <img src="https://ade-app.dev/logo.png" height="18" align="left" alt="ADE">
  &nbsp;&nbsp;<strong>Open in ADE</strong>
  &nbsp;·&nbsp; <a href="https://ade-app.dev/open?type=branch&amp;repo=arul28%2FADE&amp;branch=ade%2Findependent-prompt-settings&amp;pr=1153">ade/independent-prompt-settings branch</a>
  &nbsp;·&nbsp; <a href="https://ade-app.dev/open?type=pr&amp;repo=arul28%2FADE&amp;number=1153">PR #1153</a>
</p>
<!-- /ade:link -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Broad changes to chat session update, launch, and draft routing across desktop, CLI, and iOS; incorrect gating could leave incompatible models selected until launch or send ignored fast-mode flags at runtime.
> 
> **Overview**
> **Composer and session settings stay independent** when users change model, provider, Chat/CLI interface, machine, or lane. Reasoning effort, fast mode, permission modes, and related toggles are no longer reset, clamped, or inferred from the newly selected model; launch and update paths send the user’s raw preferences and rely on runtime capability checks where needed.
> 
> On **desktop and CLI**, switching Cursor Chat ↔ CLI only updates `interfaceMode` (no automatic model fallback). Incompatible Cursor models surface **errors at launch** instead of silently swapping models. Draft launch config is keyed to the **composer** rather than the selected lane, and **Auto-create** no longer rewrites lane/machine selection to Primary or the bound machine.
> 
> **`agentChatService`** preserves fast mode and cross-provider native settings on **model-only** `updateSession` calls, skips wholesale permission-field cleanup when the provider changes without an explicit mode update, and stops stripping fast mode when the target model lacks a fast tier.
> 
> The same independence is applied across **launch surfaces** (PR resolver, batch launch, CTO, personal chats, ModelPicker) and **iOS** (Hub, New Chat, Linear launch, model picker), with submit-time validation for chat vs CLI model availability. Tests are updated to match the new contracts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a14ff4d00587223b57b4211c7351070a0cd5dbd1. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->