### PR TITLE
docs(release): v1.2.64 release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,39 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.2.64] - 2026-08-25
+
+### Codex
+
+- Pin Codex app-server 0.149.1. Unsandboxed `!` / `/shell` are app-server RPCs with a user-shell chip; follow-ups queue during compaction or review instead of steering a turn that will reject them (#1154).
+- `/memory reset` confirms first. Background terminals have an explicit stop. Interrupted or stalled compaction fail-opens instead of wedging the session.
+
+### Prompt settings
+
+- Changing model or provider no longer rewrites approval, sandbox, or fast-mode preferences (#1153).
+
+### OpenCode
+
+- One v2 SDK client. The tracked CLI no longer echoes ADE's prompt into the session (#1155).
+
+### Chats and Work
+
+- GitHub issues attach to a chat alongside Linear (#1147).
+- Cursor Cloud fleet view on desktop, iOS, and the TUI (#1146).
+- PR pane can auto-open (#1142).
+- Work model catalogs follow the prompt-box machine (#1139).
+
+### iOS
+
+- Simulator builds stay on the lane worktree; the drawer reports what it can actually do (#1150).
+- Work chat scroll and render performance; stop shipping the whole models.dev directory to the phone (#1148, #1149).
+
+### Fixes
+
+- Project picker recents (#1152).
+- Windows brain heartbeat honors `ADE_BRAIN_HEARTBEAT_STALE_MS` (#1143).
+- Storage truth chain, suspension-aware watchdogs, runtime leak and updater status (#1140).
+
 ## [1.2.63] - 2026-08-20
 
 ### GitHub connection
@@ -1671,7 +1704,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Initial public release.
 
-[Unreleased]: https://github.com/arul28/ADE/compare/v1.2.63...HEAD
+[Unreleased]: https://github.com/arul28/ADE/compare/v1.2.64...HEAD
+[1.2.64]: https://github.com/arul28/ADE/compare/v1.2.63...v1.2.64
 [1.2.63]: https://github.com/arul28/ADE/compare/v1.2.62...v1.2.63
 [1.2.62]: https://github.com/arul28/ADE/compare/v1.2.61...v1.2.62
 [1.2.61]: https://github.com/arul28/ADE/compare/v1.2.60...v1.2.61

--- a/changelog/index.mdx
+++ b/changelog/index.mdx
@@ -5,6 +5,6 @@ description: "Latest ADE release notes and release history."
 
 ADE release notes live here in newest-first order. Start with the latest release, or browse the release list in the sidebar.
 
-<Card title="Latest release" icon="tag" href="/changelog/v1.2.63">
-  v1.2.63 - The GitHub connection renews itself without breaking itself, and asking ADE for help works the first time: the `ade` command sets itself up and reports carry what support actually needs.
+<Card title="Latest release" icon="tag" href="/changelog/v1.2.64">
+  v1.2.64 - Codex 0.149 app-server composer commands, independent prompt settings, OpenCode without prompt echo, and GitHub issues on chats.
 </Card>

--- a/changelog/v1.2.64.mdx
+++ b/changelog/v1.2.64.mdx
@@ -1,0 +1,43 @@
+---
+title: "v1.2.64"
+description: "Release notes for ADE v1.2.64 - August 25, 2026"
+---
+
+Codex in ADE now speaks the 0.149 app-server: unsandboxed `!` / `/shell`, a queued follow-up when compaction or review is in the way, and a quiet stop for background terminals. Prompt settings stay independent of the model you pick. OpenCode no longer echoes ADE's prompt into the tracked CLI, and you can attach a GitHub issue to a chat the same way you already attach Linear.
+
+---
+
+## Codex
+
+- **`!` and `/shell` run as your shell, not the model's.** An unsandboxed user-shell chip marks the turn; the command is an app-server RPC, not model text.
+- **Follow-ups wait when Codex cannot take them.** During compaction or a pending review, ADE queues the next message instead of trying to steer a turn that will reject it.
+- **Memory reset asks first.** `/memory reset` confirms before wiping the thread's memory.
+- **Background terminals have a stop.** The stop control is small and explicit; it does not look like a failed turn.
+- **Compaction fail-opens.** An interrupted or stalled compaction does not leave the session stuck; ADE surfaces the failure and continues.
+
+## Prompt settings
+
+- **The model you pick does not rewrite access settings.** Approval, sandbox, and fast-mode preferences stay as you set them when you change models or providers.
+
+## OpenCode
+
+- **One v2 SDK client.** OpenCode sessions share a single runtime client instead of mixing SDK shapes.
+- **The tracked CLI no longer reprints ADE's prompt.** Your prompt stays in ADE; the CLI session does not echo it back as if you typed it there.
+
+## Chats and Work
+
+- **GitHub issues attach to a chat, alongside Linear.** You can bind a GitHub issue the same way you already bind a Linear issue.
+- **Cursor Cloud has a fleet view.** Project-scoped cloud agents show up on desktop, iOS, and the TUI instead of only as one-off chats.
+- **The PR pane can open itself** when a review or check needs you.
+- **Work model catalogs follow the prompt-box machine.** The picker lists what that machine can actually run.
+
+## iOS simulator and Work on the phone
+
+- **Simulator builds stay on the lane's worktree**, and the simulator drawer reports what it can actually do.
+- **Work chat on iOS scrolls and renders without shipping the whole models.dev catalog to the phone.**
+
+## Fixes
+
+- Project picker recents are less noisy.
+- Windows brain heartbeat honors `ADE_BRAIN_HEARTBEAT_STALE_MS`.
+- Storage, suspension-aware watchdogs, runtime leak, and updater status tell the truth instead of looking healthy while they are not.

--- a/docs.json
+++ b/docs.json
@@ -181,6 +181,7 @@
             "expanded": true,
             "pages": [
               "changelog",
+              "changelog/v1.2.64",
               "changelog/v1.2.63",
               "changelog/v1.2.62",
               "changelog/v1.2.61",


### PR DESCRIPTION
## Summary
- Public changelog for v1.2.64 covering Codex 0.149, independent prompt settings, OpenCode v2, and Work/chat changes since v1.2.63.

## Test plan
- [x] `node scripts/validate-docs.mjs` passed


Made with [Cursor](https://cursor.com)