### PR TITLE
Pin Codex 0.149.1 and wire app-server composer RPCs

### DIFF
--- a/apps/ade-cli/package-lock.json
+++ b/apps/ade-cli/package-lock.json
@@ -9,11 +9,11 @@
       "version": "0.0.0",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "0.3.220",
-        "@cursor/sdk": "^1.0.27",
+        "@cursor/sdk": "1.0.27",
         "@factory/droid-sdk": "0.2.0",
         "@linear/sdk": "^84.0.0",
         "@modelcontextprotocol/sdk": "^1.29.0",
-        "@openai/codex": "0.144.5",
+        "@openai/codex": "0.149.1",
         "@opencode-ai/sdk": "1.18.14",
         "@xterm/addon-fit": "^0.11.0",
         "@xterm/addon-serialize": "^0.14.0",
@@ -995,9 +995,9 @@
       }
     },
     "node_modules/@openai/codex": {
-      "version": "0.144.5",
-      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.144.5.tgz",
-      "integrity": "sha512-jjB+K+OMv572mKhS+2QuLxWXDJNdpwbPenf+V+8bdq7wg4Scqt3cn6WEekD8wPqDVZqck0HSX17K9rD9kbDJQA==",
+      "version": "0.149.1",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.149.1.tgz",
+      "integrity": "sha512-6q5pbcpFbJbqOpkubSDBwXmktQ55aD8eUzGzBF1zASob2DjwhBKDSNGtdZKalfrNJUdTDTPDMmzCXEXs5tMBYA==",
       "license": "Apache-2.0",
       "bin": {
         "codex": "bin/codex.js"
@@ -1006,19 +1006,19 @@
         "node": ">=16"
       },
       "optionalDependencies": {
-        "@openai/codex-darwin-arm64": "npm:@openai/codex@0.144.5-darwin-arm64",
-        "@openai/codex-darwin-x64": "npm:@openai/codex@0.144.5-darwin-x64",
-        "@openai/codex-linux-arm64": "npm:@openai/codex@0.144.5-linux-arm64",
-        "@openai/codex-linux-x64": "npm:@openai/codex@0.144.5-linux-x64",
-        "@openai/codex-win32-arm64": "npm:@openai/codex@0.144.5-win32-arm64",
-        "@openai/codex-win32-x64": "npm:@openai/codex@0.144.5-win32-x64"
+        "@openai/codex-darwin-arm64": "npm:@openai/codex@0.149.1-darwin-arm64",
+        "@openai/codex-darwin-x64": "npm:@openai/codex@0.149.1-darwin-x64",
+        "@openai/codex-linux-arm64": "npm:@openai/codex@0.149.1-linux-arm64",
+        "@openai/codex-linux-x64": "npm:@openai/codex@0.149.1-linux-x64",
+        "@openai/codex-win32-arm64": "npm:@openai/codex@0.149.1-win32-arm64",
+        "@openai/codex-win32-x64": "npm:@openai/codex@0.149.1-win32-x64"
       }
     },
     "node_modules/@openai/codex-darwin-arm64": {
       "name": "@openai/codex",
-      "version": "0.144.5-darwin-arm64",
-      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.144.5-darwin-arm64.tgz",
-      "integrity": "sha512-zcT6NfBCqLFt+BReNSETTZW6v6PdbH0dzNtm9j7l7mDGqwPbKZDGJdnpkBao2389I0ZacyIKgSZoI0vez1d4Dw==",
+      "version": "0.149.1-darwin-arm64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.149.1-darwin-arm64.tgz",
+      "integrity": "sha512-6X84kTCbnTgPIJ2EdcPsrvwS0Wxsqpa+bCswGmRf4BjhcQ5nPMnBC6yCAaCMj+vrbXQHj+L6sa9FaR4QkmA1qw==",
       "cpu": [
         "arm64"
       ],
@@ -1033,9 +1033,9 @@
     },
     "node_modules/@openai/codex-darwin-x64": {
       "name": "@openai/codex",
-      "version": "0.144.5-darwin-x64",
-      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.144.5-darwin-x64.tgz",
-      "integrity": "sha512-//Mo0m1MwaoT6psu5xsmofXpKx4/0irIkeq10xJvk59+886EG355ibjA+ZmlRcKhE3bLjsKD7p81nTbAdRL/bw==",
+      "version": "0.149.1-darwin-x64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.149.1-darwin-x64.tgz",
+      "integrity": "sha512-MfLBQLfcElJL9tvj6y45qVHHMGSXCPnQOixuD3/Zq0g1BW/eFizkrGLdn48cFpc+l8cK+gt5nYG5pQYwVs6g4A==",
       "cpu": [
         "x64"
       ],
@@ -1050,9 +1050,9 @@
     },
     "node_modules/@openai/codex-linux-arm64": {
       "name": "@openai/codex",
-      "version": "0.144.5-linux-arm64",
-      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.144.5-linux-arm64.tgz",
-      "integrity": "sha512-zAHggxVwR2TBxKmybXY7ZMiB0G8DMonY2YPdwNNjwXcf+LOIqNGgswwNCDMbP/HEe6r8j+R9ZX/yYoo8f+n/RQ==",
+      "version": "0.149.1-linux-arm64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.149.1-linux-arm64.tgz",
+      "integrity": "sha512-OqxUfZ1TVvHd18zHPKK/8ZRlpk8Vy11mg5CMHaLxNWldTbwVImDKtSLWT+m8m4NM5Sz4PbjtZMrVT/RfpBW/mQ==",
       "cpu": [
         "arm64"
       ],
@@ -1067,9 +1067,9 @@
     },
     "node_modules/@openai/codex-linux-x64": {
       "name": "@openai/codex",
-      "version": "0.144.5-linux-x64",
-      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.144.5-linux-x64.tgz",
-      "integrity": "sha512-FalLJlBQGFdK8Gc3kj9sa/ekNdgkHhUawLaKkvy5CtB18JaP2YxtTP/Pe1pD2iBiq8mMUliRnafpF6AdBdQMbg==",
+      "version": "0.149.1-linux-x64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.149.1-linux-x64.tgz",
+      "integrity": "sha512-Of5fGYgr7tAMsyj6vhXb4/RM/UoA3Zq8BLegUBDC09UNy1XTLGYP/2XD+UX8z3qh0NDwxYdCjFIWdDNijKZggQ==",
       "cpu": [
         "x64"
       ],
@@ -1084,9 +1084,9 @@
     },
     "node_modules/@openai/codex-win32-arm64": {
       "name": "@openai/codex",
-      "version": "0.144.5-win32-arm64",
-      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.144.5-win32-arm64.tgz",
-      "integrity": "sha512-0Pj7iqjEOEvPQPO3kFfCy9vGX4BTu76ChFFZHr2eNNIfVc3FOENAv/X98u4L+iIUtDOK9DbqmfUudW3DPapshg==",
+      "version": "0.149.1-win32-arm64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.149.1-win32-arm64.tgz",
+      "integrity": "sha512-5K0DmOKGK9Bos627p8sK8ATHjovPK0sDyT6h9Cb+4v+5CW5SGw1HLgjGxoLfJ8g3cg6mtg/pRCXXo2L/j71UVA==",
       "cpu": [
         "arm64"
       ],
@@ -1101,9 +1101,9 @@
     },
     "node_modules/@openai/codex-win32-x64": {
       "name": "@openai/codex",
-      "version": "0.144.5-win32-x64",
-      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.144.5-win32-x64.tgz",
-      "integrity": "sha512-DnsSTlnnzleTxvLwIGnBitKInscxn2I7qASqosS8Fv+qysBygd+ZiBn/SQsRCgQ28PAlsNzmd3Gf3ZTecolAmg==",
+      "version": "0.149.1-win32-x64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.149.1-win32-x64.tgz",
+      "integrity": "sha512-G3QXGAg7nyyhqOeooAMUekBCeHd8a1QByhKcVAFyzNBaI06t6Ft7nsF+1SzFS0spuIdU4YyMi5YD26ukADBQUQ==",
       "cpu": [
         "x64"
       ],
@@ -5810,52 +5810,52 @@
       }
     },
     "@openai/codex": {
-      "version": "0.144.5",
-      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.144.5.tgz",
-      "integrity": "sha512-jjB+K+OMv572mKhS+2QuLxWXDJNdpwbPenf+V+8bdq7wg4Scqt3cn6WEekD8wPqDVZqck0HSX17K9rD9kbDJQA==",
+      "version": "0.149.1",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.149.1.tgz",
+      "integrity": "sha512-6q5pbcpFbJbqOpkubSDBwXmktQ55aD8eUzGzBF1zASob2DjwhBKDSNGtdZKalfrNJUdTDTPDMmzCXEXs5tMBYA==",
       "requires": {
-        "@openai/codex-darwin-arm64": "npm:@openai/codex@0.144.5-darwin-arm64",
-        "@openai/codex-darwin-x64": "npm:@openai/codex@0.144.5-darwin-x64",
-        "@openai/codex-linux-arm64": "npm:@openai/codex@0.144.5-linux-arm64",
-        "@openai/codex-linux-x64": "npm:@openai/codex@0.144.5-linux-x64",
-        "@openai/codex-win32-arm64": "npm:@openai/codex@0.144.5-win32-arm64",
-        "@openai/codex-win32-x64": "npm:@openai/codex@0.144.5-win32-x64"
+        "@openai/codex-darwin-arm64": "npm:@openai/codex@0.149.1-darwin-arm64",
+        "@openai/codex-darwin-x64": "npm:@openai/codex@0.149.1-darwin-x64",
+        "@openai/codex-linux-arm64": "npm:@openai/codex@0.149.1-linux-arm64",
+        "@openai/codex-linux-x64": "npm:@openai/codex@0.149.1-linux-x64",
+        "@openai/codex-win32-arm64": "npm:@openai/codex@0.149.1-win32-arm64",
+        "@openai/codex-win32-x64": "npm:@openai/codex@0.149.1-win32-x64"
       }
     },
     "@openai/codex-darwin-arm64": {
-      "version": "npm:@openai/codex@0.144.5-darwin-arm64",
-      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.144.5-darwin-arm64.tgz",
-      "integrity": "sha512-zcT6NfBCqLFt+BReNSETTZW6v6PdbH0dzNtm9j7l7mDGqwPbKZDGJdnpkBao2389I0ZacyIKgSZoI0vez1d4Dw==",
+      "version": "npm:@openai/codex@0.149.1-darwin-arm64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.149.1-darwin-arm64.tgz",
+      "integrity": "sha512-6X84kTCbnTgPIJ2EdcPsrvwS0Wxsqpa+bCswGmRf4BjhcQ5nPMnBC6yCAaCMj+vrbXQHj+L6sa9FaR4QkmA1qw==",
       "optional": true
     },
     "@openai/codex-darwin-x64": {
-      "version": "npm:@openai/codex@0.144.5-darwin-x64",
-      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.144.5-darwin-x64.tgz",
-      "integrity": "sha512-//Mo0m1MwaoT6psu5xsmofXpKx4/0irIkeq10xJvk59+886EG355ibjA+ZmlRcKhE3bLjsKD7p81nTbAdRL/bw==",
+      "version": "npm:@openai/codex@0.149.1-darwin-x64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.149.1-darwin-x64.tgz",
+      "integrity": "sha512-MfLBQLfcElJL9tvj6y45qVHHMGSXCPnQOixuD3/Zq0g1BW/eFizkrGLdn48cFpc+l8cK+gt5nYG5pQYwVs6g4A==",
       "optional": true
     },
     "@openai/codex-linux-arm64": {
-      "version": "npm:@openai/codex@0.144.5-linux-arm64",
-      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.144.5-linux-arm64.tgz",
-      "integrity": "sha512-zAHggxVwR2TBxKmybXY7ZMiB0G8DMonY2YPdwNNjwXcf+LOIqNGgswwNCDMbP/HEe6r8j+R9ZX/yYoo8f+n/RQ==",
+      "version": "npm:@openai/codex@0.149.1-linux-arm64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.149.1-linux-arm64.tgz",
+      "integrity": "sha512-OqxUfZ1TVvHd18zHPKK/8ZRlpk8Vy11mg5CMHaLxNWldTbwVImDKtSLWT+m8m4NM5Sz4PbjtZMrVT/RfpBW/mQ==",
       "optional": true
     },
     "@openai/codex-linux-x64": {
-      "version": "npm:@openai/codex@0.144.5-linux-x64",
-      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.144.5-linux-x64.tgz",
-      "integrity": "sha512-FalLJlBQGFdK8Gc3kj9sa/ekNdgkHhUawLaKkvy5CtB18JaP2YxtTP/Pe1pD2iBiq8mMUliRnafpF6AdBdQMbg==",
+      "version": "npm:@openai/codex@0.149.1-linux-x64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.149.1-linux-x64.tgz",
+      "integrity": "sha512-Of5fGYgr7tAMsyj6vhXb4/RM/UoA3Zq8BLegUBDC09UNy1XTLGYP/2XD+UX8z3qh0NDwxYdCjFIWdDNijKZggQ==",
       "optional": true
     },
     "@openai/codex-win32-arm64": {
-      "version": "npm:@openai/codex@0.144.5-win32-arm64",
-      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.144.5-win32-arm64.tgz",
-      "integrity": "sha512-0Pj7iqjEOEvPQPO3kFfCy9vGX4BTu76ChFFZHr2eNNIfVc3FOENAv/X98u4L+iIUtDOK9DbqmfUudW3DPapshg==",
+      "version": "npm:@openai/codex@0.149.1-win32-arm64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.149.1-win32-arm64.tgz",
+      "integrity": "sha512-5K0DmOKGK9Bos627p8sK8ATHjovPK0sDyT6h9Cb+4v+5CW5SGw1HLgjGxoLfJ8g3cg6mtg/pRCXXo2L/j71UVA==",
       "optional": true
     },
     "@openai/codex-win32-x64": {
-      "version": "npm:@openai/codex@0.144.5-win32-x64",
-      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.144.5-win32-x64.tgz",
-      "integrity": "sha512-DnsSTlnnzleTxvLwIGnBitKInscxn2I7qASqosS8Fv+qysBygd+ZiBn/SQsRCgQ28PAlsNzmd3Gf3ZTecolAmg==",
+      "version": "npm:@openai/codex@0.149.1-win32-x64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.149.1-win32-x64.tgz",
+      "integrity": "sha512-G3QXGAg7nyyhqOeooAMUekBCeHd8a1QByhKcVAFyzNBaI06t6Ft7nsF+1SzFS0spuIdU4YyMi5YD26ukADBQUQ==",
       "optional": true
     },
     "@opencode-ai/sdk": {

--- a/apps/ade-cli/package.json
+++ b/apps/ade-cli/package.json
@@ -31,7 +31,7 @@
     "@factory/droid-sdk": "0.2.0",
     "@linear/sdk": "^84.0.0",
     "@modelcontextprotocol/sdk": "^1.29.0",
-    "@openai/codex": "0.144.5",
+    "@openai/codex": "0.149.1",
     "@opencode-ai/sdk": "1.18.14",
     "@xterm/addon-fit": "^0.11.0",
     "@xterm/addon-serialize": "^0.14.0",

--- a/apps/ade-cli/src/services/tools/manifest.test.ts
+++ b/apps/ade-cli/src/services/tools/manifest.test.ts
@@ -172,9 +172,9 @@ describe("generated tools manifest", () => {
   it("keeps the codex alias version, which is not plain semver", () => {
     const pin = findToolTargetPin(manifest, "codex", "darwin-arm64");
     expect(pin.package).toBe("@openai/codex-darwin-arm64");
-    expect(pin.version).toBe("0.144.5-darwin-arm64");
+    expect(pin.version).toBe("0.149.1-darwin-arm64");
     // The alias publishes under the base package path, not the suffixed one.
-    expect(pin.tarball).toContain("/@openai/codex/-/codex-0.144.5-darwin-arm64.tgz");
+    expect(pin.tarball).toContain("/@openai/codex/-/codex-0.149.1-darwin-arm64.tgz");
   });
 
   it("uses .exe entry spellings on Windows", () => {

--- a/apps/ade-cli/src/services/tools/manifest.ts
+++ b/apps/ade-cli/src/services/tools/manifest.ts
@@ -24,7 +24,7 @@ export type ToolTargetPin = {
    * The npm *install directory* name — what consumers expect to find in a
    * `node_modules` tree. This is not always the published package name:
    * `@openai/codex-darwin-arm64` is an npm alias whose tarball is published
-   * under `@openai/codex` at version `0.144.5-darwin-arm64`.
+   * under `@openai/codex` at version `0.149.1-darwin-arm64`.
    */
   package: string;
   version: string;

--- a/apps/ade-cli/src/services/tools/paths.ts
+++ b/apps/ade-cli/src/services/tools/paths.ts
@@ -135,7 +135,7 @@ export function toolsLockRoot(toolsRoot: string): string {
   return path.join(toolsRoot, LOCK_DIR_NAME);
 }
 
-/** `@openai/codex-darwin-arm64@0.144.5-darwin-arm64` -> a single safe filename. */
+/** `@openai/codex-darwin-arm64@0.149.1-darwin-arm64` -> a single safe filename. */
 export function toolSlug(packageName: string, version: string): string {
   return `${packageName.replace(/[@/]/g, "_")}@${version}`.replace(/[^A-Za-z0-9._@-]/g, "_");
 }

--- a/apps/ade-cli/src/services/tools/toolsManifest.generated.json
+++ b/apps/ade-cli/src/services/tools/toolsManifest.generated.json
@@ -13,33 +13,33 @@
       "targets": {
         "darwin-arm64": {
           "package": "@openai/codex-darwin-arm64",
-          "version": "0.144.5-darwin-arm64",
-          "tarball": "https://registry.npmjs.org/@openai/codex/-/codex-0.144.5-darwin-arm64.tgz",
-          "integrity": "sha512-zcT6NfBCqLFt+BReNSETTZW6v6PdbH0dzNtm9j7l7mDGqwPbKZDGJdnpkBao2389I0ZacyIKgSZoI0vez1d4Dw=="
+          "version": "0.149.1-darwin-arm64",
+          "tarball": "https://registry.npmjs.org/@openai/codex/-/codex-0.149.1-darwin-arm64.tgz",
+          "integrity": "sha512-6X84kTCbnTgPIJ2EdcPsrvwS0Wxsqpa+bCswGmRf4BjhcQ5nPMnBC6yCAaCMj+vrbXQHj+L6sa9FaR4QkmA1qw=="
         },
         "darwin-x64": {
           "package": "@openai/codex-darwin-x64",
-          "version": "0.144.5-darwin-x64",
-          "tarball": "https://registry.npmjs.org/@openai/codex/-/codex-0.144.5-darwin-x64.tgz",
-          "integrity": "sha512-//Mo0m1MwaoT6psu5xsmofXpKx4/0irIkeq10xJvk59+886EG355ibjA+ZmlRcKhE3bLjsKD7p81nTbAdRL/bw=="
+          "version": "0.149.1-darwin-x64",
+          "tarball": "https://registry.npmjs.org/@openai/codex/-/codex-0.149.1-darwin-x64.tgz",
+          "integrity": "sha512-MfLBQLfcElJL9tvj6y45qVHHMGSXCPnQOixuD3/Zq0g1BW/eFizkrGLdn48cFpc+l8cK+gt5nYG5pQYwVs6g4A=="
         },
         "linux-arm64": {
           "package": "@openai/codex-linux-arm64",
-          "version": "0.144.5-linux-arm64",
-          "tarball": "https://registry.npmjs.org/@openai/codex/-/codex-0.144.5-linux-arm64.tgz",
-          "integrity": "sha512-zAHggxVwR2TBxKmybXY7ZMiB0G8DMonY2YPdwNNjwXcf+LOIqNGgswwNCDMbP/HEe6r8j+R9ZX/yYoo8f+n/RQ=="
+          "version": "0.149.1-linux-arm64",
+          "tarball": "https://registry.npmjs.org/@openai/codex/-/codex-0.149.1-linux-arm64.tgz",
+          "integrity": "sha512-OqxUfZ1TVvHd18zHPKK/8ZRlpk8Vy11mg5CMHaLxNWldTbwVImDKtSLWT+m8m4NM5Sz4PbjtZMrVT/RfpBW/mQ=="
         },
         "linux-x64": {
           "package": "@openai/codex-linux-x64",
-          "version": "0.144.5-linux-x64",
-          "tarball": "https://registry.npmjs.org/@openai/codex/-/codex-0.144.5-linux-x64.tgz",
-          "integrity": "sha512-FalLJlBQGFdK8Gc3kj9sa/ekNdgkHhUawLaKkvy5CtB18JaP2YxtTP/Pe1pD2iBiq8mMUliRnafpF6AdBdQMbg=="
+          "version": "0.149.1-linux-x64",
+          "tarball": "https://registry.npmjs.org/@openai/codex/-/codex-0.149.1-linux-x64.tgz",
+          "integrity": "sha512-Of5fGYgr7tAMsyj6vhXb4/RM/UoA3Zq8BLegUBDC09UNy1XTLGYP/2XD+UX8z3qh0NDwxYdCjFIWdDNijKZggQ=="
         },
         "win32-x64": {
           "package": "@openai/codex-win32-x64",
-          "version": "0.144.5-win32-x64",
-          "tarball": "https://registry.npmjs.org/@openai/codex/-/codex-0.144.5-win32-x64.tgz",
-          "integrity": "sha512-DnsSTlnnzleTxvLwIGnBitKInscxn2I7qASqosS8Fv+qysBygd+ZiBn/SQsRCgQ28PAlsNzmd3Gf3ZTecolAmg=="
+          "version": "0.149.1-win32-x64",
+          "tarball": "https://registry.npmjs.org/@openai/codex/-/codex-0.149.1-win32-x64.tgz",
+          "integrity": "sha512-G3QXGAg7nyyhqOeooAMUekBCeHd8a1QByhKcVAFyzNBaI06t6Ft7nsF+1SzFS0spuIdU4YyMi5YD26ukADBQUQ=="
         }
       }
     },

--- a/apps/desktop/package-lock.json
+++ b/apps/desktop/package-lock.json
@@ -14,7 +14,7 @@
         "@factory/droid-sdk": "0.2.0",
         "@linear/sdk": "^84.0.0",
         "@modelcontextprotocol/sdk": "^1.29.0",
-        "@openai/codex": "0.144.5",
+        "@openai/codex": "0.149.1",
         "@opencode-ai/sdk": "1.18.21",
         "@xterm/addon-serialize": "^0.14.0",
         "@xterm/headless": "^6.0.0",
@@ -3378,9 +3378,9 @@
       }
     },
     "node_modules/@openai/codex": {
-      "version": "0.144.5",
-      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.144.5.tgz",
-      "integrity": "sha512-jjB+K+OMv572mKhS+2QuLxWXDJNdpwbPenf+V+8bdq7wg4Scqt3cn6WEekD8wPqDVZqck0HSX17K9rD9kbDJQA==",
+      "version": "0.149.1",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.149.1.tgz",
+      "integrity": "sha512-6q5pbcpFbJbqOpkubSDBwXmktQ55aD8eUzGzBF1zASob2DjwhBKDSNGtdZKalfrNJUdTDTPDMmzCXEXs5tMBYA==",
       "license": "Apache-2.0",
       "bin": {
         "codex": "bin/codex.js"
@@ -3389,19 +3389,19 @@
         "node": ">=16"
       },
       "optionalDependencies": {
-        "@openai/codex-darwin-arm64": "npm:@openai/codex@0.144.5-darwin-arm64",
-        "@openai/codex-darwin-x64": "npm:@openai/codex@0.144.5-darwin-x64",
-        "@openai/codex-linux-arm64": "npm:@openai/codex@0.144.5-linux-arm64",
-        "@openai/codex-linux-x64": "npm:@openai/codex@0.144.5-linux-x64",
-        "@openai/codex-win32-arm64": "npm:@openai/codex@0.144.5-win32-arm64",
-        "@openai/codex-win32-x64": "npm:@openai/codex@0.144.5-win32-x64"
+        "@openai/codex-darwin-arm64": "npm:@openai/codex@0.149.1-darwin-arm64",
+        "@openai/codex-darwin-x64": "npm:@openai/codex@0.149.1-darwin-x64",
+        "@openai/codex-linux-arm64": "npm:@openai/codex@0.149.1-linux-arm64",
+        "@openai/codex-linux-x64": "npm:@openai/codex@0.149.1-linux-x64",
+        "@openai/codex-win32-arm64": "npm:@openai/codex@0.149.1-win32-arm64",
+        "@openai/codex-win32-x64": "npm:@openai/codex@0.149.1-win32-x64"
       }
     },
     "node_modules/@openai/codex-darwin-arm64": {
       "name": "@openai/codex",
-      "version": "0.144.5-darwin-arm64",
-      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.144.5-darwin-arm64.tgz",
-      "integrity": "sha512-zcT6NfBCqLFt+BReNSETTZW6v6PdbH0dzNtm9j7l7mDGqwPbKZDGJdnpkBao2389I0ZacyIKgSZoI0vez1d4Dw==",
+      "version": "0.149.1-darwin-arm64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.149.1-darwin-arm64.tgz",
+      "integrity": "sha512-6X84kTCbnTgPIJ2EdcPsrvwS0Wxsqpa+bCswGmRf4BjhcQ5nPMnBC6yCAaCMj+vrbXQHj+L6sa9FaR4QkmA1qw==",
       "cpu": [
         "arm64"
       ],
@@ -3416,9 +3416,9 @@
     },
     "node_modules/@openai/codex-darwin-x64": {
       "name": "@openai/codex",
-      "version": "0.144.5-darwin-x64",
-      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.144.5-darwin-x64.tgz",
-      "integrity": "sha512-//Mo0m1MwaoT6psu5xsmofXpKx4/0irIkeq10xJvk59+886EG355ibjA+ZmlRcKhE3bLjsKD7p81nTbAdRL/bw==",
+      "version": "0.149.1-darwin-x64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.149.1-darwin-x64.tgz",
+      "integrity": "sha512-MfLBQLfcElJL9tvj6y45qVHHMGSXCPnQOixuD3/Zq0g1BW/eFizkrGLdn48cFpc+l8cK+gt5nYG5pQYwVs6g4A==",
       "cpu": [
         "x64"
       ],
@@ -3433,9 +3433,9 @@
     },
     "node_modules/@openai/codex-linux-arm64": {
       "name": "@openai/codex",
-      "version": "0.144.5-linux-arm64",
-      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.144.5-linux-arm64.tgz",
-      "integrity": "sha512-zAHggxVwR2TBxKmybXY7ZMiB0G8DMonY2YPdwNNjwXcf+LOIqNGgswwNCDMbP/HEe6r8j+R9ZX/yYoo8f+n/RQ==",
+      "version": "0.149.1-linux-arm64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.149.1-linux-arm64.tgz",
+      "integrity": "sha512-OqxUfZ1TVvHd18zHPKK/8ZRlpk8Vy11mg5CMHaLxNWldTbwVImDKtSLWT+m8m4NM5Sz4PbjtZMrVT/RfpBW/mQ==",
       "cpu": [
         "arm64"
       ],
@@ -3450,9 +3450,9 @@
     },
     "node_modules/@openai/codex-linux-x64": {
       "name": "@openai/codex",
-      "version": "0.144.5-linux-x64",
-      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.144.5-linux-x64.tgz",
-      "integrity": "sha512-FalLJlBQGFdK8Gc3kj9sa/ekNdgkHhUawLaKkvy5CtB18JaP2YxtTP/Pe1pD2iBiq8mMUliRnafpF6AdBdQMbg==",
+      "version": "0.149.1-linux-x64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.149.1-linux-x64.tgz",
+      "integrity": "sha512-Of5fGYgr7tAMsyj6vhXb4/RM/UoA3Zq8BLegUBDC09UNy1XTLGYP/2XD+UX8z3qh0NDwxYdCjFIWdDNijKZggQ==",
       "cpu": [
         "x64"
       ],
@@ -3467,9 +3467,9 @@
     },
     "node_modules/@openai/codex-win32-arm64": {
       "name": "@openai/codex",
-      "version": "0.144.5-win32-arm64",
-      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.144.5-win32-arm64.tgz",
-      "integrity": "sha512-0Pj7iqjEOEvPQPO3kFfCy9vGX4BTu76ChFFZHr2eNNIfVc3FOENAv/X98u4L+iIUtDOK9DbqmfUudW3DPapshg==",
+      "version": "0.149.1-win32-arm64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.149.1-win32-arm64.tgz",
+      "integrity": "sha512-5K0DmOKGK9Bos627p8sK8ATHjovPK0sDyT6h9Cb+4v+5CW5SGw1HLgjGxoLfJ8g3cg6mtg/pRCXXo2L/j71UVA==",
       "cpu": [
         "arm64"
       ],
@@ -3484,9 +3484,9 @@
     },
     "node_modules/@openai/codex-win32-x64": {
       "name": "@openai/codex",
-      "version": "0.144.5-win32-x64",
-      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.144.5-win32-x64.tgz",
-      "integrity": "sha512-DnsSTlnnzleTxvLwIGnBitKInscxn2I7qASqosS8Fv+qysBygd+ZiBn/SQsRCgQ28PAlsNzmd3Gf3ZTecolAmg==",
+      "version": "0.149.1-win32-x64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.149.1-win32-x64.tgz",
+      "integrity": "sha512-G3QXGAg7nyyhqOeooAMUekBCeHd8a1QByhKcVAFyzNBaI06t6Ft7nsF+1SzFS0spuIdU4YyMi5YD26ukADBQUQ==",
       "cpu": [
         "x64"
       ],

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -77,7 +77,7 @@
     "@factory/droid-sdk": "0.2.0",
     "@linear/sdk": "^84.0.0",
     "@modelcontextprotocol/sdk": "^1.29.0",
-    "@openai/codex": "0.144.5",
+    "@openai/codex": "0.149.1",
     "@opencode-ai/sdk": "1.18.21",
     "@xterm/addon-serialize": "^0.14.0",
     "@xterm/headless": "^6.0.0",

--- a/apps/desktop/src/main/services/adeActions/registry.test.ts
+++ b/apps/desktop/src/main/services/adeActions/registry.test.ts
@@ -152,6 +152,8 @@ describe("isAllowedAdeAction", () => {
     expect(isAllowedAdeAction("chat", "setCodexGoalStatus")).toBe(true);
     expect(isAllowedAdeAction("chat", "clearCodexGoal")).toBe(true);
     expect(isAllowedAdeAction("chat", "getCodexGoal")).toBe(true);
+    expect(isAllowedAdeAction("chat", "resetCodexMemory")).toBe(true);
+    expect(isAllowedAdeAction("chat", "terminateCodexBackgroundTerminal")).toBe(true);
     expect(isAllowedAdeAction("git", "getCommit")).toBe(true);
   });
 

--- a/apps/desktop/src/main/services/adeActions/registry.ts
+++ b/apps/desktop/src/main/services/adeActions/registry.ts
@@ -585,6 +585,8 @@ export const ADE_ACTION_ALLOWLIST: Partial<Record<AdeActionDomain, readonly stri
     "setCodexGoalStatus",
     "clearCodexGoal",
     "getCodexGoal",
+    "resetCodexMemory",
+    "terminateCodexBackgroundTerminal",
     "listClaudeOutputStyles",
     "getSessionCapabilities",
     "getSessionSummary",

--- a/apps/desktop/src/main/services/chat/agentChatService.test.ts
+++ b/apps/desktop/src/main/services/chat/agentChatService.test.ts
@@ -14696,6 +14696,27 @@ describe("createAgentChatService", () => {
       expect(mockState.codexRequestPayloads.some((payload) => payload.method === "turn/start")).toBe(true);
     });
 
+    it("settles idle user shell when thread/shellCommand has no turn id", async () => {
+      pin149();
+      mockState.codexResponseOverrides.set("thread/shellCommand", {});
+      const { service } = createService();
+      const session = await service.createSession({
+        laneId: "lane-1",
+        provider: "codex",
+        model: "gpt-5.4",
+      });
+
+      await service.sendMessage({
+        sessionId: session.id,
+        text: "!pwd",
+      }, { awaitDispatch: true });
+      await service.sendMessage({
+        sessionId: session.id,
+        text: "Continue after the shell command.",
+      }, { awaitDispatch: true });
+      expect(mockState.codexRequestPayloads.some((payload) => payload.method === "turn/start")).toBe(true);
+    });
+
     it("does not reset memory until /memory-reset confirm", async () => {
       pin149();
       const events: AgentChatEventEnvelope[] = [];
@@ -14813,6 +14834,64 @@ describe("createAgentChatService", () => {
         && (payload.params as { command?: string }).command === "pwd",
       )).toBe(true);
       expect(mockState.codexRequestPayloads.some((payload) => payload.method === "turn/steer")).toBe(false);
+    });
+
+    it("keeps the parent turn active when a mid-turn user shell fails", async () => {
+      pin149();
+      mockState.codexResponseOverrides.set("thread/shellCommand", {
+        error: { code: -32000, message: "shell failed" },
+      });
+      const events: AgentChatEventEnvelope[] = [];
+      const { service } = createService({
+        onEvent: (event: AgentChatEventEnvelope) => events.push(event),
+      });
+      const session = await service.createSession({
+        laneId: "lane-1",
+        provider: "codex",
+        model: "gpt-5.4",
+      });
+      await service.sendMessage({
+        sessionId: session.id,
+        text: "Keep this turn active.",
+      }, { awaitDispatch: true });
+
+      await service.sendMessage({
+        sessionId: session.id,
+        text: "!pwd",
+      }, { awaitDispatch: true });
+      expect(events.some((event) =>
+        event.event.type === "system_notice"
+        && String(event.event.message).includes("user shell failed"),
+      )).toBe(true);
+      await expect(service.sendMessage({
+        sessionId: session.id,
+        text: "Continue the original turn.",
+      }, { awaitDispatch: true })).rejects.toThrow(/turn is already active/i);
+    });
+
+    it("sends revalidated effort when switching Codex models on a live thread", async () => {
+      pin149();
+      const { service } = createService();
+      const session = await service.createSession({
+        laneId: "lane-1",
+        provider: "codex",
+        model: "gpt-5.5",
+        modelId: "openai/gpt-5.5",
+        reasoningEffort: "high",
+      });
+      await service.sendMessage({
+        sessionId: session.id,
+        text: "Keep this thread live.",
+      }, { awaitDispatch: true });
+
+      await service.updateSession({
+        sessionId: session.id,
+        modelId: "openai/gpt-5.6-sol",
+      });
+      const settings = mockState.codexRequestPayloads.find((payload) => payload.method === "thread/settings/update");
+      expect(settings?.params).toEqual(expect.objectContaining({
+        effort: expect.any(String),
+      }));
     });
 
     it("fail-opens compaction when the turn is interrupted", async () => {

--- a/apps/desktop/src/main/services/chat/agentChatService.test.ts
+++ b/apps/desktop/src/main/services/chat/agentChatService.test.ts
@@ -189,6 +189,38 @@ vi.mock("node:child_process", () => ({
             result = { skills: [] };
           } else if (payload.method === "account/rateLimits/read") {
             result = { rateLimits: { remaining: 10, limit: 100, resetAt: null } };
+          } else if (payload.method === "thread/queue/add") {
+            const params = payload.params as { clientUserMessageId?: unknown } | undefined;
+            result = {
+              queuedSubmission: {
+                id: `queued-${mockState.codexRequestPayloads.length}`,
+                clientUserMessageId: typeof params?.clientUserMessageId === "string"
+                  ? params.clientUserMessageId
+                  : "queued-client",
+              },
+            };
+          } else if (payload.method === "thread/queue/list") {
+            result = { queuedSubmissions: [] };
+          } else if (
+            payload.method === "thread/queue/delete"
+            || payload.method === "thread/queue/update"
+            || payload.method === "thread/queue/start"
+            || payload.method === "thread/settings/update"
+            || payload.method === "memory/reset"
+            || payload.method === "thread/memoryMode/set"
+            || payload.method === "thread/backgroundTerminals/terminate"
+          ) {
+            result = {};
+          } else if (payload.method === "thread/revert") {
+            const params = payload.params as { threadId?: unknown } | undefined;
+            result = {
+              thread: { id: typeof params?.threadId === "string" ? params.threadId : "reverted-thread" },
+            };
+          } else if (payload.method === "thread/shellCommand") {
+            mockState.codexTurnCounter += 1;
+            result = { turn: { id: `turn-${mockState.codexTurnCounter}` } };
+          } else if (payload.method === "thread/backgroundTerminals/list") {
+            result = { terminals: [] };
           }
 
           const emitResponse = () => {
@@ -4962,6 +4994,12 @@ describe("createAgentChatService", () => {
       const handoffPayloads = mockState.codexRequestPayloads.slice(handoffStart);
       expect(handoffPayloads).toEqual(expect.arrayContaining([
         expect.objectContaining({
+          method: "thread/goal/clear",
+          params: expect.objectContaining({
+            threadId: "source-thread-1",
+          }),
+        }),
+        expect.objectContaining({
           method: "thread/fork",
           params: expect.objectContaining({
             threadId: "source-thread-1",
@@ -5481,10 +5519,17 @@ describe("createAgentChatService", () => {
         targetTurnId: undefined,
         expectedMethod: "thread/rollback",
       },
+      {
+        name: "reverts paginated history on Codex 0.149.1",
+        userAgent: "codex/0.149.1",
+        targetTurnId: "turn-target",
+        expectedMethod: "thread/revert",
+      },
     ])("$name", async ({ userAgent, targetTurnId, expectedMethod }) => {
       mockState.codexResponseOverrides.set("initialize", { userAgent });
       mockState.codexResponseOverrides.set("thread/rollback", { thread: { id: "rewound-thread" } });
       mockState.codexResponseOverrides.set("thread/fork", { thread: { id: "forked-before-turn" } });
+      mockState.codexResponseOverrides.set("thread/revert", { thread: { id: "reverted-thread" } });
       const { service, sessionService } = createService();
       const source = await service.createSession({
         laneId: "lane-1",
@@ -5522,13 +5567,62 @@ describe("createAgentChatService", () => {
           beforeTurnId: "turn-target",
         });
         expect(mockState.codexRequestPayloads.some((payload) => payload.method === "thread/rollback")).toBe(false);
+        expect(mockState.codexRequestPayloads.some((payload) => payload.method === "thread/revert")).toBe(false);
+      } else if (expectedMethod === "thread/revert") {
+        expect(lifecycleRequest?.params).toEqual({
+          threadId: "source-thread-1",
+          beforeTurnId: "turn-target",
+        });
+        expect(mockState.codexRequestPayloads.some((payload) => payload.method === "thread/rollback")).toBe(false);
+        expect(mockState.codexRequestPayloads.some((payload) => payload.method === "thread/fork")).toBe(false);
       } else {
         expect(lifecycleRequest?.params).toEqual({
           threadId: "source-thread-1",
           numTurns: 1,
         });
         expect(mockState.codexRequestPayloads.some((payload) => payload.method === "thread/fork")).toBe(false);
+        expect(mockState.codexRequestPayloads.some((payload) => payload.method === "thread/revert")).toBe(false);
       }
+    });
+
+    it("falls back to fork when thread/revert is rejected", async () => {
+      mockState.codexResponseOverrides.set("initialize", { userAgent: "codex/0.149.1" });
+      mockState.codexResponseOverrides.set("thread/revert", {
+        error: { code: -32601, message: "Method not found" },
+      });
+      mockState.codexResponseOverrides.set("thread/fork", { thread: { id: "forked-after-revert" } });
+      const { service, sessionService } = createService();
+      const source = await service.createSession({
+        laneId: "lane-1",
+        provider: "codex",
+        model: "gpt-5.5",
+        modelId: "openai/gpt-5.5",
+      });
+      source.threadId = "source-thread-1";
+      source.status = "idle";
+      const transcriptPath = sessionService.get(source.id)?.transcriptPath;
+      expect(transcriptPath).toBeTruthy();
+      const rewindEnvelopes: AgentChatEventEnvelope[] = [{
+        sessionId: source.id,
+        timestamp: "2026-07-07T20:00:00.000Z",
+        event: {
+          type: "user_message",
+          messageId: "user-1",
+          text: "rewind this turn",
+          turnId: "turn-target",
+        },
+      } as AgentChatEventEnvelope];
+      fs.writeFileSync(String(transcriptPath), `${JSON.stringify(rewindEnvelopes[0])}\n`, "utf8");
+      vi.mocked(parseAgentChatTranscript).mockReturnValue(rewindEnvelopes);
+
+      await service.rewindFiles({
+        sessionId: source.id,
+        userMessageId: "user-1",
+      });
+
+      expect(mockState.codexRequestPayloads.some((payload) => payload.method === "thread/revert")).toBe(true);
+      expect(mockState.codexRequestPayloads.some((payload) => payload.method === "thread/fork")).toBe(true);
+      expect(mockState.codexRequestPayloads.some((payload) => payload.method === "thread/rollback")).toBe(false);
     });
 
     it("does not delete files during Codex rewind when git cannot prove the path was absent", async () => {
@@ -13755,6 +13849,9 @@ describe("createAgentChatService", () => {
 
       expect(names).toContain("/permissions");
       expect(names).toContain("/review");
+      expect(names).toContain("/shell");
+      expect(names).toContain("/memory");
+      expect(names).toContain("/memory-reset");
       expect(commands).toEqual(expect.arrayContaining([
         expect.objectContaining({
           name: "/audit",
@@ -14532,6 +14629,276 @@ describe("createAgentChatService", () => {
     });
     expect(mockState.codexRequestPayloads.some((payload) => payload.method === "turn/start")).toBe(false);
     expect(aiIntegrationService.summarizeTerminal).not.toHaveBeenCalled();
+  });
+
+  describe("Codex 0.149 app-server composer commands", () => {
+    const pin149 = () => {
+      mockState.codexResponseOverrides.set("initialize", { userAgent: "codex/0.149.1" });
+    };
+
+    it("sends ! and /shell drafts through thread/shellCommand", async () => {
+      pin149();
+      const { service } = createService();
+      const session = await service.createSession({
+        laneId: "lane-1",
+        provider: "codex",
+        model: "gpt-5.4",
+      });
+
+      await service.sendMessage({
+        sessionId: session.id,
+        text: "!git status --short",
+      }, { awaitDispatch: true });
+
+      await vi.waitFor(() => {
+        expect(mockState.codexRequestPayloads.some((payload) => payload.method === "thread/shellCommand")).toBe(true);
+      });
+      const shell = mockState.codexRequestPayloads.find((payload) => payload.method === "thread/shellCommand");
+      expect(shell?.params).toEqual(expect.objectContaining({
+        command: "git status --short",
+      }));
+      expect(mockState.codexRequestPayloads.some((payload) => payload.method === "turn/start")).toBe(false);
+    });
+
+    it("adopts the thread/shellCommand turn so the composer can settle", async () => {
+      pin149();
+      mockState.codexResponseOverrides.set("thread/shellCommand", { turn: { id: "shell-turn-1" } });
+      const events: AgentChatEventEnvelope[] = [];
+      const { service } = createService({
+        onEvent: (event: AgentChatEventEnvelope) => events.push(event),
+      });
+      const session = await service.createSession({
+        laneId: "lane-1",
+        provider: "codex",
+        model: "gpt-5.4",
+      });
+
+      await service.sendMessage({
+        sessionId: session.id,
+        text: "!pwd",
+      }, { awaitDispatch: true });
+      mockState.emitCodexPayload({
+        jsonrpc: "2.0",
+        method: "turn/completed",
+        params: { turn: { id: "shell-turn-1", status: "completed" } },
+      });
+      await vi.waitFor(() => {
+        expect(events.some((event) =>
+          event.event.type === "done"
+          && event.event.turnId === "shell-turn-1",
+        )).toBe(true);
+      });
+
+      await service.sendMessage({
+        sessionId: session.id,
+        text: "Continue after the shell command.",
+      }, { awaitDispatch: true });
+      expect(mockState.codexRequestPayloads.some((payload) => payload.method === "turn/start")).toBe(true);
+    });
+
+    it("does not reset memory until /memory-reset confirm", async () => {
+      pin149();
+      const events: AgentChatEventEnvelope[] = [];
+      const { service } = createService({
+        onEvent: (event: AgentChatEventEnvelope) => events.push(event),
+      });
+      const session = await service.createSession({
+        laneId: "lane-1",
+        provider: "codex",
+        model: "gpt-5.4",
+      });
+
+      await service.sendMessage({
+        sessionId: session.id,
+        text: "/memory-reset",
+      }, { awaitDispatch: true });
+
+      expect(mockState.codexRequestPayloads.some((payload) => payload.method === "memory/reset")).toBe(false);
+      expect(events.some((event) =>
+        event.event.type === "system_notice"
+        && String(event.event.message).includes("/memory-reset confirm"),
+      )).toBe(true);
+
+      await service.sendMessage({
+        sessionId: session.id,
+        text: "/memory-reset confirm",
+      }, { awaitDispatch: true });
+
+      expect(mockState.codexRequestPayloads.some((payload) => payload.method === "memory/reset")).toBe(true);
+    });
+
+    it("sets memory mode with /memory on", async () => {
+      pin149();
+      const { service } = createService();
+      const session = await service.createSession({
+        laneId: "lane-1",
+        provider: "codex",
+        model: "gpt-5.4",
+      });
+
+      await service.sendMessage({
+        sessionId: session.id,
+        text: "/memory on",
+      }, { awaitDispatch: true });
+
+      expect(mockState.codexRequestPayloads.some((payload) =>
+        payload.method === "thread/memoryMode/set"
+        && (payload.params as { mode?: string }).mode === "enabled",
+      )).toBe(true);
+    });
+
+    it("queues a follow-up during compaction instead of steering", async () => {
+      pin149();
+      const events: AgentChatEventEnvelope[] = [];
+      const { service } = createService({
+        onEvent: (event: AgentChatEventEnvelope) => events.push(event),
+      });
+      const session = await service.createSession({
+        laneId: "lane-1",
+        provider: "codex",
+        model: "gpt-5.4",
+      });
+      await service.sendMessage({
+        sessionId: session.id,
+        text: "Keep this turn active.",
+      }, { awaitDispatch: true });
+      mockState.emitCodexPayload({
+        jsonrpc: "2.0",
+        method: "item/started",
+        params: {
+          turnId: "turn-1",
+          item: { id: "compact-1", type: "contextCompaction" },
+        },
+      });
+
+      const queued = await service.steer({
+        sessionId: session.id,
+        text: "are u still alive",
+      });
+      expect(queued.queued).toBe(true);
+      expect(mockState.codexRequestPayloads.some((payload) => payload.method === "thread/queue/add")).toBe(true);
+      expect(mockState.codexRequestPayloads.some((payload) => payload.method === "turn/steer")).toBe(false);
+
+      const coalesced = await service.steer({
+        sessionId: session.id,
+        text: "are u still alive",
+      });
+      expect(coalesced.queued).toBe(true);
+      expect(events.some((event) =>
+        event.event.type === "system_notice"
+        && event.event.message === "Duplicate check-in ignored.",
+      )).toBe(true);
+    });
+
+    it("runs mid-turn ! commands as user shell instead of steer", async () => {
+      pin149();
+      const { service } = createService();
+      const session = await service.createSession({
+        laneId: "lane-1",
+        provider: "codex",
+        model: "gpt-5.4",
+      });
+      await service.sendMessage({
+        sessionId: session.id,
+        text: "Keep this turn active.",
+      }, { awaitDispatch: true });
+
+      await service.steer({
+        sessionId: session.id,
+        text: "!pwd",
+      });
+
+      expect(mockState.codexRequestPayloads.some((payload) =>
+        payload.method === "thread/shellCommand"
+        && (payload.params as { command?: string }).command === "pwd",
+      )).toBe(true);
+      expect(mockState.codexRequestPayloads.some((payload) => payload.method === "turn/steer")).toBe(false);
+    });
+
+    it("fail-opens compaction when the turn is interrupted", async () => {
+      pin149();
+      const events: AgentChatEventEnvelope[] = [];
+      const { service } = createService({
+        onEvent: (event: AgentChatEventEnvelope) => events.push(event),
+      });
+      const session = await service.createSession({
+        laneId: "lane-1",
+        provider: "codex",
+        model: "gpt-5.4",
+      });
+      await service.sendMessage({
+        sessionId: session.id,
+        text: "Keep this turn active.",
+      }, { awaitDispatch: true });
+      mockState.emitCodexPayload({
+        jsonrpc: "2.0",
+        method: "item/started",
+        params: {
+          turnId: "turn-1",
+          item: { id: "compact-stall", type: "contextCompaction" },
+        },
+      });
+      await vi.waitFor(() => {
+        expect(events.some((event) =>
+          (event.event.type === "context_compact" || event.event.type === "codex_context_compaction")
+          && event.event.state === "started",
+        )).toBe(true);
+      });
+
+      await service.interrupt({ sessionId: session.id });
+      expect(events.some((event) =>
+        (event.event.type === "context_compact" || event.event.type === "codex_context_compaction")
+        && event.event.state === "failed"
+        && event.event.failReason === "interrupted",
+      )).toBe(true);
+    });
+
+    it("fail-opens compaction after a stall", async () => {
+      pin149();
+      const events: AgentChatEventEnvelope[] = [];
+      const { service } = createService({
+        onEvent: (event: AgentChatEventEnvelope) => events.push(event),
+      });
+      const session = await service.createSession({
+        laneId: "lane-1",
+        provider: "codex",
+        model: "gpt-5.4",
+      });
+      await service.sendMessage({
+        sessionId: session.id,
+        text: "Keep this turn active.",
+      }, { awaitDispatch: true });
+      vi.useFakeTimers();
+      try {
+        mockState.emitCodexPayload({
+          jsonrpc: "2.0",
+          method: "item/started",
+          params: {
+            turnId: "turn-1",
+            item: { id: "compact-timeout", type: "contextCompaction" },
+          },
+        });
+        let started = false;
+        for (let i = 0; i < 20 && !started; i += 1) {
+          await Promise.resolve();
+          started = events.some((event) =>
+            (event.event.type === "context_compact" || event.event.type === "codex_context_compaction")
+            && event.event.state === "started"
+            && event.event.compactionId === "compact-timeout",
+          );
+        }
+        expect(started).toBe(true);
+        await vi.advanceTimersByTimeAsync(180_000);
+      } finally {
+        vi.useRealTimers();
+      }
+      expect(events.some((event) =>
+        (event.event.type === "context_compact" || event.event.type === "codex_context_compaction")
+        && event.event.compactionId === "compact-timeout"
+        && event.event.state === "failed"
+        && event.event.failReason === "timed_out",
+      )).toBe(true);
+    });
   });
 
   describe("runtime-native chat titles", () => {

--- a/apps/desktop/src/main/services/chat/agentChatService.ts
+++ b/apps/desktop/src/main/services/chat/agentChatService.ts
@@ -18638,33 +18638,50 @@ export function createAgentChatService(args: {
           threadId: managed.session.threadId,
           command: userShell.command,
         });
-        if (!skipTurnStartForActiveComposerCommand) {
-          const shellTurnId = typeof shellResult.turn?.id === "string" ? shellResult.turn.id : null;
-          if (shellTurnId) {
-            runtime.awaitingTurnStart = false;
-            if (isTerminalCodexTurn(runtime, shellTurnId, managed)) {
-              runtime.activeTurnId = null;
-              runtime.startedTurnId = null;
-            } else {
-              runtime.activeTurnId = shellTurnId;
-              scheduleCodexNoFirstEventWatchdog(managed, runtime, shellTurnId);
-            }
-          }
+        if (skipTurnStartForActiveComposerCommand) {
+          markDispatched();
+          persistDeliveredLaneDirectiveKey(managed, args.laneDirectiveKey);
+          emitChatEvent(managed, {
+            type: "user_message",
+            text: displayText || userText,
+            turnId: runtime.activeTurnId ?? undefined,
+          });
+          persistChatState(managed);
+          return;
+        }
+        const shellTurnId = typeof shellResult.turn?.id === "string" ? shellResult.turn.id : null;
+        if (!shellTurnId) {
+          runtime.awaitingTurnStart = false;
+          completeInlineCodexSlash();
+          return;
+        }
+        runtime.awaitingTurnStart = false;
+        if (isTerminalCodexTurn(runtime, shellTurnId, managed)) {
+          runtime.activeTurnId = null;
+          runtime.startedTurnId = null;
+        } else {
+          runtime.activeTurnId = shellTurnId;
+          scheduleCodexNoFirstEventWatchdog(managed, runtime, shellTurnId);
         }
       } catch (error) {
         runtime.awaitingTurnStart = false;
+        if (skipTurnStartForActiveComposerCommand) {
+          markDispatched();
+          persistDeliveredLaneDirectiveKey(managed, args.laneDirectiveKey);
+          emitChatEvent(managed, {
+            type: "system_notice",
+            noticeKind: "info",
+            message: `Unsandboxed user shell failed: ${error instanceof Error ? error.message : String(error)}`,
+            turnId: runtime.activeTurnId ?? undefined,
+          });
+          persistChatState(managed);
+          return;
+        }
         completeFailedInlineCodexSlash("Unsandboxed user shell failed", error);
         return;
       }
       markDispatched();
       persistDeliveredLaneDirectiveKey(managed, args.laneDirectiveKey);
-      if (skipTurnStartForActiveComposerCommand) {
-        emitChatEvent(managed, {
-          type: "user_message",
-          text: displayText || userText,
-          turnId: runtime.activeTurnId ?? undefined,
-        });
-      }
       persistChatState(managed);
       return;
     }
@@ -45070,7 +45087,7 @@ export function createAgentChatService(args: {
           await previousCodexRuntime.request("thread/settings/update", {
             threadId: managed.session.threadId,
             ...(modelChanged ? { model: nextModel } : {}),
-            ...(reasoningEffort !== undefined && managed.session.reasoningEffort
+            ...(managed.session.reasoningEffort && (reasoningEffort !== undefined || modelChanged)
               ? { effort: managed.session.reasoningEffort }
               : {}),
           });

--- a/apps/desktop/src/main/services/chat/agentChatService.ts
+++ b/apps/desktop/src/main/services/chat/agentChatService.ts
@@ -94,6 +94,25 @@ import {
 import { discoverClaudeSlashCommands } from "./claudeSlashCommandDiscovery";
 import { discoverCodexSlashCommands } from "./codexSlashCommandDiscovery";
 import {
+  CODEX_COMPACTION_STALL_MS,
+  type CodexCompactionFailReason,
+  codexServerSupportsBackgroundTerminals,
+  codexServerSupportsDeferGoalContinuation,
+  codexServerSupportsMemoryRpc,
+  codexServerSupportsPaginatedHistory,
+  codexServerSupportsThreadQueue,
+  codexServerSupportsThreadRevert,
+  codexServerSupportsThreadSettings,
+  codexServerSupportsUserShell,
+} from "./codexAppServerFeatures";
+import {
+  CODEX_MEMORY_RESET_RECEIPT,
+  parseCodexMemorySlashCommand,
+  parseCodexShellSlashCommand,
+  parseCodexUserShellDraft,
+  shouldCoalesceCodexCheckIn,
+} from "../../../shared/codexComposerCommands";
+import {
   countHumanChildMessagesForTurn,
   formatHumanChildMessageAnnotation,
 } from "./spawnMissionOwnership";
@@ -223,6 +242,8 @@ import type {
   AgentChatCrossMachineForkTransport,
   AgentChatCrossMachineHandoffCapsule,
   AgentChatCodexClearGoalArgs,
+  AgentChatCodexResetMemoryArgs,
+  AgentChatCodexTerminateBackgroundTerminalArgs,
   AgentChatCodexApprovalPolicy,
   AgentChatCodexConfigSource,
   AgentChatCodexGetGoalArgs,
@@ -1373,6 +1394,20 @@ type CodexRuntime = {
   planTextByItemId: Map<string, string>;
   manualCompactionItemIds: Set<string>;
   manualCompactionPending: boolean;
+  activeCompactions: Map<string, {
+    itemId: string;
+    trigger: "manual" | "auto";
+    turnId: string;
+    startedAt: number;
+    timer: NodeJS.Timeout | null;
+  }>;
+  reviewTurnIds: Set<string>;
+  lastQueuedCheckIn: { text: string; atMs: number } | null;
+  queuedSubmissionBySteerId: Map<string, string>;
+  backgroundTerminalsByProcessId: Map<string, { command: string; cwd: string | null; itemId: string | null }>;
+  userShellItemIds: Set<string>;
+  memoryMode: "enabled" | "disabled" | null;
+  historyPaginated: boolean;
   webSearchActionsByItemId: Map<string, CodexWebSearchAction[]>;
   planningApprovalGuardByTurnId: Map<string, boolean>;
   pendingTurnPlanningApprovalGuarded: boolean | null;
@@ -1725,6 +1760,9 @@ const CODEX_BUILT_IN_SLASH_COMMANDS: AgentChatSlashCommand[] = [
   { name: "/init", description: "Generate an AGENTS.md scaffold in the current directory.", source: "sdk" },
   { name: "/goal", description: "Set, show, pause, resume, or clear the chat goal.", source: "local", argumentHint: "[pause|resume|clear|<objective>]" },
   { name: "/inject", description: "Inject context text into Codex thread history.", source: "local", argumentHint: "<context text>" },
+  { name: "/shell", description: "Run an unsandboxed user shell command.", source: "local", argumentHint: "<command>" },
+  { name: "/memory", description: "Show or change this thread's Codex memory eligibility.", source: "local", argumentHint: "[on|off|status]" },
+  { name: "/memory-reset", description: "Clear every memory file under this Codex home.", source: "local" },
   { name: "/logout", description: "Sign out of Codex.", source: "sdk" },
   { name: "/model", description: "Choose the active model and reasoning effort.", source: "sdk" },
   { name: "/fast", description: "Toggle Fast mode for supported models.", source: "local", argumentHint: "[on|off|status]" },
@@ -2429,6 +2467,9 @@ function runtimeBackgroundWork(runtime: ChatRuntime | null): SessionBackgroundWo
       const backgroundTypes: Array<string | null> = [];
       for (const subagent of runtime.activeSubagents.values()) {
         if (subagent.background) backgroundTypes.push(null);
+      }
+      for (const _processId of runtime.backgroundTerminalsByProcessId.keys()) {
+        backgroundTypes.push("background_task");
       }
       return summarizeBackgroundWork(backgroundTypes);
     }
@@ -3902,6 +3943,19 @@ export function codexServerSupportsForkBeforeTurn(version: CodexServerVersion | 
   if (!version) return false;
   if (version.major > 0) return true;
   return version.minor >= 145;
+}
+
+function isCodexCompactionActive(runtime: CodexRuntime): boolean {
+  return runtime.activeCompactions.size > 0;
+}
+
+function isCodexReviewTurnActive(runtime: CodexRuntime): boolean {
+  const turnId = runtime.activeTurnId ?? runtime.startedTurnId;
+  return Boolean(turnId && runtime.reviewTurnIds.has(turnId));
+}
+
+function codexTurnRejectsSteer(runtime: CodexRuntime): boolean {
+  return isCodexCompactionActive(runtime) || isCodexReviewTurnActive(runtime);
 }
 
 function codexTimestampOrNull(value: unknown): string | null {
@@ -17483,6 +17537,7 @@ export function createAgentChatService(args: {
       (managed.runtime.kind === "claude" || managed.runtime.kind === "cursor" || managed.runtime.kind === "pi") && reasonAllowsPreservation;
     if (managed.runtime.kind === "codex") {
       const runtime = managed.runtime;
+      failOpenCodexCompactions(managed, runtime, "teardown");
       const interruptedTurnId = runtime.activeTurnId ?? runtime.startedTurnId ?? null;
       const shouldMarkInterrupted =
         reasonAllowsPreservation
@@ -18160,7 +18215,7 @@ export function createAgentChatService(args: {
       onDispatched = undefined;
       callback();
     };
-    const slashText = args.promptText.trim();
+    const slashText = (args.userText?.trim() || args.promptText).trim();
 
     const emitCodexGoalNotice = (
       message: string,
@@ -18407,26 +18462,33 @@ export function createAgentChatService(args: {
       return;
     }
 
-    if (runtime.activeTurnId) {
+    const pendingUserShell = parseCodexUserShellDraft(slashText) ?? parseCodexShellSlashCommand(slashText);
+    const pendingMemoryCommand = parseCodexMemorySlashCommand(slashText);
+    if (runtime.activeTurnId && !pendingUserShell && !pendingMemoryCommand) {
       throw new Error("A turn is already active. Use steer or interrupt.");
     }
-    setSessionActive(managed);
-    if (!args.optimisticCodexTurnStart) {
-      emitPreparedUserMessage(managed, {
-        text: userText,
-        displayText,
-        attachments,
-        contextAttachments,
-        metadata: args.metadata,
-        laneDirectiveKey: args.laneDirectiveKey,
-        onDispatched: markDispatched,
-      });
-      emitChatEvent(managed, { type: "status", turnStatus: "started" });
-      captureTurnBeforeSha(managed);
-      emitChatEvent(managed, {
-        type: "activity",
-        ...initialTurnActivity(managed.session),
-      });
+    const skipTurnStartForActiveComposerCommand = Boolean(
+      runtime.activeTurnId && (pendingUserShell || pendingMemoryCommand),
+    );
+    if (!skipTurnStartForActiveComposerCommand) {
+      setSessionActive(managed);
+      if (!args.optimisticCodexTurnStart) {
+        emitPreparedUserMessage(managed, {
+          text: userText,
+          displayText,
+          attachments,
+          contextAttachments,
+          metadata: args.metadata,
+          laneDirectiveKey: args.laneDirectiveKey,
+          onDispatched: markDispatched,
+        });
+        emitChatEvent(managed, { type: "status", turnStatus: "started" });
+        captureTurnBeforeSha(managed);
+        emitChatEvent(managed, {
+          type: "activity",
+          ...initialTurnActivity(managed.session),
+        });
+      }
     }
     const providerSlashCommand = args.providerSlashCommand === true;
     const completeInlineCodexSlash = (
@@ -18538,6 +18600,7 @@ export function createAgentChatService(args: {
       const reviewTurnId = typeof reviewResult.turn?.id === "string" ? reviewResult.turn.id : null;
       if (reviewTurnId) {
         runtime.awaitingTurnStart = false;
+        runtime.reviewTurnIds.add(reviewTurnId);
         if (isTerminalCodexTurn(runtime, reviewTurnId, managed)) {
           runtime.activeTurnId = null;
           runtime.startedTurnId = null;
@@ -18546,6 +18609,140 @@ export function createAgentChatService(args: {
         }
         runtime.activeTurnId = reviewTurnId;
         scheduleCodexNoFirstEventWatchdog(managed, runtime, reviewTurnId);
+      }
+      return;
+    }
+
+    const userShell = pendingUserShell;
+    if (userShell) {
+      if (!codexServerSupportsUserShell(runtime.serverVersion)) {
+        if (skipTurnStartForActiveComposerCommand) {
+          markDispatched();
+          persistDeliveredLaneDirectiveKey(managed, args.laneDirectiveKey);
+          emitChatEvent(managed, {
+            type: "system_notice",
+            noticeKind: "info",
+            message: "This Codex app-server cannot run unsandboxed user shell commands.",
+            turnId: runtime.activeTurnId ?? undefined,
+          });
+          persistChatState(managed);
+          return;
+        }
+        runtime.awaitingTurnStart = false;
+        completeInlineCodexSlash("This Codex app-server cannot run unsandboxed user shell commands.");
+        return;
+      }
+      if (!skipTurnStartForActiveComposerCommand) runtime.awaitingTurnStart = true;
+      try {
+        const shellResult = await runtime.request<{ turn?: { id?: string } }>("thread/shellCommand", {
+          threadId: managed.session.threadId,
+          command: userShell.command,
+        });
+        if (!skipTurnStartForActiveComposerCommand) {
+          const shellTurnId = typeof shellResult.turn?.id === "string" ? shellResult.turn.id : null;
+          if (shellTurnId) {
+            runtime.awaitingTurnStart = false;
+            if (isTerminalCodexTurn(runtime, shellTurnId, managed)) {
+              runtime.activeTurnId = null;
+              runtime.startedTurnId = null;
+            } else {
+              runtime.activeTurnId = shellTurnId;
+              scheduleCodexNoFirstEventWatchdog(managed, runtime, shellTurnId);
+            }
+          }
+        }
+      } catch (error) {
+        runtime.awaitingTurnStart = false;
+        completeFailedInlineCodexSlash("Unsandboxed user shell failed", error);
+        return;
+      }
+      markDispatched();
+      persistDeliveredLaneDirectiveKey(managed, args.laneDirectiveKey);
+      if (skipTurnStartForActiveComposerCommand) {
+        emitChatEvent(managed, {
+          type: "user_message",
+          text: displayText || userText,
+          turnId: runtime.activeTurnId ?? undefined,
+        });
+      }
+      persistChatState(managed);
+      return;
+    }
+
+    const memoryCommand = pendingMemoryCommand;
+    if (memoryCommand) {
+      const finishMemory = (message?: string) => {
+        if (skipTurnStartForActiveComposerCommand) {
+          markDispatched();
+          persistDeliveredLaneDirectiveKey(managed, args.laneDirectiveKey);
+          if (message) {
+            emitChatEvent(managed, {
+              type: "system_notice",
+              noticeKind: "info",
+              message,
+              turnId: runtime.activeTurnId ?? undefined,
+            });
+          }
+          persistChatState(managed);
+          return;
+        }
+        completeInlineCodexSlash(message);
+      };
+      if (memoryCommand.kind === "invalid") {
+        finishMemory(memoryCommand.message);
+        return;
+      }
+      if (memoryCommand.kind === "reset") {
+        if (!memoryCommand.confirm) {
+          finishMemory("Reset Codex memory? Confirm with /memory-reset confirm. This deletes every memory file under this Codex home, not just this chat.");
+          return;
+        }
+        if (!codexServerSupportsMemoryRpc(runtime.serverVersion)) {
+          finishMemory("This Codex app-server cannot reset memory.");
+          return;
+        }
+        try {
+          await runtime.request("memory/reset", {});
+          finishMemory(CODEX_MEMORY_RESET_RECEIPT);
+        } catch (error) {
+          if (skipTurnStartForActiveComposerCommand) {
+            finishMemory(`Codex memory reset failed: ${error instanceof Error ? error.message : String(error)}`);
+          } else {
+            completeFailedInlineCodexSlash("Codex memory reset failed", error);
+          }
+        }
+        return;
+      }
+      if (!codexServerSupportsMemoryRpc(runtime.serverVersion) && memoryCommand.kind === "set") {
+        finishMemory("This Codex app-server cannot change memory mode.");
+        return;
+      }
+      if (memoryCommand.kind === "status") {
+        const mode = runtime.memoryMode ?? "unknown";
+        finishMemory(
+          mode === "enabled"
+            ? "Codex memory is on for this thread."
+            : mode === "disabled"
+              ? "Codex memory is off for this thread."
+              : "Codex memory status is unknown for this thread.",
+        );
+        return;
+      }
+      try {
+        await runtime.request("thread/memoryMode/set", {
+          threadId: managed.session.threadId,
+          mode: memoryCommand.enabled ? "enabled" : "disabled",
+        });
+        runtime.memoryMode = memoryCommand.enabled ? "enabled" : "disabled";
+        finishMemory(
+          memoryCommand.enabled ? "Codex memory is on for this thread." : "Codex memory is off for this thread.",
+        );
+      } catch (error) {
+        if (skipTurnStartForActiveComposerCommand) {
+          finishMemory(`Codex memory update failed: ${error instanceof Error ? error.message : String(error)}`);
+        } else {
+          completeFailedInlineCodexSlash("Codex memory update failed", error);
+        }
       }
       return;
     }
@@ -25093,6 +25290,7 @@ export function createAgentChatService(args: {
       ...(managed.session.modelId ? { modelId: managed.session.modelId } : {}),
     });
     persistChatState(managed);
+    settleCodexTurnSideEffects(managed, runtime, interruptedTurnId, "interrupted");
   };
 
   const emitClaudeSubagentStarted = (
@@ -26223,6 +26421,175 @@ export function createAgentChatService(args: {
     evictOldestEntries(runtime.acceptedSteersByTurnId, 64);
   };
 
+  const emitCodexCompactionEvent = (
+    managed: ManagedChatSession,
+    payload: {
+      itemId: string;
+      turnId?: string;
+      trigger: "manual" | "auto";
+      state: "started" | "completed" | "failed";
+      failReason?: CodexCompactionFailReason;
+    },
+  ): void => {
+    emitChatEvent(managed, {
+      type: "codex_context_compaction",
+      turnId: payload.turnId ?? "",
+      trigger: payload.trigger,
+      state: payload.state,
+      compactionId: payload.itemId,
+      ...(payload.failReason ? { failReason: payload.failReason } : {}),
+    });
+  };
+
+  const failOpenCodexCompaction = (
+    managed: ManagedChatSession,
+    runtime: CodexRuntime,
+    itemId: string,
+    reason: CodexCompactionFailReason,
+  ): void => {
+    const tracked = runtime.activeCompactions.get(itemId);
+    if (!tracked) return;
+    if (tracked.timer) clearTimeout(tracked.timer);
+    runtime.activeCompactions.delete(itemId);
+    emitCodexCompactionEvent(managed, {
+      itemId,
+      turnId: tracked.turnId,
+      trigger: tracked.trigger,
+      state: "failed",
+      failReason: reason,
+    });
+  };
+
+  const failOpenCodexCompactions = (
+    managed: ManagedChatSession,
+    runtime: CodexRuntime,
+    reason: CodexCompactionFailReason,
+  ): void => {
+    for (const itemId of [...runtime.activeCompactions.keys()]) {
+      failOpenCodexCompaction(managed, runtime, itemId, reason);
+    }
+  };
+
+  const armCodexCompactionStallTimer = (
+    managed: ManagedChatSession,
+    runtime: CodexRuntime,
+    itemId: string,
+  ): void => {
+    const tracked = runtime.activeCompactions.get(itemId);
+    if (!tracked) return;
+    if (tracked.timer) clearTimeout(tracked.timer);
+    tracked.timer = setTimeout(() => {
+      if (runtime.activeCompactions.get(itemId)?.timer !== tracked.timer) return;
+      failOpenCodexCompaction(managed, runtime, itemId, "timed_out");
+    }, CODEX_COMPACTION_STALL_MS);
+    tracked.timer.unref?.();
+  };
+
+  const readCodexQueueSubmissionId = (result: unknown): string | null => {
+    const record = asRecord(result);
+    if (!record) return null;
+    const queued = asRecord(record.queuedSubmission) ?? asRecord(record.submission);
+    return stringOrNull(queued?.id) ?? stringOrNull(record.id);
+  };
+
+  const startCodexQueuedFollowUp = async (
+    managed: ManagedChatSession,
+    runtime: CodexRuntime,
+  ): Promise<void> => {
+    if (!codexServerSupportsThreadQueue(runtime.serverVersion)) return;
+    if (isCodexCompactionActive(runtime) || isCodexReviewTurnActive(runtime)) return;
+    if (runtime.activeTurnId) return;
+    const threadId = managed.session.threadId;
+    if (!threadId) return;
+    try {
+      await runtime.request("thread/queue/start", { threadId });
+    } catch (error) {
+      logger.debug("codex.queue.start_failed", {
+        sessionId: managed.session.id,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+  };
+
+  const emitCodexBackgroundTaskUpdate = (
+    managed: ManagedChatSession,
+    processId: string,
+    status: Extract<AgentChatEvent, { type: "scheduled_work_update" }>["status"],
+    terminal: { command: string; cwd: string | null },
+  ): void => {
+    emitChatEvent(managed, {
+      type: "scheduled_work_update",
+      id: `background:${processId}`,
+      kind: "background_task",
+      status,
+      origin: "background_task",
+      title: terminal.command,
+      summary: terminal.cwd ? `cwd ${terminal.cwd}` : undefined,
+      sourceTaskId: processId,
+    });
+  };
+
+  const refreshCodexBackgroundTerminals = async (
+    managed: ManagedChatSession,
+    runtime: CodexRuntime,
+  ): Promise<void> => {
+    if (!codexServerSupportsBackgroundTerminals(runtime.serverVersion)) return;
+    const threadId = managed.session.threadId;
+    if (!threadId) return;
+    try {
+      const result = await runtime.request<{
+        terminals?: Array<{
+          processId?: string;
+          command?: string;
+          cwd?: string | null;
+          itemId?: string | null;
+        }>;
+      }>("thread/backgroundTerminals/list", { threadId });
+      const previous = runtime.backgroundTerminalsByProcessId;
+      const next = new Map<string, { command: string; cwd: string | null; itemId: string | null }>();
+      for (const terminal of result.terminals ?? []) {
+        const processId = String(terminal.processId ?? "").trim();
+        if (!processId) continue;
+        const itemId = typeof terminal.itemId === "string" ? terminal.itemId : null;
+        if (itemId && runtime.userShellItemIds.has(itemId)) continue;
+        next.set(processId, {
+          command: String(terminal.command ?? "").trim() || processId,
+          cwd: typeof terminal.cwd === "string" ? terminal.cwd : null,
+          itemId,
+        });
+      }
+      runtime.backgroundTerminalsByProcessId = next;
+      for (const [processId, terminal] of next) {
+        emitCodexBackgroundTaskUpdate(managed, processId, "running", terminal);
+      }
+      for (const [processId, terminal] of previous) {
+        if (next.has(processId)) continue;
+        emitCodexBackgroundTaskUpdate(managed, processId, "stopped", terminal);
+      }
+    } catch (error) {
+      logger.warn("codex.background_terminals.list_failed", {
+        sessionId: managed.session.id,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+  };
+
+  const settleCodexTurnSideEffects = (
+    managed: ManagedChatSession,
+    runtime: CodexRuntime,
+    turnId: string | null | undefined,
+    status: "completed" | "failed" | "interrupted" | string,
+  ): void => {
+    if (turnId) runtime.reviewTurnIds.delete(turnId);
+    if (status !== "completed") {
+      failOpenCodexCompactions(managed, runtime, "interrupted");
+    }
+    void refreshCodexBackgroundTerminals(managed, runtime);
+    if (status !== "completed" || !isCodexCompactionActive(runtime)) {
+      void startCodexQueuedFollowUp(managed, runtime);
+    }
+  };
+
   const handleCodexItemEvent = (
     managed: ManagedChatSession,
     runtime: CodexRuntime,
@@ -26234,7 +26601,10 @@ export function createAgentChatService(args: {
     const itemType = String(item.type ?? "");
     const explicitTurnId = turnIdHint ?? extractCodexTurnId(item);
     const trackedTurnId = runtime.itemTurnIdByItemId.get(itemId) ?? null;
-    if (isInterruptedCodexTurn(runtime, explicitTurnId ?? trackedTurnId)) {
+    if (
+      isInterruptedCodexTurn(runtime, explicitTurnId ?? trackedTurnId)
+      && itemType !== "contextCompaction"
+    ) {
       return;
     }
     const turnId = (() => {
@@ -26269,27 +26639,43 @@ export function createAgentChatService(args: {
           runtime.manualCompactionPending = false;
         }
         const trigger = runtime.manualCompactionItemIds.has(itemId) ? "manual" : "auto";
-        emitChatEvent(managed, {
-          type: "codex_context_compaction",
-          state: "started",
+        runtime.activeCompactions.set(itemId, {
+          itemId,
           trigger,
           turnId: compactionTurnId,
-          compactionId: itemId,
+          startedAt: Date.now(),
+          timer: null,
+        });
+        armCodexCompactionStallTimer(managed, runtime, itemId);
+        emitCodexCompactionEvent(managed, {
+          itemId,
+          turnId: compactionTurnId,
+          trigger,
+          state: "started",
         });
         return;
       }
       if (eventKind === "completed") {
-        const trigger = runtime.manualCompactionItemIds.has(itemId) ? "manual" : "auto";
-        emitChatEvent(managed, {
-          type: "codex_context_compaction",
-          state: "completed",
+        const tracked = runtime.activeCompactions.get(itemId);
+        if (tracked?.timer) clearTimeout(tracked.timer);
+        runtime.activeCompactions.delete(itemId);
+        const trigger = tracked?.trigger
+          ?? (runtime.manualCompactionItemIds.has(itemId) ? "manual" : "auto");
+        emitCodexCompactionEvent(managed, {
+          itemId,
+          turnId: compactionTurnId || tracked?.turnId,
           trigger,
-          turnId: compactionTurnId,
-          compactionId: itemId,
+          state: "completed",
         });
         runtime.manualCompactionItemIds.delete(itemId);
+        void startCodexQueuedFollowUp(managed, runtime);
       }
       return;
+    }
+
+    if (itemType === "review") {
+      const reviewTurnId = turnId ?? runtime.activeTurnId ?? runtime.startedTurnId;
+      if (reviewTurnId) runtime.reviewTurnIds.add(reviewTurnId);
     }
 
     if (itemType === "plan") {
@@ -26331,6 +26717,8 @@ export function createAgentChatService(args: {
       const output = String(item.aggregatedOutput ?? runtime.commandOutputByItemId.get(itemId) ?? "");
       runtime.commandOutputByItemId.set(itemId, output);
       evictOldestEntries(runtime.commandOutputByItemId, MAX_SESSION_MAP_ENTRIES);
+      const commandSource = item.source === "userShell" ? "userShell" as const : undefined;
+      if (commandSource === "userShell") runtime.userShellItemIds.add(itemId);
       emitChatEvent(managed, {
         type: "command",
         command: String(item.command ?? "command"),
@@ -26340,11 +26728,15 @@ export function createAgentChatService(args: {
         turnId,
         exitCode: typeof item.exitCode === "number" ? item.exitCode : null,
         durationMs: typeof item.durationMs === "number" ? item.durationMs : null,
-        status
+        status,
+        ...(commandSource ? { source: commandSource } : {}),
       });
       if (eventKind === "completed") {
         runtime.commandOutputByItemId.delete(itemId);
         runtime.commandOutputStorageClosedItemIds.delete(itemId);
+      }
+      if (commandSource !== "userShell") {
+        void refreshCodexBackgroundTerminals(managed, runtime);
       }
       return;
     }
@@ -27396,6 +27788,7 @@ export function createAgentChatService(args: {
       sessionService.setHeadShaEnd(managed.session.id, endSha);
     }
     persistChatState(managed);
+    settleCodexTurnSideEffects(managed, runtime, turnId, status);
     if (runtime.pendingSteers.length && managed.runtime === runtime) {
       await deliverNextQueuedSteer(managed, runtime);
     }
@@ -27638,6 +28031,32 @@ export function createAgentChatService(args: {
         adoptRuntimeSessionTitle(managed, params, `codex_${method.replace(/[^\w]+/g, "_")}`);
         return;
       }
+    }
+
+    if (method === "thread/queue/changed") {
+      if (!codexServerSupportsThreadQueue(runtime.serverVersion)) return;
+      const threadId = managed.session.threadId;
+      if (!threadId) return;
+      try {
+        const listed = await runtime.request<{
+          queuedSubmissions?: Array<{ id?: string; clientUserMessageId?: string }>;
+        }>("thread/queue/list", { threadId });
+        const liveIds = new Set(
+          (listed.queuedSubmissions ?? [])
+            .map((submission) => String(submission.id ?? "").trim())
+            .filter(Boolean),
+        );
+        for (const [steerId, submissionId] of [...runtime.queuedSubmissionBySteerId]) {
+          if (liveIds.has(submissionId)) continue;
+          runtime.queuedSubmissionBySteerId.delete(steerId);
+        }
+      } catch (error) {
+        logger.debug("codex.queue.list_failed", {
+          sessionId: managed.session.id,
+          error: error instanceof Error ? error.message : String(error),
+        });
+      }
+      return;
     }
 
     if (method === "thread/deleted") {
@@ -27902,6 +28321,7 @@ export function createAgentChatService(args: {
       }
 
       persistChatState(managed);
+      settleCodexTurnSideEffects(managed, runtime, turnId, status);
       if (runtime.pendingSteers.length && managed.runtime === runtime) {
         await deliverNextQueuedSteer(managed, runtime);
       }
@@ -28167,6 +28587,7 @@ export function createAgentChatService(args: {
         ...(managed.session.modelId ? { modelId: managed.session.modelId } : {}),
       });
       persistChatState(managed);
+      settleCodexTurnSideEffects(managed, runtime, turnId, "interrupted");
       if (runtime.pendingSteers.length && managed.runtime === runtime) {
         await deliverNextQueuedSteer(managed, runtime);
       }
@@ -28498,6 +28919,14 @@ export function createAgentChatService(args: {
       planTextByItemId: new Map<string, string>(),
       manualCompactionItemIds: new Set<string>(),
       manualCompactionPending: false,
+      activeCompactions: new Map(),
+      reviewTurnIds: new Set<string>(),
+      lastQueuedCheckIn: null,
+      queuedSubmissionBySteerId: new Map<string, string>(),
+      backgroundTerminalsByProcessId: new Map(),
+      userShellItemIds: new Set<string>(),
+      memoryMode: null,
+      historyPaginated: false,
       webSearchActionsByItemId: new Map<string, CodexWebSearchAction[]>(),
       planningApprovalGuardByTurnId: new Map<string, boolean>(),
       pendingTurnPlanningApprovalGuarded: null,
@@ -28901,6 +29330,9 @@ export function createAgentChatService(args: {
       ...codexPolicyArgs(codexPolicy),
       ...(dynamicTools.length ? { dynamicTools } : {}),
       experimentalRawEvents: false,
+      ...(codexServerSupportsPaginatedHistory(runtime.serverVersion)
+        ? { historyMode: "paginated" as const }
+        : {}),
     });
     applyCodexEffectiveThreadState(managed, startResponse, {
       requestedReasoningEffort: reasoningEffort,
@@ -28912,6 +29344,7 @@ export function createAgentChatService(args: {
       }),
     });
     adoptRuntimeSessionTitle(managed, startResponse, "codex_thread_start");
+    runtime.historyPaginated = codexServerSupportsPaginatedHistory(runtime.serverVersion);
     const newThreadId = typeof startResponse.thread?.id === "string" ? startResponse.thread.id : undefined;
     if (newThreadId) {
       managed.session.threadId = newThreadId;
@@ -31633,9 +32066,22 @@ export function createAgentChatService(args: {
         throw new Error("Full-history fork requires a Codex thread id. Send a Codex message first, then try Fork again.");
       }
       const runtime = await ensureCodexSessionRuntime(managed);
+      try {
+        await runtime.request("thread/goal/clear", {
+          threadId: sourceThreadId,
+        }, { timeoutMs: CODEX_INLINE_COMMAND_TIMEOUT_MS });
+      } catch (error) {
+        logger.warn("agent_chat.codex_goal_clear_before_fork_failed", {
+          sessionId: managed.session.id,
+          error: error instanceof Error ? error.message : String(error),
+        });
+      }
       const forkResponse = await runtime.request<CodexThreadLifecycleResponse>("thread/fork", {
         threadId: sourceThreadId,
         excludeTurns: true,
+        ...(codexServerSupportsDeferGoalContinuation(runtime.serverVersion)
+          ? { deferGoalContinuation: true }
+          : {}),
       }, { timeoutMs: CODEX_INLINE_COMMAND_TIMEOUT_MS });
       const forkedThreadId = typeof forkResponse.thread?.id === "string" ? forkResponse.thread.id.trim() : "";
       if (!forkedThreadId) {
@@ -39503,6 +39949,78 @@ export function createAgentChatService(args: {
         return { steerId, queued: false };
       }
 
+      const composerText = preparedSteer.visibleText;
+      const steeredUserShell = parseCodexUserShellDraft(composerText) ?? parseCodexShellSlashCommand(composerText);
+      if (steeredUserShell) {
+        if (!codexServerSupportsUserShell(runtime.serverVersion)) {
+          emitChatEvent(managed, {
+            type: "system_notice",
+            noticeKind: "info",
+            message: "This Codex app-server cannot run unsandboxed user shell commands.",
+            turnId: runtime.activeTurnId,
+          });
+          return { steerId, queued: false };
+        }
+        await runtime.request("thread/shellCommand", {
+          threadId: managed.session.threadId,
+          command: steeredUserShell.command,
+        });
+        emitChatEvent(managed, {
+          type: "user_message",
+          text: composerText,
+          steerId,
+          turnId: runtime.activeTurnId,
+          deliveryState: "delivered",
+        });
+        persistChatState(managed);
+        return { steerId, queued: false };
+      }
+      const steeredMemory = parseCodexMemorySlashCommand(composerText);
+      if (steeredMemory) {
+        const notice = async (message: string) => {
+          emitChatEvent(managed, {
+            type: "system_notice",
+            noticeKind: "info",
+            message,
+            turnId: runtime.activeTurnId ?? undefined,
+          });
+          persistChatState(managed);
+          return { steerId, queued: false as const };
+        };
+        if (steeredMemory.kind === "invalid") return notice(steeredMemory.message);
+        if (steeredMemory.kind === "reset") {
+          if (!steeredMemory.confirm) {
+            return notice("Reset Codex memory? Confirm with /memory-reset confirm. This deletes every memory file under this Codex home, not just this chat.");
+          }
+          if (!codexServerSupportsMemoryRpc(runtime.serverVersion)) {
+            return notice("This Codex app-server cannot reset memory.");
+          }
+          await runtime.request("memory/reset", {});
+          return notice(CODEX_MEMORY_RESET_RECEIPT);
+        }
+        if (steeredMemory.kind === "status") {
+          const mode = runtime.memoryMode ?? "unknown";
+          return notice(
+            mode === "enabled"
+              ? "Codex memory is on for this thread."
+              : mode === "disabled"
+                ? "Codex memory is off for this thread."
+                : "Codex memory status is unknown for this thread.",
+          );
+        }
+        if (!codexServerSupportsMemoryRpc(runtime.serverVersion)) {
+          return notice("This Codex app-server cannot change memory mode.");
+        }
+        await runtime.request("thread/memoryMode/set", {
+          threadId: managed.session.threadId,
+          mode: steeredMemory.enabled ? "enabled" : "disabled",
+        });
+        runtime.memoryMode = steeredMemory.enabled ? "enabled" : "disabled";
+        return notice(
+          steeredMemory.enabled ? "Codex memory is on for this thread." : "Codex memory is off for this thread.",
+        );
+      }
+
       const input: Array<Record<string, unknown>> = [
         {
           type: "text",
@@ -39533,6 +40051,54 @@ export function createAgentChatService(args: {
       }
 
       let deliveredTurnId = runtime.activeTurnId;
+      if (codexTurnRejectsSteer(runtime)) {
+        if (!codexServerSupportsThreadQueue(runtime.serverVersion)) {
+          emitChatEvent(managed, {
+            type: "system_notice",
+            noticeKind: "info",
+            message: isCodexCompactionActive(runtime)
+              ? "Codex is compacting context. Wait until it finishes — this server cannot queue a follow-up."
+              : "Codex is in a review turn. Wait until it finishes — this server cannot queue a follow-up.",
+            turnId: deliveredTurnId,
+          });
+          return { steerId, queued: false };
+        }
+        const nowMs = Date.now();
+        if (shouldCoalesceCodexCheckIn({
+          previousText: runtime.lastQueuedCheckIn?.text,
+          previousAtMs: runtime.lastQueuedCheckIn?.atMs,
+          nextText: preparedSteer.visibleText,
+          nowMs,
+        })) {
+          emitChatEvent(managed, {
+            type: "system_notice",
+            noticeKind: "info",
+            message: "Duplicate check-in ignored.",
+            turnId: deliveredTurnId,
+          });
+          return { steerId, queued: true };
+        }
+        const queued = await runtime.request("thread/queue/add", {
+          threadId: managed.session.threadId,
+          input,
+          clientUserMessageId: steerId,
+        });
+        const submissionId = readCodexQueueSubmissionId(queued);
+        if (submissionId) runtime.queuedSubmissionBySteerId.set(steerId, submissionId);
+        runtime.lastQueuedCheckIn = { text: preparedSteer.visibleText, atMs: nowMs };
+        emitChatEvent(managed, {
+          type: "user_message",
+          text: preparedSteer.visibleText,
+          ...(preparedSteer.attachments.length ? { attachments: preparedSteer.attachments } : {}),
+          ...(preparedSteer.contextAttachments.length ? { contextAttachments: preparedSteer.contextAttachments } : {}),
+          ...(preparedSteer.metadata ? { metadata: preparedSteer.metadata } : {}),
+          steerId,
+          turnId: deliveredTurnId,
+          deliveryState: "queued",
+        });
+        persistChatState(managed);
+        return { steerId, queued: true };
+      }
       const steerActiveTurn = async (expectedTurnId: string): Promise<void> => {
         await runtime.request("turn/steer", {
           threadId: managed.session.threadId,
@@ -39963,7 +40529,36 @@ export function createAgentChatService(args: {
   const cancelSteer = async ({ sessionId, steerId, requireQueued = false }: AgentChatCancelSteerArgs): Promise<void> => {
     const managed = ensureManagedSession(sessionId);
     const runtime = managed.runtime;
-    if (!runtime || runtime.kind === "codex") {
+    if (runtime?.kind === "codex") {
+      const submissionId = runtime.queuedSubmissionBySteerId.get(steerId);
+      if (!submissionId) {
+        if (requireQueued) throw new Error("This message is no longer queued.");
+        return;
+      }
+      const threadId = managed.session.threadId;
+      if (threadId) {
+        try {
+          await runtime.request("thread/queue/delete", { threadId, id: submissionId });
+        } catch (error) {
+          if (requireQueued) throw error;
+          logger.warn("codex.queue.delete_failed", {
+            sessionId,
+            error: error instanceof Error ? error.message : String(error),
+          });
+        }
+      }
+      runtime.queuedSubmissionBySteerId.delete(steerId);
+      emitChatEvent(managed, {
+        type: "system_notice",
+        noticeKind: "info",
+        steerId,
+        message: "Queued message cancelled.",
+        turnId: runtime.activeTurnId ?? undefined,
+      });
+      persistChatState(managed);
+      return;
+    }
+    if (!runtime) {
       if (requireQueued) throw new Error("This message is no longer queued.");
       return;
     }
@@ -40004,7 +40599,31 @@ export function createAgentChatService(args: {
     const trimmed = text.trim();
     const managed = ensureManagedSession(sessionId);
     const runtime = managed.runtime;
-    if (!runtime || runtime.kind === "codex") return;
+    if (runtime?.kind === "codex") {
+      const submissionId = runtime.queuedSubmissionBySteerId.get(steerId);
+      if (!submissionId) return;
+      const threadId = managed.session.threadId;
+      if (!threadId) return;
+      if (!trimmed.length) {
+        await cancelSteer({ sessionId, steerId, requireQueued: true });
+        return;
+      }
+      await runtime.request("thread/queue/update", {
+        threadId,
+        id: submissionId,
+        input: [{ type: "text", text: trimmed, text_elements: [] }],
+      });
+      emitChatEvent(managed, {
+        type: "user_message",
+        text: trimmed,
+        steerId,
+        turnId: runtime.activeTurnId ?? undefined,
+        deliveryState: "queued",
+      });
+      persistChatState(managed);
+      return;
+    }
+    if (!runtime) return;
 
     const idx = runtime.pendingSteers.findIndex((s) => s.steerId === steerId);
     if (idx === -1) return;
@@ -40412,6 +41031,8 @@ export function createAgentChatService(args: {
       if (!managed.session.threadId) return result;
       if (!runtime.activeTurnId) {
         await interruptActiveCodexSubagentTurns(managed, runtime);
+        failOpenCodexCompactions(managed, runtime, "interrupted");
+        void startCodexQueuedFollowUp(managed, runtime);
         return result;
       }
       let interruptedTurnId = runtime.activeTurnId;
@@ -40469,6 +41090,8 @@ export function createAgentChatService(args: {
         }
       }
       await interruptActiveCodexSubagentTurns(managed, runtime);
+      failOpenCodexCompactions(managed, runtime, "interrupted");
+      void startCodexQueuedFollowUp(managed, runtime);
       return result;
     }
 
@@ -44312,7 +44935,14 @@ export function createAgentChatService(args: {
         || managed.session.modelId !== descriptor.id
         || managed.session.model !== nextModel;
 
-      if (managed.runtime && modelChanged) {
+      const previousCodexRuntime = managed.runtime?.kind === "codex" ? managed.runtime : null;
+      const liveCodexSettings = previousProvider === "codex"
+        && nextProvider === "codex"
+        && Boolean(previousCodexRuntime)
+        && Boolean(managed.session.threadId)
+        && codexServerSupportsThreadSettings(previousCodexRuntime?.serverVersion ?? null);
+
+      if (managed.runtime && modelChanged && !liveCodexSettings) {
         if (managed.runtime.kind === "cursor" && managed.runtime.busy) {
           managed.runtime.pendingModelSwitchReset = true;
         } else {
@@ -44357,7 +44987,7 @@ export function createAgentChatService(args: {
           readTranscriptEnvelopes(managed, { includeBuffered: true }),
           descriptor.contextWindow,
         );
-      } else if (previousProvider === "codex") {
+      } else if (previousProvider === "codex" && !liveCodexSettings) {
         delete managed.session.threadId;
         managed.runtimeInvalidated = true;
         clearLaneDirectiveKey(managed);
@@ -44430,7 +45060,32 @@ export function createAgentChatService(args: {
       if (managed.session.identityKey === "cto" && (modelChanged || reasoningEffort !== undefined)) {
         persistCtoModelPreference(managed, descriptor.id);
       }
-      if (reasoningEffort !== undefined && managed.runtime?.kind === "codex") {
+      if (
+        (modelChanged || reasoningEffort !== undefined)
+        && liveCodexSettings
+        && previousCodexRuntime
+        && managed.session.threadId
+      ) {
+        try {
+          await previousCodexRuntime.request("thread/settings/update", {
+            threadId: managed.session.threadId,
+            ...(modelChanged ? { model: nextModel } : {}),
+            ...(reasoningEffort !== undefined && managed.session.reasoningEffort
+              ? { effort: managed.session.reasoningEffort }
+              : {}),
+          });
+        } catch (error) {
+          logger.warn("agent_chat.codex_thread_settings_update_failed", {
+            sessionId,
+            error: error instanceof Error ? error.message : String(error),
+          });
+          delete managed.session.threadId;
+          managed.runtimeInvalidated = true;
+          clearLaneDirectiveKey(managed);
+          teardownRuntime(managed, "model_switch");
+          refreshReconstructionContext(managed);
+        }
+      } else if (reasoningEffort !== undefined && managed.runtime?.kind === "codex") {
         managed.runtime.threadResumed = false;
         managed.runtime.canAttachResumedTurnStart = false;
       }
@@ -44467,8 +45122,27 @@ export function createAgentChatService(args: {
         }
       }
       if (prev !== next && managed.runtime?.kind === "codex") {
-        managed.runtime.threadResumed = false;
-        managed.runtime.canAttachResumedTurnStart = false;
+        if (
+          managed.session.threadId
+          && codexServerSupportsThreadSettings(managed.runtime.serverVersion)
+        ) {
+          try {
+            await managed.runtime.request("thread/settings/update", {
+              threadId: managed.session.threadId,
+              ...(next ? { effort: next } : {}),
+            });
+          } catch (error) {
+            logger.warn("agent_chat.codex_thread_settings_update_failed", {
+              sessionId,
+              error: error instanceof Error ? error.message : String(error),
+            });
+            managed.runtime.threadResumed = false;
+            managed.runtime.canAttachResumedTurnStart = false;
+          }
+        } else {
+          managed.runtime.threadResumed = false;
+          managed.runtime.canAttachResumedTurnStart = false;
+        }
       }
       if (prev !== next && managed.runtime?.kind === "pi" && next) {
         await managed.runtime.sdk.setThinking(next).catch((error) => {
@@ -46298,19 +46972,52 @@ export function createAgentChatService(args: {
 
       const runtime = await ensureCodexSessionRuntime(managed);
       const threadId = await ensureCodexControlThread(managed, runtime, "rewind");
-      const useForkBeforeTurn = codexServerSupportsForkBeforeTurn(runtime.serverVersion) && plan.targetTurnId != null;
+      const canRevert = codexServerSupportsThreadRevert(runtime.serverVersion) && plan.targetTurnId != null;
+      const canForkBeforeTurn = codexServerSupportsForkBeforeTurn(runtime.serverVersion)
+        && plan.targetTurnId != null;
       // thread/rollback is deprecated upstream; retain it for <=0.144 servers and turns without a usable id.
-      const lifecycleResponse = useForkBeforeTurn
-        ? await runtime.request<CodexThreadLifecycleResponse>("thread/fork", {
+      // thread/revert is paginated-only (0.148+); fall back to fork, then rollback, when the server rejects it.
+      let lifecycleResponse: CodexThreadLifecycleResponse | null = null;
+      let rewindMethod: "revert" | "fork_before_turn" | "rollback" = "rollback";
+      if (canRevert) {
+        try {
+          const reverted = await runtime.request<CodexThreadLifecycleResponse>("thread/revert", {
             threadId,
             beforeTurnId: plan.targetTurnId,
-          }, { timeoutMs: CODEX_INLINE_COMMAND_TIMEOUT_MS })
-        : await runtime.request<CodexThreadLifecycleResponse>("thread/rollback", {
-            threadId,
-            numTurns: 1,
           }, { timeoutMs: CODEX_INLINE_COMMAND_TIMEOUT_MS });
+          if (typeof reverted.thread?.id === "string" && reverted.thread.id.trim()) {
+            lifecycleResponse = reverted;
+            rewindMethod = "revert";
+          }
+        } catch (error) {
+          logger.warn("agent_chat.codex_thread_revert_failed", {
+            sessionId: managed.session.id,
+            error: error instanceof Error ? error.message : String(error),
+          });
+        }
+      }
+      if (!lifecycleResponse) {
+        rewindMethod = canForkBeforeTurn ? "fork_before_turn" : "rollback";
+        lifecycleResponse = canForkBeforeTurn
+          ? await runtime.request<CodexThreadLifecycleResponse>("thread/fork", {
+              threadId,
+              beforeTurnId: plan.targetTurnId,
+            }, { timeoutMs: CODEX_INLINE_COMMAND_TIMEOUT_MS })
+          : await runtime.request<CodexThreadLifecycleResponse>("thread/rollback", {
+              threadId,
+              numTurns: 1,
+            }, { timeoutMs: CODEX_INLINE_COMMAND_TIMEOUT_MS });
+      }
       applyCodexEffectiveThreadState(managed, lifecycleResponse);
-      adoptRuntimeSessionTitle(managed, lifecycleResponse, useForkBeforeTurn ? "codex_thread_fork_before_turn" : "codex_thread_rollback");
+      adoptRuntimeSessionTitle(
+        managed,
+        lifecycleResponse,
+        rewindMethod === "revert"
+          ? "codex_thread_revert"
+          : rewindMethod === "fork_before_turn"
+            ? "codex_thread_fork_before_turn"
+            : "codex_thread_rollback",
+      );
       const rolledBackThreadId = typeof lifecycleResponse.thread?.id === "string"
         ? lifecycleResponse.thread.id
         : threadId;
@@ -47008,6 +47715,55 @@ export function createAgentChatService(args: {
     return null;
   };
 
+  const resetCodexMemory = async ({
+    sessionId,
+  }: AgentChatCodexResetMemoryArgs): Promise<void> => {
+    const managed = ensureManagedSession(sessionId);
+    if (managed.session.provider !== "codex") {
+      throw new Error("Memory reset is only available for Codex chats.");
+    }
+    const runtime = await ensureCodexSessionRuntime(managed);
+    if (!codexServerSupportsMemoryRpc(runtime.serverVersion)) {
+      throw new Error("This Codex app-server cannot reset memory.");
+    }
+    await runtime.request("memory/reset", {}, { timeoutMs: CODEX_INLINE_COMMAND_TIMEOUT_MS });
+    emitChatEvent(managed, {
+      type: "system_notice",
+      noticeKind: "info",
+      message: CODEX_MEMORY_RESET_RECEIPT,
+    });
+    persistChatState(managed);
+  };
+
+  const terminateCodexBackgroundTerminal = async ({
+    sessionId,
+    processId,
+  }: AgentChatCodexTerminateBackgroundTerminalArgs): Promise<void> => {
+    const managed = ensureManagedSession(sessionId);
+    if (managed.session.provider !== "codex") {
+      throw new Error("Background terminal stop is only available for Codex chats.");
+    }
+    const runtime = await ensureCodexSessionRuntime(managed);
+    if (!codexServerSupportsBackgroundTerminals(runtime.serverVersion)) {
+      throw new Error("This Codex app-server cannot terminate background terminals.");
+    }
+    const threadId = managed.session.threadId;
+    if (!threadId) throw new Error("This Codex chat has no thread to stop a background terminal on.");
+    const normalizedProcessId = processId.trim();
+    if (!normalizedProcessId) throw new Error("A processId is required to stop a Codex background terminal.");
+    await runtime.request("thread/backgroundTerminals/terminate", {
+      threadId,
+      processId: normalizedProcessId,
+    }, { timeoutMs: CODEX_INLINE_COMMAND_TIMEOUT_MS });
+    const previous = runtime.backgroundTerminalsByProcessId.get(normalizedProcessId);
+    runtime.backgroundTerminalsByProcessId.delete(normalizedProcessId);
+    if (previous) {
+      emitCodexBackgroundTaskUpdate(managed, normalizedProcessId, "stopped", previous);
+    }
+    await refreshCodexBackgroundTerminals(managed, runtime);
+    persistChatState(managed);
+  };
+
   let fallbackScheduledWorkState: unknown = null;
   scheduledWorkScheduler = createScheduledWorkScheduler({
     loadState: () => db?.getJson(scheduledWorkStateKey) ?? fallbackScheduledWorkState,
@@ -47227,6 +47983,8 @@ export function createAgentChatService(args: {
     setCodexGoal,
     setCodexGoalStatus,
     clearCodexGoal,
+    resetCodexMemory,
+    terminateCodexBackgroundTerminal,
     runSessionTurn,
     steer,
     steerUserMessage,

--- a/apps/desktop/src/main/services/chat/codexAppServerFeatures.test.ts
+++ b/apps/desktop/src/main/services/chat/codexAppServerFeatures.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+import { parseCodexServerVersion } from "./agentChatService";
+import {
+  compactionFailLabel,
+  PINNED_CODEX_APP_SERVER_VERSION,
+  codexServerSupportsBackgroundTerminals,
+  codexServerSupportsDeferGoalContinuation,
+  codexServerSupportsMemoryRpc,
+  codexServerSupportsPaginatedHistory,
+  codexServerSupportsThreadQueue,
+  codexServerSupportsThreadRevert,
+  codexServerSupportsThreadSettings,
+  codexServerSupportsUserShell,
+} from "./codexAppServerFeatures";
+
+describe("codex app-server feature gates", () => {
+  it("keeps 0.144 on the old rewind/rollback path", () => {
+    const v144 = parseCodexServerVersion("codex/0.144.5");
+    expect(codexServerSupportsPaginatedHistory(v144)).toBe(false);
+    expect(codexServerSupportsThreadQueue(v144)).toBe(false);
+    expect(codexServerSupportsThreadRevert(v144)).toBe(false);
+  });
+
+  it("unlocks 0.149 surfaces", () => {
+    const v149 = parseCodexServerVersion("codex/0.149.1");
+    expect(codexServerSupportsPaginatedHistory(v149)).toBe(true);
+    expect(codexServerSupportsDeferGoalContinuation(v149)).toBe(true);
+    expect(codexServerSupportsThreadQueue(v149)).toBe(true);
+    expect(codexServerSupportsThreadSettings(v149)).toBe(true);
+    expect(codexServerSupportsThreadRevert(v149)).toBe(true);
+    expect(codexServerSupportsBackgroundTerminals(v149)).toBe(true);
+    expect(codexServerSupportsUserShell(v149)).toBe(true);
+    expect(codexServerSupportsMemoryRpc(v149)).toBe(true);
+  });
+
+  it("pins the app-server version ADE ships", () => {
+    expect(PINNED_CODEX_APP_SERVER_VERSION).toBe("0.149.1");
+  });
+
+  it("does not invent support when the user-agent is missing", () => {
+    expect(codexServerSupportsThreadQueue(null)).toBe(false);
+    expect(codexServerSupportsThreadRevert(null)).toBe(false);
+  });
+
+  it("labels compaction failures", () => {
+    expect(compactionFailLabel("timed_out")).toBe("Compaction timed out");
+    expect(compactionFailLabel("interrupted")).toBe("Compaction failed");
+    expect(compactionFailLabel("teardown")).toBe("Compaction failed");
+  });
+});

--- a/apps/desktop/src/main/services/chat/codexAppServerFeatures.ts
+++ b/apps/desktop/src/main/services/chat/codexAppServerFeatures.ts
@@ -1,0 +1,54 @@
+export const CODEX_COMPACTION_STALL_MS = 180_000;
+export const PINNED_CODEX_APP_SERVER_VERSION = "0.149.1";
+
+export type CodexAppServerVersion = {
+  major: number;
+  minor: number;
+  patch: number;
+};
+
+export function codexServerAtLeast(
+  version: CodexAppServerVersion | null,
+  minMinor: number,
+): boolean {
+  if (!version) return false;
+  if (version.major > 0) return true;
+  return version.minor >= minMinor;
+}
+
+/** `thread/fork` `beforeTurnId` + `excludeTurns` + paginated history (0.145). */
+export function codexServerSupportsPaginatedHistory(version: CodexAppServerVersion | null): boolean {
+  return codexServerAtLeast(version, 145);
+}
+
+export function codexServerSupportsDeferGoalContinuation(version: CodexAppServerVersion | null): boolean {
+  return codexServerAtLeast(version, 145);
+}
+
+/** Durable FIFO `thread/queue/*` (0.146+; ADE pins 0.149.1). */
+export function codexServerSupportsThreadQueue(version: CodexAppServerVersion | null): boolean {
+  return codexServerAtLeast(version, 146);
+}
+
+export function codexServerSupportsThreadSettings(version: CodexAppServerVersion | null): boolean {
+  return codexServerAtLeast(version, 146);
+}
+
+export function codexServerSupportsThreadRevert(version: CodexAppServerVersion | null): boolean {
+  return codexServerAtLeast(version, 148);
+}
+
+export function codexServerSupportsBackgroundTerminals(version: CodexAppServerVersion | null): boolean {
+  return codexServerAtLeast(version, 146);
+}
+
+export function codexServerSupportsUserShell(version: CodexAppServerVersion | null): boolean {
+  return codexServerAtLeast(version, 146);
+}
+
+export function codexServerSupportsMemoryRpc(version: CodexAppServerVersion | null): boolean {
+  return codexServerAtLeast(version, 146);
+}
+
+export type { ContextCompactFailReason as CodexCompactionFailReason } from "../../../shared/contextCompaction";
+export { compactionFailLabel } from "../../../shared/contextCompaction";

--- a/apps/desktop/src/main/services/chat/contextCompactionEmitter.ts
+++ b/apps/desktop/src/main/services/chat/contextCompactionEmitter.ts
@@ -41,7 +41,8 @@ export function buildContextCompactEvent(
   session: AgentChatSession,
   input: {
     trigger: "manual" | "auto" | "ade_fallback";
-    state?: "started" | "completed";
+    state?: "started" | "completed" | "failed";
+    failReason?: "interrupted" | "timed_out" | "teardown";
     turnId?: string;
     compactionId?: string;
     preTokens?: number;
@@ -72,12 +73,15 @@ export function buildContextCompactEvent(
   const startedAt = state.startedAtByKey.get(mergeKey);
   state.startedAtByKey.delete(mergeKey);
   const durationMs = input.durationMs ?? (startedAt != null && now > startedAt ? now - startedAt : undefined);
-  state.sessionCompactionCount += 1;
+  if (lifecycle !== "failed") {
+    state.sessionCompactionCount += 1;
+  }
 
   return {
     type: "context_compact",
     trigger: input.trigger,
-    state: "completed",
+    state: lifecycle,
+    ...(input.failReason ? { failReason: input.failReason } : {}),
     ...(input.turnId ? { turnId: input.turnId } : {}),
     ...(compactionId ? { compactionId } : {}),
     ...(input.preTokens != null ? { preTokens: input.preTokens } : {}),
@@ -85,7 +89,9 @@ export function buildContextCompactEvent(
     ...(input.tokensRemoved != null ? { tokensRemoved: input.tokensRemoved } : {}),
     ...(durationMs != null ? { durationMs } : {}),
     ...(provider ? { provider } : {}),
-    ...(state.sessionCompactionCount >= 2 ? { sessionCompactionCount: state.sessionCompactionCount } : {}),
+    ...(lifecycle !== "failed" && state.sessionCompactionCount >= 2
+      ? { sessionCompactionCount: state.sessionCompactionCount }
+      : {}),
   };
 }
 
@@ -99,6 +105,7 @@ export function mapLegacyCompactionEvent(
     return buildContextCompactEvent(state, session, {
       trigger: event.trigger,
       state: event.state,
+      failReason: event.failReason,
       turnId: event.turnId,
       compactionId: event.compactionId ?? event.turnId,
       preTokens: event.preTokens,
@@ -111,6 +118,7 @@ export function mapLegacyCompactionEvent(
     return buildContextCompactEvent(state, session, {
       trigger: event.trigger,
       state: event.state,
+      failReason: event.failReason,
       turnId: event.turnId,
       compactionId: event.compactionId ?? event.turnId,
     });

--- a/apps/desktop/src/main/services/ipc/registerIpc.ts
+++ b/apps/desktop/src/main/services/ipc/registerIpc.ts
@@ -369,6 +369,8 @@ import type {
   AgentChatApproveArgs,
   AgentChatArchiveArgs,
   AgentChatCodexClearGoalArgs,
+  AgentChatCodexResetMemoryArgs,
+  AgentChatCodexTerminateBackgroundTerminalArgs,
   AgentChatCodexGetGoalArgs,
   AgentChatCodexSetGoalArgs,
   AgentChatCodexSetGoalStatusArgs,
@@ -8215,6 +8217,16 @@ export function registerIpc({
   ipcMain.handle(IPC.agentChatCodexClearGoal, async (_event, arg: AgentChatCodexClearGoalArgs): Promise<CodexThreadGoal | null> => {
     const ctx = ensureAgentChatContext();
     return ctx.agentChatService.clearCodexGoal(arg);
+  });
+
+  ipcMain.handle(IPC.agentChatCodexResetMemory, async (_event, arg: AgentChatCodexResetMemoryArgs): Promise<void> => {
+    const ctx = ensureAgentChatContext();
+    return ctx.agentChatService.resetCodexMemory(arg);
+  });
+
+  ipcMain.handle(IPC.agentChatCodexTerminateBackgroundTerminal, async (_event, arg: AgentChatCodexTerminateBackgroundTerminalArgs): Promise<void> => {
+    const ctx = ensureAgentChatContext();
+    return ctx.agentChatService.terminateCodexBackgroundTerminal(arg);
   });
 
   ipcMain.handle(IPC.agentChatListClaudePlugins, async (_event, arg: AgentChatClaudePluginsArgs = {}): Promise<AgentChatClaudePlugin[]> => {

--- a/apps/desktop/src/preload/global.d.ts
+++ b/apps/desktop/src/preload/global.d.ts
@@ -114,6 +114,8 @@ import type {
   AgentChatApproveArgs,
   AgentChatArchiveArgs,
   AgentChatCodexClearGoalArgs,
+  AgentChatCodexResetMemoryArgs,
+  AgentChatCodexTerminateBackgroundTerminalArgs,
   AgentChatCodexGetGoalArgs,
   AgentChatCodexSetGoalArgs,
   AgentChatCodexSetGoalStatusArgs,
@@ -2043,6 +2045,14 @@ declare global {
             args: AgentChatCodexClearGoalArgs,
             pin?: OpenProjectBinding | null,
           ) => Promise<CodexThreadGoal | null>;
+          resetMemory: (
+            args: AgentChatCodexResetMemoryArgs,
+            pin?: OpenProjectBinding | null,
+          ) => Promise<void>;
+          terminateBackgroundTerminal: (
+            args: AgentChatCodexTerminateBackgroundTerminalArgs,
+            pin?: OpenProjectBinding | null,
+          ) => Promise<void>;
         };
         readTranscript: (args: {
           sessionId: string;

--- a/apps/desktop/src/preload/preload.ts
+++ b/apps/desktop/src/preload/preload.ts
@@ -370,6 +370,8 @@ import type {
   AgentChatApproveArgs,
   AgentChatArchiveArgs,
   AgentChatCodexClearGoalArgs,
+  AgentChatCodexResetMemoryArgs,
+  AgentChatCodexTerminateBackgroundTerminalArgs,
   AgentChatCodexGetGoalArgs,
   AgentChatCreateArgs,
   AgentChatLaunchArgs,
@@ -1448,6 +1450,8 @@ const MUTATING_CHAT_ACTIONS = new Set<string>([
   "setCodexGoal",
   "setCodexGoalStatus",
   "clearCodexGoal",
+  "resetCodexMemory",
+  "terminateCodexBackgroundTerminal",
   // Private draft state must never fall through to the process-global IPC
   // database while the owning project binding is changing.
   "listPromptStashes",
@@ -7264,6 +7268,22 @@ const adeBridge = {
         );
         agentChatSummaryCache.clear();
         return goal as CodexThreadGoal | null;
+      },
+      resetMemory: async (
+        args: AgentChatCodexResetMemoryArgs,
+        pin?: OpenProjectBinding | null,
+      ): Promise<void> => {
+        await callPinnedOrBoundRuntimeActionOr(pin, "chat", "resetCodexMemory", { args }, () =>
+          ipcRenderer.invoke(IPC.agentChatCodexResetMemory, args),
+        );
+      },
+      terminateBackgroundTerminal: async (
+        args: AgentChatCodexTerminateBackgroundTerminalArgs,
+        pin?: OpenProjectBinding | null,
+      ): Promise<void> => {
+        await callPinnedOrBoundRuntimeActionOr(pin, "chat", "terminateCodexBackgroundTerminal", { args }, () =>
+          ipcRenderer.invoke(IPC.agentChatCodexTerminateBackgroundTerminal, args),
+        );
       },
     },
     readTranscript: (args: {

--- a/apps/desktop/src/renderer/components/chat/AgentChatComposer.tsx
+++ b/apps/desktop/src/renderer/components/chat/AgentChatComposer.tsx
@@ -54,6 +54,7 @@ import {
   type ComposerTrigger,
   type ComposerTriggerDismissal,
 } from "../../../shared/composerTriggers";
+import { codexUserShellChipRange } from "../../../shared/codexComposerCommands";
 import {
   formatChatMentionToken,
   isChatMentionTokenBody,
@@ -2275,17 +2276,46 @@ export function AgentChatComposer({
     });
   }, [attachedPaths, draft, knownSlashCommandNames, useRichComposer]);
   const [plainOverlayScrollTop, setPlainOverlayScrollTop] = useState(0);
+  const userShellChipRange = sessionProvider === "codex"
+    ? codexUserShellChipRange(draft)
+    : null;
+  const plainUserShellChipRange = useRichComposer ? null : userShellChipRange;
   useLayoutEffect(() => {
-    if (!plainComposerTokens.length) return;
+    if (!plainComposerTokens.length && !plainUserShellChipRange) return;
     setPlainOverlayScrollTop(textareaRef.current?.scrollTop ?? 0);
-  }, [draft, plainComposerTokens.length]);
+  }, [draft, plainComposerTokens.length, plainUserShellChipRange]);
   const plainOverlayContent = useMemo(() => {
-    if (!plainComposerTokens.length) return null;
+    if (!plainComposerTokens.length && !plainUserShellChipRange) return null;
     const segments: React.ReactNode[] = [];
     let pos = 0;
-    plainComposerTokens.forEach((token, index) => {
+    const tokens: Array<{ start: number; end: number; kind: "file" | "command" | "mention" | "shell" }> = [...plainComposerTokens];
+    if (plainUserShellChipRange) {
+      tokens.push({
+        start: plainUserShellChipRange.start,
+        end: plainUserShellChipRange.end,
+        kind: "shell" as const,
+      });
+      tokens.sort((left, right) => left.start - right.start);
+    }
+    tokens.forEach((token, index) => {
       if (token.start > pos) segments.push(draft.slice(pos, token.start));
       const tokenText = draft.slice(token.start, token.end);
+      if (token.kind === "shell") {
+        segments.push(
+          <span
+            key={`chip-${index}-${token.start}`}
+            className="rounded-[4px] bg-cyan-500/16 px-0.5 text-cyan-100/92 shadow-[inset_0_0_0_1px_rgba(103,232,249,0.28)]"
+            title="User shell · unsandboxed"
+          >
+            <span className="relative inline-block align-baseline">
+              <span className="invisible whitespace-pre">{tokenText}</span>
+              <span className="absolute inset-0 overflow-hidden text-ellipsis whitespace-nowrap">$</span>
+            </span>
+          </span>,
+        );
+        pos = token.end;
+        return;
+      }
       const displayText = token.kind === "mention"
         ? mentionLabels?.[tokenText]?.trim() || mentionLabelsRef.current.get(tokenText)?.trim() || tokenText
         : tokenText;
@@ -2318,7 +2348,7 @@ export function AgentChatComposer({
     // measurable so the overlay height matches the textarea's scrollHeight.
     segments.push("​");
     return segments;
-  }, [draft, mentionLabels, plainComposerTokens]);
+  }, [draft, mentionLabels, plainComposerTokens, plainUserShellChipRange]);
 
   // Pre-warm the lane's quick-open file index as soon as the composer is
   // bound to a session so the first "@" query is served from a warm index.
@@ -6056,7 +6086,9 @@ export function AgentChatComposer({
                 rows={1}
                 onInput={resizeTextarea}
                 onScroll={(event) => {
-                  if (plainComposerTokens.length) setPlainOverlayScrollTop(event.currentTarget.scrollTop);
+                  if (plainComposerTokens.length || plainUserShellChipRange) {
+                    setPlainOverlayScrollTop(event.currentTarget.scrollTop);
+                  }
                 }}
                 onCompositionStart={() => {
                   imeComposingRef.current = true;
@@ -6099,6 +6131,20 @@ export function AgentChatComposer({
               />
             </div>
           )}
+          {userShellChipRange && useRichComposer ? (
+            <div
+              className="flex items-center gap-1.5 px-4 pb-1.5 font-mono text-[11px] leading-none text-cyan-200/55"
+              title="User shell · unsandboxed"
+            >
+              <span
+                className="rounded-[4px] bg-cyan-500/16 px-1 py-px text-cyan-100/85 shadow-[inset_0_0_0_1px_rgba(103,232,249,0.28)]"
+                aria-hidden
+              >
+                $
+              </span>
+              <span>User shell</span>
+            </div>
+          ) : null}
           {selectedSmartLinkNode?.isConnected ? (
             <ComposerSmartLinkMenu
               anchor={selectedSmartLinkNode}

--- a/apps/desktop/src/renderer/components/chat/AgentChatMessageList.tsx
+++ b/apps/desktop/src/renderer/components/chat/AgentChatMessageList.tsx
@@ -5288,6 +5288,7 @@ function AgentChatMessageListMain({
   onRestoreCancelledQueue,
   turnDiffSummaries,
   sessionEnded = false,
+  sessionProvider = null,
   hasOlderHistory = false,
   loadingOlderHistory = false,
   olderHistoryError = null,
@@ -5337,6 +5338,7 @@ function AgentChatMessageListMain({
   /** Stable identity for collapse warm-cache isolation when rendering a nested transcript. */
   transcriptCollapseCacheKey?: string | null;
   sessionEnded?: boolean;
+  sessionProvider?: string | null;
   /** True when older transcript pages exist above the loaded events. */
   hasOlderHistory?: boolean;
   /** True while an older transcript page is being fetched. */
@@ -6528,8 +6530,10 @@ function AgentChatMessageListMain({
   );
 
   const minimapSourceEntries = useMemo(
-    () => collectUserMessageMinimapSourceEntries(groupedRows),
-    [groupedRows],
+    () => collectUserMessageMinimapSourceEntries(groupedRows, {
+      includeCodexExtras: sessionProvider === "codex",
+    }),
+    [groupedRows, sessionProvider],
   );
 
   const promptHistoryFocusIndex = useMemo(() => {

--- a/apps/desktop/src/renderer/components/chat/AgentChatPane.test.tsx
+++ b/apps/desktop/src/renderer/components/chat/AgentChatPane.test.tsx
@@ -751,6 +751,8 @@ function installAdeMocks(options?: {
         setGoal: setCodexGoal,
         clearGoal: clearCodexGoal,
         setGoalStatus: setCodexGoalStatus,
+        resetMemory: vi.fn().mockResolvedValue(undefined),
+        terminateBackgroundTerminal: vi.fn().mockResolvedValue(undefined),
       },
       fileSearch: vi.fn().mockResolvedValue([]),
       saveTempAttachment,

--- a/apps/desktop/src/renderer/components/chat/AgentChatPane.tsx
+++ b/apps/desktop/src/renderer/components/chat/AgentChatPane.tsx
@@ -199,6 +199,7 @@ import { findUserMessageForTurn, isParentUserMessage, resolveTurnActive } from "
 import { ModelPicker } from "../shared/ModelPicker/ModelPicker";
 import { ReasoningEffortPicker } from "../shared/ModelPicker/ReasoningEffortPicker";
 import { ConfirmDialog, useConfirmDialog } from "../shared/InlineDialogs";
+import { isCodexMemoryResetDraft } from "../../../shared/codexComposerCommands";
 import { ChatActionsDrawerPanel, type ChatActionsTab } from "./ChatActionsDrawerPanel";
 import { ChatSourcesPanel } from "./ChatSourcesPanel";
 import { CrossMachineHandoffModal } from "./CrossMachineHandoffModal";
@@ -10189,6 +10190,7 @@ export function AgentChatPane({
   }, [invalidateCurrentChatSessionList, refreshSessions]);
 
   const archiveConfirm = useConfirmDialog();
+  const memoryResetConfirm = useConfirmDialog();
   const requestArchiveChat = useCallback(
     async (sessionId: string, title: string) => {
       const ok = await archiveConfirm.confirmAsync({
@@ -10686,6 +10688,35 @@ export function AgentChatPane({
       } catch (outputStyleError) {
         setDraft((current) => (current.trim().length ? current : draft));
         setError(outputStyleError instanceof Error ? outputStyleError.message : String(outputStyleError));
+      } finally {
+        setBusy(false);
+      }
+      return;
+    }
+    if (
+      selectedSessionId
+      && sessionProvider === "codex"
+      && isCodexMemoryResetDraft(text)
+      && !attachments.length
+      && !contextAttachmentsSnapshot.length
+      && !visualContextPrefix.length
+    ) {
+      const ok = await memoryResetConfirm.confirmAsync({
+        title: "Reset Codex memory?",
+        message: "Deletes every memory file under this Codex home, not just this chat.",
+        confirmLabel: "Reset memory",
+        danger: true,
+      });
+      if (!ok) return;
+      setBusy(true);
+      setError(null);
+      setDraft("");
+      draftsPerSessionRef.current.delete(selectedSessionId);
+      try {
+        await window.ade.agentChat.codex.resetMemory({ sessionId: selectedSessionId }, chatRuntimePinRef.current);
+      } catch (resetError) {
+        setDraft((current) => (current.trim().length ? current : text));
+        setError(resetError instanceof Error ? resetError.message : String(resetError));
       } finally {
         setBusy(false);
       }
@@ -11827,6 +11858,19 @@ export function AgentChatPane({
           scheduleSessionsRefresh();
         }).catch((cancelError) => {
           setError(cancelError instanceof Error ? cancelError.message : String(cancelError));
+        });
+      } : undefined}
+      onStopBackgroundTask={selectedSessionId && (selectedSession?.provider ?? sessionProvider) === "codex" ? (snapshot) => {
+        const processId = snapshot.sourceTaskId?.trim();
+        if (!processId) {
+          setError("This background command has no process id to stop.");
+          return;
+        }
+        void window.ade.agentChat.codex.terminateBackgroundTerminal({
+          sessionId: selectedSessionId,
+          processId,
+        }, chatRuntimePinRef.current).catch((stopError) => {
+          setError(stopError instanceof Error ? stopError.message : String(stopError));
         });
       } : undefined}
       variant="pane"
@@ -13833,6 +13877,7 @@ export function AgentChatPane({
                           : turnActive && selectedSession?.status !== "ended"}
                         sessionTurnActive={turnActive}
                         sessionEnded={selectedSession?.status === "ended"}
+                        sessionProvider={selectedSession?.provider ?? sessionProvider}
                         runtimePin={chatRuntimePin}
                         className="min-h-0 border-0"
                         surfaceMode={surfaceMode}
@@ -14225,6 +14270,7 @@ export function AgentChatPane({
         />
       ) : null}
       <ConfirmDialog state={archiveConfirm.state} onClose={archiveConfirm.close} />
+      <ConfirmDialog state={memoryResetConfirm.state} onClose={memoryResetConfirm.close} />
       {onImportedSession && importTargetLane ? (
         <ImportSessionBrowser
           open={importBrowserOpen}

--- a/apps/desktop/src/renderer/components/chat/ChatSubagentsPanel.tsx
+++ b/apps/desktop/src/renderer/components/chat/ChatSubagentsPanel.tsx
@@ -8,6 +8,7 @@ import {
   CircleHalf,
   Pause,
   Play,
+  Square,
   TreeStructure,
   X,
 } from "@phosphor-icons/react";
@@ -699,7 +700,13 @@ function backgroundDurationLabel(snapshot: ChatScheduledWorkSnapshot, nowMs?: nu
  * command carries a leading `cd <path> &&`. Terminal rows render their final
  * state (the backend now guarantees terminal events arrive).
  */
-function BackgroundCommandRow({ snapshot }: { snapshot: ChatScheduledWorkSnapshot }) {
+function BackgroundCommandRow({
+  snapshot,
+  onStop,
+}: {
+  snapshot: ChatScheduledWorkSnapshot;
+  onStop?: (snapshot: ChatScheduledWorkSnapshot) => void;
+}) {
   const [expanded, setExpanded] = useState(false);
   const rawCommand = (snapshot.title || snapshot.prompt || snapshot.summary || "").trim();
   const label = backgroundCommandLabel(rawCommand) || rawCommand || "Background command";
@@ -717,11 +724,12 @@ function BackgroundCommandRow({ snapshot }: { snapshot: ChatScheduledWorkSnapsho
 
   return (
     <div className="rounded-md transition-colors duration-150 hover:bg-white/[0.035]">
+      <div className="grid w-full grid-cols-[minmax(0,1fr)_auto] items-center gap-1 pr-1">
       <button
         type="button"
         onClick={() => setExpanded((value) => !value)}
         aria-expanded={expanded}
-        className="grid w-full grid-cols-[auto_minmax(0,1fr)_auto] items-center gap-1.5 px-2 py-1.5 text-left"
+        className="grid min-w-0 grid-cols-[auto_minmax(0,1fr)_auto] items-center gap-1.5 px-2 py-1.5 text-left"
         title={rawCommand || label}
       >
         <span aria-hidden className="shrink-0 text-fg/30">
@@ -746,6 +754,18 @@ function BackgroundCommandRow({ snapshot }: { snapshot: ChatScheduledWorkSnapsho
           </span>
         </span>
       </button>
+      {isRunning && onStop ? (
+        <button
+          type="button"
+          aria-label="Stop background command"
+          title="Stop background command"
+          onClick={() => onStop(snapshot)}
+          className="flex h-7 w-7 items-center justify-center rounded-md text-fg/45 transition-colors hover:bg-rose-500/10 hover:text-rose-200/90"
+        >
+          <Square aria-hidden size={10} weight="fill" />
+        </button>
+      ) : null}
+      </div>
       <AnimatePresence initial={false}>
         {expanded ? (
           <motion.div
@@ -1011,6 +1031,7 @@ export function ChatSubagentsPanel({
   schedulesPaused = false,
   onToggleSchedulesPaused,
   onCancelScheduledWork,
+  onStopBackgroundTask,
   sessionModelLabel = null,
 }: {
   sessionId?: string | null;
@@ -1052,7 +1073,8 @@ export function ChatSubagentsPanel({
   onToggleSchedulesPaused?: () => void;
   /** Cancel one durable schedule. Claude cron jobs are deleted through CronDelete. */
   onCancelScheduledWork?: (snapshot: ChatScheduledWorkSnapshot) => void;
-  /** Parent session model label for inherited roster chips when a child did not report one. */
+  /** Stop a running Codex background terminal via `thread/backgroundTerminals/terminate`. */
+  onStopBackgroundTask?: (snapshot: ChatScheduledWorkSnapshot) => void;
   sessionModelLabel?: string | null;
 }) {
   const [expanded, setExpanded] = useState(false);
@@ -1491,8 +1513,8 @@ export function ChatSubagentsPanel({
           hint={paneSectionHint({ activeCount: backgroundGroups.active.length, runningCount: backgroundRunningCount, failedCount: backgroundFailedCount })}
           groups={backgroundGroups} capped={cappedBackground} paneUi={paneUi} sticky={stickyHeaders}
           idOf={(item) => item.id}
-          renderActiveRow={(item) => <BackgroundCommandRow snapshot={item} />}
-          renderEarlierRow={(item) => <BackgroundCommandRow snapshot={item} />}
+          renderActiveRow={(item) => <BackgroundCommandRow snapshot={item} onStop={onStopBackgroundTask} />}
+          renderEarlierRow={(item) => <BackgroundCommandRow snapshot={item} onStop={onStopBackgroundTask} />}
           onToggleCollapsed={() => toggleSection("background")} onToggleEarlier={() => toggleEarlier("background")}
           onClear={(ids) => clearEarlier("background", ids)} onRestore={() => restoreCleared("background")}
           onShowAll={() => setShowAll((current) => ({ ...current, background: true }))} showAll={showAll.background === true}

--- a/apps/desktop/src/renderer/components/chat/ChatUserMinimap.tsx
+++ b/apps/desktop/src/renderer/components/chat/ChatUserMinimap.tsx
@@ -174,7 +174,9 @@ export function ChatUserMinimap({
     : null;
   const resolvedPreviewIndex = resolvedHoverIndex ?? resolvedKeyboardIndex;
   const previewEntry = resolvedPreviewIndex === null ? null : (entries[resolvedPreviewIndex] ?? null);
-  const previewOutcomeLabel = turnOutcomeLabel(previewEntry?.turnOutcome ?? null);
+  const previewOutcomeLabel = (previewEntry?.kind ?? "user") === "user"
+    ? turnOutcomeLabel(previewEntry?.turnOutcome ?? null)
+    : null;
 
   // Keep a durable continuation marker when the resident tail has fewer than
   // two user turns. Otherwise the whole rail disappears at the transcript
@@ -275,22 +277,29 @@ export function ChatUserMinimap({
             const lensDistance =
               resolvedPreviewIndex === null ? null : Math.abs(index - resolvedPreviewIndex);
             const outcome = entry.turnOutcome;
+            const kind = entry.kind ?? "user";
+            const isPrimary = kind === "user";
             return (
               <span
                 key={entry.key}
                 aria-hidden="true"
                 data-minimap-tick=""
                 data-outcome={outcome ?? undefined}
+                data-minimap-kind={kind}
                 className={cn(
-                  "pointer-events-none absolute left-0 -translate-y-1/2 rounded-full transition-[background-color,width] duration-150",
-                  // Thickness, not just colour, marks a turn that needs attention.
-                  isAttentionOutcome(outcome) ? "h-1" : "h-0.5",
-                  lensWidthClass(lensDistance),
+                  "pointer-events-none absolute -translate-y-1/2 transition-[background-color,width] duration-150",
+                  kind === "compact" && "left-[2px] h-1.5 w-1.5 rotate-45 rounded-[1px]",
+                  kind === "queued" && "left-[1px] h-1 w-1 rounded-[1px]",
+                  isPrimary && "left-0 rounded-full",
+                  isPrimary && (isAttentionOutcome(outcome) ? "h-1" : "h-0.5"),
+                  isPrimary && lensWidthClass(lensDistance),
                   tickToneClass(
                     outcome,
-                    index === activeIndex || index === resolvedKeyboardIndex,
-                    lensDistance === 0,
+                    isPrimary && (entry.fullUserOrdinal === activeIndex || index === resolvedKeyboardIndex),
+                    isPrimary && lensDistance === 0,
                   ),
+                  kind === "compact" && (outcome === "failed" ? "bg-red-400/80" : "bg-amber-300/70"),
+                  kind === "queued" && "bg-cyan-300/70",
                 )}
                 style={{ top: `${resolveMinimapTopPercent(index, itemCount)}%` }}
               />

--- a/apps/desktop/src/renderer/components/chat/ContextCompactDivider.tsx
+++ b/apps/desktop/src/renderer/components/chat/ContextCompactDivider.tsx
@@ -1,7 +1,8 @@
-import { CircleNotch, Check } from "@phosphor-icons/react";
+import { CircleNotch, Check, WarningCircle } from "@phosphor-icons/react";
 import { motion } from "motion/react";
 import type { AgentChatEvent } from "../../../shared/types";
 import {
+  compactionFailLabel,
   normalizeContextCompactEvent,
   resolveProviderTint,
 } from "../../../shared/contextCompaction";
@@ -15,16 +16,25 @@ function completedTitle(_sessionCompactionCount?: number, fallback?: boolean): s
   return fallback ? "Context compacted (fallback)" : "Context compacted";
 }
 
+function compactTitle(compact: NonNullable<ReturnType<typeof normalizeContextCompactEvent>>): string {
+  const isFallback = compact.trigger === "ade_fallback";
+  if (compact.state === "started") {
+    return isFallback ? "Compacting context (fallback)…" : "Compacting context…";
+  }
+  if (compact.state === "failed") {
+    return compactionFailLabel(compact.failReason);
+  }
+  return completedTitle(compact.sessionCompactionCount, isFallback);
+}
+
 export function ContextCompactDivider({ event }: ContextCompactDividerProps) {
   const compact = normalizeContextCompactEvent(event);
   if (!compact) return null;
 
   const isInProgress = compact.state === "started";
-  // ADE only steps in when the SDK's own >90% auto-compaction demonstrably did
-  // not run; label it distinctly so the accompanying notice doesn't read as a
-  // duplicate of a normal compaction.
-  const isFallback = compact.trigger === "ade_fallback";
+  const isFailed = compact.state === "failed";
   const tint = resolveProviderTint(compact.provider);
+  const title = compactTitle(compact);
 
   return (
     <motion.div
@@ -33,7 +43,7 @@ export function ContextCompactDivider({ event }: ContextCompactDividerProps) {
       initial={false}
       animate={{ opacity: 1 }}
       transition={{ duration: 0.28, ease: "easeOut" }}
-      aria-label={isInProgress ? "Compacting context" : completedTitle(compact.sessionCompactionCount, isFallback)}
+      aria-label={title}
     >
       <span
         className="h-px min-w-8 flex-1 bg-gradient-to-r from-transparent via-amber-400/20 to-transparent"
@@ -44,7 +54,7 @@ export function ContextCompactDivider({ event }: ContextCompactDividerProps) {
         className={cn(
           // One transcript width for every row — see `--chat-content-width`.
           "inline-flex max-w-[var(--chat-content-width,52rem)] items-center rounded-full px-3 py-1.5 ring-1 ring-inset",
-          "bg-amber-500/[0.08] text-amber-100/85",
+          isFailed ? "bg-rose-500/[0.08] text-rose-100/85" : "bg-amber-500/[0.08] text-amber-100/85",
           tint.ring,
           tint.border,
         )}
@@ -52,13 +62,13 @@ export function ContextCompactDivider({ event }: ContextCompactDividerProps) {
       >
         {isInProgress ? (
           <CircleNotch size={12} weight="bold" className="animate-spin text-amber-200/80" aria-hidden />
+        ) : isFailed ? (
+          <WarningCircle size={12} weight="bold" className="text-rose-200/90" aria-hidden />
         ) : (
           <Check size={12} weight="bold" className="text-amber-200/90" aria-hidden />
         )}
         <span className="ml-2 whitespace-nowrap text-[length:calc(var(--chat-font-size)*10/14)] font-semibold tracking-[0.02em]">
-          {isInProgress
-            ? (isFallback ? "Compacting context (fallback)…" : "Compacting context…")
-            : completedTitle(compact.sessionCompactionCount, isFallback)}
+          {title}
         </span>
       </motion.div>
       <span

--- a/apps/desktop/src/renderer/components/chat/chatTranscriptRows.ts
+++ b/apps/desktop/src/renderer/components/chat/chatTranscriptRows.ts
@@ -823,7 +823,7 @@ function buildCommandWorkLogEvent(
     entry: withLocalhostUrls({
       id: buildWorkLogEntryId(collapseKey, event),
       createdAt: timestamp,
-      label: "Shell",
+      label: event.source === "userShell" ? "User shell" : "Shell",
       command: event.command,
       output: event.output,
       cwd: event.cwd,
@@ -2309,7 +2309,7 @@ export function appendCollapsedChatTranscriptEvent(
         const existing = normalizeContextCompactEvent(candidateEvent as AgentChatEvent);
         if (!existing) return false;
         if (contextCompactMergeKey(existing) !== mergeKey) return false;
-        return existing.state === "started" || incoming.state === "completed";
+        return existing.state === "started" || incoming.state === "completed" || incoming.state === "failed";
       });
     if (matchIndex >= 0) {
       const actualIndex = rows.length - 1 - matchIndex;

--- a/apps/desktop/src/renderer/components/chat/chatUserMinimap.logic.test.ts
+++ b/apps/desktop/src/renderer/components/chat/chatUserMinimap.logic.test.ts
@@ -362,4 +362,67 @@ describe("chatUserMinimap.logic", () => {
     const offsets = computeRowStartOffsets(4, (i) => 10 + i, 0);
     expect(computeScrollTopForRow(2, offsets)).toBe(offsets[2]);
   });
+
+  it("adds Codex queued and compact ticks without a tick per done event", () => {
+    const rows: ChatTranscriptGroupedEnvelope[] = [
+      userRow("ask", "u1"),
+      {
+        key: "queued",
+        timestamp: "2026-01-01T00:00:01.000Z",
+        event: {
+          type: "user_message",
+          text: "still there?",
+          steerId: "s1",
+          deliveryState: "queued",
+        },
+      },
+      {
+        key: "compact",
+        timestamp: "2026-01-01T00:00:02.000Z",
+        event: {
+          type: "codex_context_compaction",
+          state: "failed",
+          trigger: "auto",
+          turnId: "t1",
+          failReason: "timed_out",
+        },
+      },
+      doneRow("completed", "d1"),
+    ];
+    const entries = collectUserMessageMinimapSourceEntries(rows, { includeCodexExtras: true });
+    expect(entries.map((entry) => entry.kind)).toEqual(["user", "queued", "compact"]);
+    expect(entries.find((entry) => entry.kind === "queued")?.preview).toBe("still there?");
+    expect(entries.find((entry) => entry.kind === "compact")?.turnOutcome).toBe("failed");
+  });
+
+  it("keeps a single compact tick for started then completed compaction", () => {
+    const rows: ChatTranscriptGroupedEnvelope[] = [
+      userRow("ask", "u1"),
+      {
+        key: "compact-start",
+        timestamp: "2026-01-01T00:00:01.000Z",
+        event: {
+          type: "context_compact",
+          state: "started",
+          trigger: "auto",
+          turnId: "t1",
+          compactionId: "c1",
+        },
+      },
+      {
+        key: "compact-done",
+        timestamp: "2026-01-01T00:00:02.000Z",
+        event: {
+          type: "context_compact",
+          state: "completed",
+          trigger: "auto",
+          turnId: "t1",
+          compactionId: "c1",
+        },
+      },
+    ];
+    const entries = collectUserMessageMinimapSourceEntries(rows, { includeCodexExtras: true });
+    expect(entries.filter((entry) => entry.kind === "compact")).toHaveLength(1);
+    expect(entries.find((entry) => entry.kind === "compact")?.preview).toBe("Context compacted");
+  });
 });

--- a/apps/desktop/src/renderer/components/chat/chatUserMinimap.logic.ts
+++ b/apps/desktop/src/renderer/components/chat/chatUserMinimap.logic.ts
@@ -30,6 +30,8 @@ const ASSISTANT_PREVIEW_MAX_CHARS = 220;
 
 export type ChatUserMinimapTurnOutcome = "completed" | "interrupted" | "failed";
 
+export type ChatUserMinimapTickKind = "user" | "compact" | "queued";
+
 export type ChatUserMinimapSourceEntry = {
   /** Index in `groupedRows` for this user message. */
   rowIndex: number;
@@ -43,6 +45,8 @@ export type ChatUserMinimapSourceEntry = {
   assistantPreview: string | null;
   /** How this user message's turn ended; `null` while it is still running. */
   turnOutcome: ChatUserMinimapTurnOutcome | null;
+  /** Codex extras are smaller ticks; user ticks stay primary. */
+  kind?: ChatUserMinimapTickKind;
 };
 
 type TimelineUserMessageRow = ChatTranscriptGroupedEnvelope & {
@@ -83,8 +87,43 @@ function settleSpan(span: MinimapSpanAccumulator | null): void {
   span.entry.turnOutcome = span.lastDoneStatus ?? terminalTurnOutcome(span.lastStatusTurnStatus);
 }
 
+function collectCodexMinimapExtra(
+  row: ChatTranscriptGroupedEnvelope,
+  rowIndex: number,
+  fullUserOrdinal: number,
+): ChatUserMinimapSourceEntry | null {
+  const { event } = row;
+  if (event.type === "user_message" && event.deliveryState === "queued" && event.steerId) {
+    const preview = summarizeInlineText(event.displayText?.trim() || event.text || "", PREVIEW_MAX_CHARS);
+    return {
+      rowIndex,
+      key: `${row.key}:queued`,
+      preview: preview.length ? preview : "Queued follow-up",
+      fullUserOrdinal: Math.max(0, fullUserOrdinal - 1),
+      assistantPreview: null,
+      turnOutcome: null,
+      kind: "queued",
+    };
+  }
+  if (event.type === "context_compact" || event.type === "codex_context_compaction") {
+    if (event.state === "started") return null;
+    const failed = event.state === "failed";
+    return {
+      rowIndex,
+      key: `${row.key}:compact`,
+      preview: failed ? "Compaction failed" : "Context compacted",
+      fullUserOrdinal: Math.max(0, fullUserOrdinal - 1),
+      assistantPreview: null,
+      turnOutcome: failed ? "failed" : null,
+      kind: "compact",
+    };
+  }
+  return null;
+}
+
 export function collectUserMessageMinimapSourceEntries(
   groupedRows: readonly ChatTranscriptGroupedEnvelope[],
+  options?: { includeCodexExtras?: boolean },
 ): ChatUserMinimapSourceEntry[] {
   const out: ChatUserMinimapSourceEntry[] = [];
   let fullUserOrdinal = 0;
@@ -108,11 +147,17 @@ export function collectUserMessageMinimapSourceEntries(
         fullUserOrdinal,
         assistantPreview: null,
         turnOutcome: null,
+        kind: "user",
       };
       out.push(entry);
       fullUserOrdinal += 1;
       span = { entry, lastAssistantText: null, lastDoneStatus: null, lastStatusTurnStatus: undefined };
       continue;
+    }
+
+    if (options?.includeCodexExtras) {
+      const extra = collectCodexMinimapExtra(row, rowIndex, fullUserOrdinal);
+      if (extra) out.push(extra);
     }
 
     if (!span) continue;
@@ -208,6 +253,7 @@ export function computeActiveFullUserOrdinal(
     const top = offsets[rowIndex];
     if (top == null) continue;
     if (top <= scrollTop + 1) {
+      if ((fullEntries[i]!.kind ?? "user") !== "user") continue;
       bestOrdinal = fullEntries[i]!.fullUserOrdinal;
     } else {
       break;

--- a/apps/desktop/src/renderer/components/terminals/useWorkSessions.test.ts
+++ b/apps/desktop/src/renderer/components/terminals/useWorkSessions.test.ts
@@ -1686,7 +1686,9 @@ describe("useWorkSessions — refresh-before-focus ordering", () => {
         status: "running",
       }),
     ]);
-    expect(workState.openItemIds).toContain("new-pty-session");
+    await waitFor(() => {
+      expect(workState.openItemIds).toContain("new-pty-session");
+    });
     expect(workState.activeItemId).toBe("new-pty-session");
   });
 

--- a/apps/desktop/src/renderer/components/terminals/useWorkSessions.ts
+++ b/apps/desktop/src/renderer/components/terminals/useWorkSessions.ts
@@ -1679,7 +1679,14 @@ export function useWorkSessions({ active = true }: UseWorkSessionsOptions = {}) 
     // project's refresh result. A foreign chat can stay open while the local
     // session list refreshes, so prune against the same combined index used to
     // render tabs instead of silently dropping every foreign tab.
+    // Pending optimistic rows are also live: launchPtySession opens the tab
+    // before React flushes setSessions, and a concurrent refresh can re-render
+    // with a stale sessionsById in between. Dropping those ids makes the new
+    // terminal exist in the roster but never appear as a tab.
     const validIds = new Set(sessionsById.keys());
+    for (const sessionId of pendingOptimisticSessionsRef.current.keys()) {
+      validIds.add(sessionId);
+    }
 
     setProjectViewState((prev) => {
       const nextOpen = prev.openItemIds.filter((id) => validIds.has(id));

--- a/apps/desktop/src/renderer/webclient/adapter/__tests__/hostCommandContract.test.ts
+++ b/apps/desktop/src/renderer/webclient/adapter/__tests__/hostCommandContract.test.ts
@@ -52,6 +52,8 @@ const KNOWN_UNSUPPORTED: Record<string, string> = {
   "chat.codex.getGoal": "codex goal state is local to the app-server connection",
   "chat.codex.setGoal": "codex goal state is local to the app-server connection",
   "chat.codex.setGoalStatus": "codex goal state is local to the app-server connection",
+  "chat.codex.resetMemory": "codex memory RPC is local to the app-server connection",
+  "chat.codex.terminateBackgroundTerminal": "codex background terminals are local to the app-server connection",
   "cto.getLinearProjects": "not exposed remotely yet",
   "attention.acknowledgeMachine": "machine-local attention state",
   "rebase.dismiss": "machine-local rebase suggestion state",

--- a/apps/desktop/src/renderer/webclient/adapter/agentChat.ts
+++ b/apps/desktop/src/renderer/webclient/adapter/agentChat.ts
@@ -547,6 +547,14 @@ export function createAgentChatNamespace(infra: AdapterInfra): AdeNamespace<"age
         guardPin("codex.clearGoal", pin);
         return await call("chat.codex.clearGoal", args, null, false);
       },
+      resetMemory: async (args: unknown, pin?: RuntimePinArg) => {
+        guardPin("codex.resetMemory", pin);
+        await call("chat.codex.resetMemory", args, undefined, false);
+      },
+      terminateBackgroundTerminal: async (args: unknown, pin?: RuntimePinArg) => {
+        guardPin("codex.terminateBackgroundTerminal", pin);
+        await call("chat.codex.terminateBackgroundTerminal", args, undefined, false);
+      },
     },
   };
 

--- a/apps/desktop/src/shared/codexComposerCommands.test.ts
+++ b/apps/desktop/src/shared/codexComposerCommands.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from "vitest";
+import {
+  codexUserShellChipRange,
+  isCodexMemoryResetDraft,
+  parseCodexMemorySlashCommand,
+  parseCodexShellSlashCommand,
+  parseCodexUserShellDraft,
+  shouldCoalesceCodexCheckIn,
+} from "./codexComposerCommands";
+
+describe("parseCodexUserShellDraft", () => {
+  it("parses a leading bang command", () => {
+    expect(parseCodexUserShellDraft("!git status --short")).toEqual({
+      command: "git status --short",
+    });
+  });
+
+  it("ignores a bang with no command", () => {
+    expect(parseCodexUserShellDraft("!")).toBeNull();
+    expect(parseCodexUserShellDraft("hello")).toBeNull();
+  });
+});
+
+describe("parseCodexShellSlashCommand", () => {
+  it("parses /shell with a command", () => {
+    expect(parseCodexShellSlashCommand("/shell git status --short")).toEqual({
+      command: "git status --short",
+    });
+  });
+
+  it("rejects /shell with no command", () => {
+    expect(parseCodexShellSlashCommand("/shell")).toBeNull();
+  });
+});
+
+describe("parseCodexMemorySlashCommand", () => {
+  it("parses on/off/status", () => {
+    expect(parseCodexMemorySlashCommand("/memory")).toEqual({ kind: "status" });
+    expect(parseCodexMemorySlashCommand("/memory on")).toEqual({ kind: "set", enabled: true });
+    expect(parseCodexMemorySlashCommand("/memory off")).toEqual({ kind: "set", enabled: false });
+  });
+
+  it("parses reset without confirming", () => {
+    expect(parseCodexMemorySlashCommand("/memory-reset")).toEqual({ kind: "reset", confirm: false });
+    expect(isCodexMemoryResetDraft("/memory-reset")).toBe(true);
+    expect(parseCodexMemorySlashCommand("/memory-reset confirm")).toEqual({ kind: "reset", confirm: true });
+  });
+});
+
+describe("shouldCoalesceCodexCheckIn", () => {
+  it("coalesces identical text inside the window", () => {
+    expect(shouldCoalesceCodexCheckIn({
+      previousText: "are u still alive",
+      previousAtMs: 1_000,
+      nextText: "are u still alive",
+      nowMs: 5_000,
+    })).toBe(true);
+  });
+
+  it("does not coalesce different text or an expired window", () => {
+    expect(shouldCoalesceCodexCheckIn({
+      previousText: "are u still alive",
+      previousAtMs: 1_000,
+      nextText: "keep going",
+      nowMs: 5_000,
+    })).toBe(false);
+    expect(shouldCoalesceCodexCheckIn({
+      previousText: "are u still alive",
+      previousAtMs: 1_000,
+      nextText: "are u still alive",
+      nowMs: 20_000,
+    })).toBe(false);
+  });
+});
+
+describe("codexUserShellChipRange", () => {
+  it("covers the leading bang", () => {
+    expect(codexUserShellChipRange("!git status")).toEqual({ start: 0, end: 1 });
+    expect(codexUserShellChipRange("  !ls")).toEqual({ start: 2, end: 3 });
+  });
+});

--- a/apps/desktop/src/shared/codexComposerCommands.ts
+++ b/apps/desktop/src/shared/codexComposerCommands.ts
@@ -1,0 +1,85 @@
+/**
+ * Codex composer grammar shared by the desktop composer and the app-server
+ * adapter. Keep this module renderer-safe: no Node APIs.
+ */
+
+export const CODEX_USER_SHELL_PREFIX = "!";
+export const CODEX_MEMORY_RESET_RECEIPT = "Codex memory reset for this home.";
+export const CODEX_CHECKIN_COALESCE_WINDOW_MS = 12_000;
+
+export type CodexUserShellDraft = {
+  command: string;
+};
+
+export type CodexMemorySlashCommand =
+  | { kind: "status" }
+  | { kind: "set"; enabled: boolean }
+  | { kind: "reset"; confirm: boolean }
+  | { kind: "invalid"; message: string };
+
+function firstLine(text: string): string {
+  const newline = text.search(/\r|\n/);
+  return (newline < 0 ? text : text.slice(0, newline)).trim();
+}
+
+export function parseCodexUserShellDraft(text: string): CodexUserShellDraft | null {
+  const trimmed = text.trim();
+  if (!trimmed.startsWith(CODEX_USER_SHELL_PREFIX)) return null;
+  const command = trimmed.slice(CODEX_USER_SHELL_PREFIX.length).trim();
+  return command.length ? { command } : null;
+}
+
+export function parseCodexShellSlashCommand(text: string): CodexUserShellDraft | null {
+  const match = /^\/shell(?:\s+|$)(.*)$/is.exec(text.trim());
+  if (!match) return null;
+  const command = match[1]!.trim();
+  return command.length ? { command } : null;
+}
+
+export function parseCodexMemorySlashCommand(text: string): CodexMemorySlashCommand | null {
+  const trimmed = firstLine(text);
+  if (!trimmed.toLowerCase().startsWith("/memory")) return null;
+  const rest = trimmed.replace(/^\/memory(?:-reset)?(?:\s+|$)/i, "");
+  const isReset = /^\/memory-reset(?:\s|$)/i.test(trimmed);
+  if (isReset) {
+    const confirm = rest.trim().toLowerCase() === "confirm";
+    return { kind: "reset", confirm };
+  }
+  const arg = rest.trim().toLowerCase();
+  if (!arg || arg === "status") return { kind: "status" };
+  if (arg === "on" || arg === "enable" || arg === "enabled") return { kind: "set", enabled: true };
+  if (arg === "off" || arg === "disable" || arg === "disabled") return { kind: "set", enabled: false };
+  if (arg === "reset") return { kind: "reset", confirm: false };
+  return {
+    kind: "invalid",
+    message: "Usage: /memory [on|off|status] or /memory-reset.",
+  };
+}
+
+export function isCodexMemoryResetDraft(text: string): boolean {
+  const parsed = parseCodexMemorySlashCommand(text);
+  return parsed?.kind === "reset" && !parsed.confirm;
+}
+
+export function shouldCoalesceCodexCheckIn(args: {
+  previousText: string | null | undefined;
+  previousAtMs: number | null | undefined;
+  nextText: string;
+  nowMs: number;
+  windowMs?: number;
+}): boolean {
+  const previous = args.previousText?.trim() ?? "";
+  const next = args.nextText.trim();
+  if (!previous || previous !== next) return false;
+  if (args.previousAtMs == null || !Number.isFinite(args.previousAtMs)) return false;
+  const windowMs = args.windowMs ?? CODEX_CHECKIN_COALESCE_WINDOW_MS;
+  return args.nowMs - args.previousAtMs >= 0 && args.nowMs - args.previousAtMs <= windowMs;
+}
+
+/** Visual `$` chip for a leading `!command` draft. The `!` stays in the stored text. */
+export function codexUserShellChipRange(text: string): { start: number; end: number } | null {
+  const match = /^(\s*)!(\S*)/.exec(text);
+  if (!match) return null;
+  const start = match[1]!.length;
+  return { start, end: start + 1 };
+}

--- a/apps/desktop/src/shared/contextCompaction.test.ts
+++ b/apps/desktop/src/shared/contextCompaction.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   buildContextCompactMetadataChips,
+  compactionFailLabel,
   contextCompactMergeKey,
   detectCompactionSignalText,
   formatCompactDuration,
@@ -75,6 +76,18 @@ describe("contextCompaction", () => {
   it("detects compaction signals in free-form status text", () => {
     expect(detectCompactionSignalText("Summarizing conversation history")).toBe(true);
     expect(detectCompactionSignalText("Running tests")).toBe(false);
+  });
+
+  it("labels failed compaction from failReason", () => {
+    const timedOut = normalizeContextCompactEvent({
+      type: "codex_context_compaction",
+      state: "failed",
+      trigger: "auto",
+      turnId: "turn-1",
+      failReason: "timed_out",
+    })!;
+    expect(compactionFailLabel(timedOut.failReason)).toBe("Compaction timed out");
+    expect(compactionFailLabel("interrupted")).toBe("Compaction failed");
   });
 
   it("uses compactionId as the merge key when present", () => {

--- a/apps/desktop/src/shared/contextCompaction.ts
+++ b/apps/desktop/src/shared/contextCompaction.ts
@@ -4,9 +4,12 @@ export type ContextCompactProvider = "claude" | "codex" | "opencode" | "cursor" 
 
 export type ContextCompactEvent = Extract<AgentChatEvent, { type: "context_compact" }>;
 
+export type ContextCompactFailReason = "interrupted" | "timed_out" | "teardown";
+
 export type NormalizedContextCompact = {
   trigger: "manual" | "auto" | "ade_fallback";
-  state: "started" | "completed";
+  state: "started" | "completed" | "failed";
+  failReason?: ContextCompactFailReason;
   turnId?: string;
   compactionId?: string;
   preTokens?: number;
@@ -37,6 +40,7 @@ export function normalizeContextCompactEvent(event: AgentChatEvent): NormalizedC
     return {
       trigger: event.trigger,
       state: event.state ?? "completed",
+      failReason: event.failReason,
       turnId: event.turnId,
       compactionId: event.compactionId,
       preTokens: event.preTokens,
@@ -51,6 +55,7 @@ export function normalizeContextCompactEvent(event: AgentChatEvent): NormalizedC
     return {
       trigger: event.trigger,
       state: event.state,
+      failReason: event.failReason,
       turnId: event.turnId,
       compactionId: event.compactionId ?? event.turnId,
     };
@@ -135,6 +140,7 @@ export function mergeNormalizedContextCompact(
     trigger: incoming.trigger ?? previous.trigger,
     turnId: incoming.turnId ?? previous.turnId,
     compactionId: incoming.compactionId ?? previous.compactionId,
+    failReason: incoming.failReason ?? previous.failReason,
     preTokens: incoming.preTokens ?? previous.preTokens,
     postTokens: incoming.postTokens ?? previous.postTokens,
     tokensRemoved: incoming.tokensRemoved ?? previous.tokensRemoved,
@@ -153,6 +159,7 @@ export function toContextCompactChatEvent(
     state: compact.state,
     ...(compact.turnId ? { turnId: compact.turnId } : {}),
     ...(compact.compactionId ? { compactionId: compact.compactionId } : {}),
+    ...(compact.failReason ? { failReason: compact.failReason } : {}),
     ...(compact.preTokens != null ? { preTokens: compact.preTokens } : {}),
     ...(compact.postTokens != null ? { postTokens: compact.postTokens } : {}),
     ...(compact.tokensRemoved != null ? { tokensRemoved: compact.tokensRemoved } : {}),
@@ -166,4 +173,19 @@ export function detectCompactionSignalText(text: string | null | undefined): boo
   if (!text) return false;
   const lower = text.toLowerCase();
   return /\b(compact(ing|ed|ion)?|summariz(e|ing|ed|ation)?|trim(ming|med)?\s+context|context\s+(window\s+)?(trim|compact|summar))\b/.test(lower);
+}
+
+export function compactionFailLabel(reason?: ContextCompactFailReason): string {
+  switch (reason) {
+    case "timed_out":
+      return "Compaction timed out";
+    case "interrupted":
+    case "teardown":
+    case undefined:
+      return "Compaction failed";
+    default: {
+      const exhaustive: never = reason;
+      return exhaustive;
+    }
+  }
 }

--- a/apps/desktop/src/shared/ipc.ts
+++ b/apps/desktop/src/shared/ipc.ts
@@ -341,6 +341,8 @@ export const IPC = {
   agentChatCodexSetGoal: "ade.agentChat.codex.goal.set",
   agentChatCodexSetGoalStatus: "ade.agentChat.codex.goal.setStatus",
   agentChatCodexClearGoal: "ade.agentChat.codex.goal.clear",
+  agentChatCodexResetMemory: "ade.agentChat.codex.memory.reset",
+  agentChatCodexTerminateBackgroundTerminal: "ade.agentChat.codex.backgroundTerminals.terminate",
   orchestrationRunCreate: "ade.orchestration.runCreate",
   orchestrationBundleRead: "ade.orchestration.bundleRead",
   orchestrationManifestReadSection: "ade.orchestration.manifestReadSection",

--- a/apps/desktop/src/shared/types/chat.ts
+++ b/apps/desktop/src/shared/types/chat.ts
@@ -693,6 +693,8 @@ export type AgentChatEvent =
       exitCode?: number | null;
       durationMs?: number | null;
       status: "running" | "completed" | "failed";
+      /** Codex `!` / `/shell` runs unsandboxed via `thread/shellCommand`. */
+      source?: "userShell";
       runtime?: AgentChatRuntime;
     }
   | {
@@ -1066,16 +1068,19 @@ export type AgentChatEvent =
       // `compacting` status, OpenCode's compaction part) emit a "started" event when
       // compaction begins and a "completed" event when it ends, so the UI can show a
       // live "compacting…" indicator instead of only the finished result. Omitted by
-      // legacy/completion-only sources (treated as "completed").
-      state?: "started" | "completed";
+      // legacy/completion-only sources (treated as "completed"). "failed" covers
+      // interrupt, teardown, and a wall-clock stall so the divider cannot spin forever.
+      state?: "started" | "completed" | "failed";
+      failReason?: "interrupted" | "timed_out" | "teardown";
       turnId?: string;
     }
   | {
       type: "codex_context_compaction";
       turnId: string;
-      state: "started" | "completed";
+      state: "started" | "completed" | "failed";
       trigger: "manual" | "auto";
       compactionId?: string;
+      failReason?: "interrupted" | "timed_out" | "teardown";
     }
   | {
       type: "codex_safety_buffering";
@@ -2930,6 +2935,15 @@ export type AgentChatCodexSetGoalStatusArgs = {
 
 export type AgentChatCodexClearGoalArgs = {
   sessionId: string;
+};
+
+export type AgentChatCodexResetMemoryArgs = {
+  sessionId: string;
+};
+
+export type AgentChatCodexTerminateBackgroundTerminalArgs = {
+  sessionId: string;
+  processId: string;
 };
 
 export type AgentChatApproveArgs = {


### PR DESCRIPTION
## Summary
- Pin desktop and CLI Codex to **0.149.1** and gate queue, revert, user shell, memory, and background terminals on the live app-server version.
- During compaction or review, queue follow-ups instead of steering; fail-open stalled or interrupted compaction; rewind with `thread/revert` and fall back to fork when revert is rejected.
- Composer UX: `$` chip for `!` user shell, memory-reset confirm, a quiet background Stop, and Codex minimap ticks only for queued follow-ups and finished compaction.

## Test plan
- [x] `cd apps/desktop && npx vitest run src/main/services/chat/agentChatService.test.ts src/main/services/chat/codexAppServerFeatures.test.ts src/shared/codexComposerCommands.test.ts src/shared/contextCompaction.test.ts src/renderer/components/chat/chatUserMinimap.logic.test.ts src/main/services/adeActions/registry.test.ts src/renderer/webclient/adapter/__tests__/hostCommandContract.test.ts` (1017 passed)
- [x] `npm --prefix apps/desktop run typecheck`
- [x] `cd apps/ade-cli && npx vitest run src/services/tools/manifest.test.ts`
- [ ] Codex chat: idle `!git status`, mid-turn `!pwd`, `/memory-reset` confirm, check-in during compaction queues instead of steer
- [ ] Stop a Codex background command from the subagents panel
- [ ] Rewind a Codex turn on 0.149 (revert) and confirm older servers still fork/rollback


Made with [Cursor](https://cursor.com)

<!-- ade:link v=1 type=pr repo=arul28/ADE branch=ade%2Fcodex-app-server-diagnostics num=1154 -->
<p>
  <img src="https://ade-app.dev/logo.png" height="18" align="left" alt="ADE">
  &nbsp;&nbsp;<strong>Open in ADE</strong>
  &nbsp;·&nbsp; <a href="https://ade-app.dev/open?type=branch&amp;repo=arul28%2FADE&amp;branch=ade%2Fcodex-app-server-diagnostics&amp;pr=1154">ade/codex-app-server-diagnostics branch</a>
  &nbsp;·&nbsp; <a href="https://ade-app.dev/open?type=pr&amp;repo=arul28%2FADE&amp;number=1154">PR #1154</a>
</p>
<!-- /ade:link -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Codex 0.149.1.
  * Added memory reset and background-terminal stop actions.
  * Added user shell commands, queued follow-ups, paginated history, and improved rewind behavior.
  * Added shell command indicators and controls for stopping active background tasks.
  * Enhanced chat minimap entries for queued messages and context compaction events.

* **Bug Fixes**
  * Improved handling and display of interrupted, timed-out, or failed context compaction.
  * Improved session-tab preservation for pending sessions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->