### PR TITLE
Keep Manage Lane on Work and restyle the dialog

### DIFF
--- a/apps/desktop/src/renderer/components/lanes/LaneContextMenu.test.tsx
+++ b/apps/desktop/src/renderer/components/lanes/LaneContextMenu.test.tsx
@@ -96,6 +96,16 @@ describe("LaneContextMenu grouping", () => {
     expect(screen.getByRole("menuitem", { name: "Manage Lane" })).toBeTruthy();
   });
 
+  it("opens Manage Lane without selecting the lane (Work must not route to Lanes)", () => {
+    const props = renderLaneMenu();
+
+    fireEvent.click(screen.getByRole("menuitem", { name: "Manage Lane" }));
+
+    expect(props.onManage).toHaveBeenCalledWith(lane.id);
+    expect(props.selectLane).not.toHaveBeenCalled();
+    expect(props.onClose).toHaveBeenCalledTimes(1);
+  });
+
   it("keeps every clipboard action reachable behind the Copy submenu", () => {
     const props = renderLaneMenu();
 

--- a/apps/desktop/src/renderer/components/lanes/LaneDialogShell.tsx
+++ b/apps/desktop/src/renderer/components/lanes/LaneDialogShell.tsx
@@ -7,6 +7,7 @@ export function LaneDialogShell({
   open,
   onOpenChange,
   title,
+  titleContent,
   description,
   headerExtra,
   icon: Icon,
@@ -21,6 +22,8 @@ export function LaneDialogShell({
   open: boolean;
   onOpenChange: (open: boolean) => void;
   title: string;
+  /** Replaces the default title text while keeping `title` for the accessible name. */
+  titleContent?: ReactNode;
   description?: string;
   headerExtra?: ReactNode;
   icon?: ComponentType<{ size?: number | string; className?: string }>;
@@ -65,24 +68,32 @@ export function LaneDialogShell({
                 <div className="shrink-0 border-b border-white/[0.06] bg-white/[0.02] px-4 pb-3 pt-4 sm:px-5 sm:pt-5">
                   <div className="flex items-start justify-between gap-3">
                     <div className="min-w-0 flex-1">
-                      <Dialog.Title className="flex items-center gap-2 text-base font-semibold text-fg sm:text-lg">
-                        {Icon ? (
-                          <span className="inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-lg border border-white/[0.08] bg-accent/[0.12] text-accent">
-                            <Icon size={16} />
-                          </span>
-                        ) : null}
-                        <span className="truncate">{title}</span>
+                      <Dialog.Title className={titleContent
+                        ? "sr-only"
+                        : "flex items-center gap-2 text-base font-semibold text-fg sm:text-lg"}
+                      >
+                        {titleContent ? title : (
+                          <>
+                            {Icon ? (
+                              <span className="inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-lg border border-white/[0.08] bg-accent/[0.12] text-accent">
+                                <Icon size={16} />
+                              </span>
+                            ) : null}
+                            <span className="truncate">{title}</span>
+                          </>
+                        )}
                       </Dialog.Title>
+                      {titleContent ? <div className="min-w-0">{titleContent}</div> : null}
                       {headerExtra ? <div className="mt-3 min-w-0">{headerExtra}</div> : null}
                       {description ? (
                         <Dialog.Description className="mt-2 text-sm leading-relaxed text-muted-fg sm:max-w-2xl">
                           {description}
                         </Dialog.Description>
-                      ) : !headerExtra ? (
+                      ) : (
                         <Dialog.Description className="sr-only">
                           {title}
                         </Dialog.Description>
-                      ) : null}
+                      )}
                     </div>
                     <Dialog.Close asChild>
                       <Button variant="ghost" size="sm" className="shrink-0" disabled={busy}>

--- a/apps/desktop/src/renderer/components/lanes/ManageLaneDialog.test.tsx
+++ b/apps/desktop/src/renderer/components/lanes/ManageLaneDialog.test.tsx
@@ -130,6 +130,26 @@ describe("ManageLaneDialog tabs", () => {
     expect(selectedTabLabel()).toBe("Delete");
   });
 
+  it("titles the dialog with the lane name instead of Manage Lane", () => {
+    const lane = makeLane({ name: "Manage tabs", color: "#5eead4" });
+    render(<ManageLaneDialog {...makeProps({ managedLane: lane, allLanes: [lane] })} />);
+
+    expect(screen.queryByText("Manage Lane")).toBeNull();
+    expect(screen.getByRole("heading", { name: "Manage tabs" })).toBeTruthy();
+    const name = screen.getByText("Manage tabs", { selector: "span" });
+    expect(name.style.color).toBe("rgb(94, 234, 212)");
+  });
+
+  it("keeps Select everything compact and separate from the delete targets", () => {
+    render(<ManageLaneDialog {...makeProps()} />);
+
+    const selectEverything = screen.getByRole("button", { name: "Select everything" });
+    expect(selectEverything.className).toContain("h-8");
+    expect(screen.queryByText("Worktree, local & remote branch")).toBeNull();
+    const targets = screen.getByRole("checkbox", { name: /Worktree/i }).closest(".ml-3");
+    expect(targets).toBeTruthy();
+  });
+
   it("opens on the delete tab for batch lane management", () => {
     const firstLane = makeLane({ id: "lane-1", name: "First lane" });
     const secondLane = makeLane({ id: "lane-2", name: "Second lane" });

--- a/apps/desktop/src/renderer/components/lanes/ManageLaneDialog.tsx
+++ b/apps/desktop/src/renderer/components/lanes/ManageLaneDialog.tsx
@@ -31,6 +31,14 @@ import type {
   LaneSummary,
   OpenProjectBinding,
 } from "../../../shared/types";
+import { LaneDialogShell } from "./LaneDialogShell";
+import {
+  LABEL_CLASS_NAME,
+  INPUT_CLASS_NAME,
+  SELECT_CLASS_NAME
+} from "./laneDialogTokens";
+import { LaneColorPicker } from "./LaneColorPicker";
+import { colorsInUse, getLaneAccent, laneColorName } from "./laneColorPalette";
 
 /** Independent delete targets shown as a checklist. */
 export type LaneDeleteSelection = {
@@ -48,14 +56,6 @@ export const EMPTY_LANE_DELETE_SELECTION: LaneDeleteSelection = {
 function laneDeleteSelectionHasAny(selection: LaneDeleteSelection): boolean {
   return selection.worktree || selection.localBranch || selection.remoteBranch;
 }
-import { LaneDialogShell } from "./LaneDialogShell";
-import {
-  LABEL_CLASS_NAME,
-  INPUT_CLASS_NAME,
-  SELECT_CLASS_NAME
-} from "./laneDialogTokens";
-import { LaneColorPicker } from "./LaneColorPicker";
-import { colorsInUse, laneColorName } from "./laneColorPalette";
 
 function formatBytesCompact(bytes: number): string {
   const safe = Math.max(0, bytes);
@@ -84,16 +84,20 @@ const STEP_LABELS: Record<LaneDeleteStepName, string> = {
   database_cleanup: "Updating database"
 };
 
+const MANAGE_LANE_TITLE_CLASS = "truncate text-xl font-semibold tracking-tight sm:text-2xl";
+
 function ManageLaneRenameControls({
   lane,
   allLanes,
   onRenamed,
   runtimePin,
+  nameColor,
 }: {
   lane: LaneSummary;
   allLanes: LaneSummary[];
   onRenamed?: () => void | Promise<void>;
   runtimePin?: OpenProjectBinding | null;
+  nameColor: string;
 }) {
   const [editing, setEditing] = useState(false);
   const [draftName, setDraftName] = useState(lane.name);
@@ -143,14 +147,14 @@ function ManageLaneRenameControls({
 
   if (!canRename) {
     return (
-      <span className="text-base font-semibold tracking-tight text-accent">{lane.name}</span>
+      <span className={MANAGE_LANE_TITLE_CLASS} style={{ color: nameColor }}>{lane.name}</span>
     );
   }
 
   if (!editing) {
     return (
       <div className="flex min-w-0 items-center gap-1.5">
-        <span className="truncate text-base font-semibold tracking-tight text-accent">{lane.name}</span>
+        <span className={MANAGE_LANE_TITLE_CLASS} style={{ color: nameColor }}>{lane.name}</span>
         <button
           type="button"
           aria-label="Rename lane"
@@ -219,20 +223,13 @@ function ManageLaneRenameControls({
 function ManageLaneHeaderDetails({
   lanes,
   isBatch,
-  allLanes,
-  onRenamed,
-  runtimePin,
 }: {
   lanes: LaneSummary[];
   isBatch: boolean;
-  allLanes: LaneSummary[];
-  onRenamed?: () => void | Promise<void>;
-  runtimePin?: OpenProjectBinding | null;
 }) {
   if (isBatch) {
     return (
       <div data-tour="lanes.manageDialog.laneInfo" className="space-y-2">
-        <div className="text-xs text-muted-fg/80">{lanes.length} lanes selected</div>
         <div className="max-h-[min(28vh,160px)] space-y-1.5 overflow-y-auto pr-1">
           {lanes.map((lane) => (
             <div key={lane.id} className="flex flex-wrap items-center gap-x-2 gap-y-1 text-xs">
@@ -260,21 +257,12 @@ function ManageLaneHeaderDetails({
 
   return (
     <div data-tour="lanes.manageDialog.laneInfo" className="min-w-0">
-      <div className="flex flex-wrap items-center gap-x-2.5 gap-y-1">
-        <LaneIcon size={14} weight="duotone" className="shrink-0 text-accent/80" />
-        <ManageLaneRenameControls
-          lane={lane}
-          allLanes={allLanes}
-          onRenamed={onRenamed}
-          runtimePin={runtimePin}
-        />
-        {lane.status.dirty ? (
-          <span className="rounded-md bg-amber-500/10 px-1.5 py-0.5 text-[10px] font-medium uppercase text-amber-400">
-            dirty
-          </span>
-        ) : null}
-      </div>
-      <dl className="mt-2.5 space-y-1.5 text-xs">
+      {lane.status.dirty ? (
+        <span className="rounded-md bg-amber-500/10 px-1.5 py-0.5 text-[10px] font-medium uppercase text-amber-400">
+          dirty
+        </span>
+      ) : null}
+      <dl className={`space-y-1.5 text-xs${lane.status.dirty ? " mt-2.5" : ""}`}>
         <div className="grid grid-cols-[auto,1fr] gap-x-3 gap-y-0.5">
           <dt className="text-muted-fg/60">Branch</dt>
           <dd className="min-w-0 truncate font-mono text-fg/85">{lane.branchRef}</dd>
@@ -583,9 +571,28 @@ export function ManageLaneDialog({
           <ManageLaneHeaderDetails
             lanes={lanes}
             isBatch={isBatch}
+          />
+        )
+      : undefined;
+
+  const laneAccent = singleLane
+    ? getLaneAccent(singleLane, Math.max(0, allLanes.findIndex((candidate) => candidate.id === singleLane.id)))
+    : undefined;
+  const dialogTitle = isBatch
+    ? `${lanes.length} lanes`
+    : singleLane?.name ?? "Lane";
+  const titleContent = isBatch
+    ? (
+        <span className={MANAGE_LANE_TITLE_CLASS}>{dialogTitle}</span>
+      )
+    : singleLane && laneAccent
+      ? (
+          <ManageLaneRenameControls
+            lane={singleLane}
             allLanes={allLanes}
             onRenamed={onAppearanceChanged}
             runtimePin={runtimePin}
+            nameColor={laneAccent}
           />
         )
       : undefined;
@@ -594,8 +601,8 @@ export function ManageLaneDialog({
     <LaneDialogShell
       open={open}
       onOpenChange={onOpenChange}
-      title={isBatch ? `Manage ${lanes.length} Lanes` : "Manage Lane"}
-      icon={LaneIcon}
+      title={dialogTitle}
+      titleContent={titleContent}
       headerExtra={headerExtra}
       widthClassName="w-[calc(100vw-1rem)] max-w-[720px] sm:max-w-[min(720px,calc(100vw-2rem))]"
       busy={laneActionBusy}
@@ -878,59 +885,55 @@ function DeleteTargetChecklist({
   ];
 
   return (
-    <div
-      data-tour="lanes.manageDialog.tabs"
-      className="mt-4 overflow-hidden rounded-xl border border-white/[0.08] bg-black/25"
-    >
+    <div data-tour="lanes.manageDialog.tabs" className="mt-4 space-y-2">
       <button
         type="button"
         disabled={disabled}
         onClick={onToggleAll}
         aria-pressed={allSelected}
-        className="flex w-full items-center gap-3 border-b border-white/[0.06] bg-white/[0.02] px-3 py-2.5 text-left transition-colors hover:bg-white/[0.04] disabled:cursor-not-allowed disabled:opacity-60"
+        className="flex h-8 w-full items-center gap-2 rounded-lg border border-white/[0.08] bg-white/[0.03] px-2.5 text-left transition-colors hover:bg-white/[0.05] disabled:cursor-not-allowed disabled:opacity-60"
       >
         <DeleteCheckbox checked={allSelected} indeterminate={someSelected && !allSelected} />
-        <div className="min-w-0 flex-1">
-          <div className="text-xs font-semibold text-fg">Select everything</div>
-          <div className="text-[11px] text-muted-fg/60">Worktree, local &amp; remote branch</div>
-        </div>
+        <div className="min-w-0 flex-1 text-[11px] font-medium text-fg">Select everything</div>
         {allSelected ? (
-          <span className="shrink-0 rounded-full bg-red-500/15 px-2 py-0.5 text-[10px] font-medium text-red-200">All</span>
+          <span className="shrink-0 rounded-full bg-red-500/15 px-1.5 py-px text-[10px] font-medium text-red-200">All</span>
         ) : null}
       </button>
 
-      <div className="divide-y divide-white/[0.04]">
-        {rows.map((row) => {
-          const checked = selection[row.key];
-          return (
-            <button
-              key={row.key}
-              type="button"
-              role="checkbox"
-              aria-checked={checked}
-              disabled={disabled}
-              onClick={() => onToggle(row.key, !checked)}
-              className={`flex w-full items-center gap-3 px-3 py-2.5 text-left transition-colors disabled:cursor-not-allowed disabled:opacity-60 ${
-                checked ? "bg-red-500/[0.08]" : "hover:bg-white/[0.03]"
-              }`}
-            >
-              <DeleteCheckbox checked={checked} />
-              <span
-                className={`flex h-7 w-7 shrink-0 items-center justify-center rounded-lg border ${
-                  checked
-                    ? "border-red-400/30 bg-red-500/15 text-red-200"
-                    : "border-white/[0.08] bg-white/[0.03] text-muted-fg/70"
+      <div className="ml-3 overflow-hidden rounded-xl border border-white/[0.08] bg-black/25">
+        <div className="divide-y divide-white/[0.04]">
+          {rows.map((row) => {
+            const checked = selection[row.key];
+            return (
+              <button
+                key={row.key}
+                type="button"
+                role="checkbox"
+                aria-checked={checked}
+                disabled={disabled}
+                onClick={() => onToggle(row.key, !checked)}
+                className={`flex w-full items-center gap-3 px-3 py-2.5 text-left transition-colors disabled:cursor-not-allowed disabled:opacity-60 ${
+                  checked ? "bg-red-500/[0.08]" : "hover:bg-white/[0.03]"
                 }`}
               >
-                {row.icon}
-              </span>
-              <span className="min-w-0 flex-1">
-                <span className={`block text-xs font-medium ${checked ? "text-red-100" : "text-fg"}`}>{row.title}</span>
-                <span className={`block truncate text-[11px] text-muted-fg/60 ${row.mono ? "font-mono" : ""}`}>{row.hint}</span>
-              </span>
-            </button>
-          );
-        })}
+                <DeleteCheckbox checked={checked} />
+                <span
+                  className={`flex h-7 w-7 shrink-0 items-center justify-center rounded-lg border ${
+                    checked
+                      ? "border-red-400/30 bg-red-500/15 text-red-200"
+                      : "border-white/[0.08] bg-white/[0.03] text-muted-fg/70"
+                  }`}
+                >
+                  {row.icon}
+                </span>
+                <span className="min-w-0 flex-1">
+                  <span className={`block text-xs font-medium ${checked ? "text-red-100" : "text-fg"}`}>{row.title}</span>
+                  <span className={`block truncate text-[11px] text-muted-fg/60 ${row.mono ? "font-mono" : ""}`}>{row.hint}</span>
+                </span>
+              </button>
+            );
+          })}
+        </div>
       </div>
     </div>
   );

--- a/apps/desktop/src/renderer/components/lanes/laneContextMenuItems.tsx
+++ b/apps/desktop/src/renderer/components/lanes/laneContextMenuItems.tsx
@@ -324,7 +324,9 @@ export function buildLaneMenuGroups(args: LaneMenuArgs): LaneMenuGroup[] {
       kind: "action",
       key: "manage",
       label: "Manage Lane",
-      onSelect: () => { onClose(); selectLane(laneId); onManage(laneId); },
+      // Do not call selectLane here. On Work, that action navigates to the
+      // Lanes tab (split-open). Manage must stay on the surface that opened it.
+      onSelect: () => { onClose(); onManage(laneId); },
     });
   }
   if (deletableVisibleIds.length > 1) {

--- a/apps/desktop/src/renderer/components/terminals/useWorkLaneContextMenu.test.tsx
+++ b/apps/desktop/src/renderer/components/terminals/useWorkLaneContextMenu.test.tsx
@@ -151,6 +151,30 @@ describe("useWorkLaneContextMenu", () => {
     expect(navigate).toHaveBeenCalledWith("/work");
   });
 
+  it("opens local manage without routing to the Lanes tab", () => {
+    const { result } = renderHook(() => useWorkLaneContextMenu(), {
+      wrapper: ({ children }) => <MemoryRouter>{children}</MemoryRouter>,
+    });
+
+    act(() => {
+      result.current.trigger("lane-remote", {
+        preventDefault: vi.fn(),
+        clientX: 12,
+        clientY: 34,
+      });
+    });
+    const view = render(<>{result.current.menu}</>);
+    const onManage = capturedLaneContextMenuProps?.onManage as (laneId: string) => void;
+    act(() => {
+      onManage("lane-remote");
+    });
+    view.rerender(<>{result.current.menu}</>);
+
+    expect(capturedManageLaneHostProps).toMatchObject({ laneId: "lane-remote" });
+    expect(view.getByTestId("work-manage-lane-dialog")).toBeTruthy();
+    expect(navigate).not.toHaveBeenCalled();
+  });
+
   it("starts a foreign lane draft with its owning machine", () => {
     const writeClipboardText = vi.fn().mockResolvedValue(undefined);
     Object.defineProperty(window, "ade", {

--- a/apps/ios/ADE/Views/Lanes/LaneManageSheet.swift
+++ b/apps/ios/ADE/Views/Lanes/LaneManageSheet.swift
@@ -163,6 +163,8 @@ struct LaneManageSheet: View {
             manageErrorBanner(errorMessage)
           }
 
+          laneNameTitle
+
           laneInfoHeader
 
           if isPrimary {
@@ -184,7 +186,7 @@ struct LaneManageSheet: View {
       .adeScreenBackground()
       .overlay { busyOverlay }
       .adeNavigationGlass()
-      .navigationTitle("Manage lane")
+      .navigationTitle(snapshot.lane.name)
       .navigationBarTitleDisplayMode(.inline)
       .toolbar {
         ToolbarItem(placement: .cancellationAction) {
@@ -214,26 +216,32 @@ struct LaneManageSheet: View {
     }
   }
 
+  private var laneTint: Color {
+    laneSurfaceTint(forHex: snapshot.lane.color).text ?? ADEColor.accent
+  }
+
+  private var laneNameTitle: some View {
+    HStack(alignment: .firstTextBaseline, spacing: 8) {
+      Text(snapshot.lane.name)
+        .font(.largeTitle.weight(.bold))
+        .foregroundStyle(laneTint)
+        .lineLimit(2)
+        .minimumScaleFactor(0.7)
+      if snapshot.lane.status.dirty {
+        Text("DIRTY")
+          .font(.caption2.weight(.bold))
+          .foregroundStyle(ADEColor.warning)
+          .padding(.horizontal, 6)
+          .padding(.vertical, 2)
+          .background(ADEColor.warning.opacity(0.14), in: Capsule())
+      }
+      Spacer(minLength: 0)
+    }
+    .accessibilityAddTraits(.isHeader)
+  }
+
   private var laneInfoHeader: some View {
     VStack(alignment: .leading, spacing: 8) {
-      HStack(spacing: 8) {
-        WorkLaneLogoMark(
-          color: laneSurfaceTint(forHex: snapshot.lane.color).text ?? ADEColor.accent,
-          laneIcon: snapshot.lane.icon,
-          size: 13
-        )
-        Text(snapshot.lane.name)
-          .font(.headline.weight(.semibold))
-          .foregroundStyle(ADEColor.textPrimary)
-        if snapshot.lane.status.dirty {
-          Text("DIRTY")
-            .font(.caption2.weight(.bold))
-            .foregroundStyle(ADEColor.warning)
-            .padding(.horizontal, 6)
-            .padding(.vertical, 2)
-            .background(ADEColor.warning.opacity(0.14), in: Capsule())
-        }
-      }
       LabeledContent("Branch") {
         Text(branchLabel)
           .font(.system(.caption, design: .monospaced))
@@ -335,57 +343,75 @@ struct LaneManageSheet: View {
   }
 
   private var deleteChecklist: some View {
-    VStack(spacing: 0) {
-      deleteChecklistRow(
-        title: "Select everything",
-        subtitle: "Worktree, local & remote branch",
-        symbol: "checkmark.circle",
-        isSelected: deleteSelection.allSelected,
-        isIndeterminate: deleteSelection.hasAny && !deleteSelection.allSelected
-      ) {
-        deleteSelection = deleteSelection.allSelected ? .empty : LaneDeleteSelection(worktree: true, localBranch: true, remoteBranch: true)
+    VStack(alignment: .leading, spacing: 8) {
+      Button {
+        deleteSelection = deleteSelection.allSelected
+          ? .empty
+          : LaneDeleteSelection(worktree: true, localBranch: true, remoteBranch: true)
+      } label: {
+        HStack(spacing: 8) {
+          Image(systemName: deleteSelection.allSelected
+            ? "checkmark.square.fill"
+            : (deleteSelection.hasAny ? "minus.square.fill" : "square"))
+            .font(.system(size: 15, weight: .semibold))
+            .foregroundStyle(deleteSelection.hasAny ? ADEColor.danger : ADEColor.textMuted)
+          Text("Select everything")
+            .font(.caption.weight(.semibold))
+            .foregroundStyle(ADEColor.textPrimary)
+          Spacer(minLength: 0)
+        }
+        .padding(.horizontal, 10)
+        .padding(.vertical, 6)
+        .background(ADEColor.surfaceBackground.opacity(0.4), in: RoundedRectangle(cornerRadius: 8, style: .continuous))
+        .overlay(
+          RoundedRectangle(cornerRadius: 8, style: .continuous)
+            .stroke(ADEColor.border.opacity(0.16), lineWidth: 0.5)
+        )
       }
+      .buttonStyle(.plain)
+      .disabled(!canRunLiveActions || busyAction != nil)
 
-      Divider().opacity(0.2)
+      VStack(spacing: 0) {
+        deleteChecklistRow(
+          title: "Worktree",
+          subtitle: "Removes the working folder and ADE registration.",
+          symbol: "shippingbox",
+          isSelected: deleteSelection.worktree
+        ) {
+          toggleDeleteTarget(.worktree, !deleteSelection.worktree)
+        }
 
-      deleteChecklistRow(
-        title: "Worktree",
-        subtitle: "Removes the working folder and ADE registration.",
-        symbol: "shippingbox",
-        isSelected: deleteSelection.worktree
-      ) {
-        toggleDeleteTarget(.worktree, !deleteSelection.worktree)
+        Divider().opacity(0.2)
+
+        deleteChecklistRow(
+          title: "Local branch",
+          subtitle: branchLabel,
+          symbol: "arrow.triangle.branch",
+          isSelected: deleteSelection.localBranch,
+          monoSubtitle: true
+        ) {
+          toggleDeleteTarget(.localBranch, !deleteSelection.localBranch)
+        }
+
+        Divider().opacity(0.2)
+
+        deleteChecklistRow(
+          title: "Remote branch",
+          subtitle: "origin · \(branchLabel)",
+          symbol: "cloud",
+          isSelected: deleteSelection.remoteBranch,
+          monoSubtitle: true
+        ) {
+          toggleDeleteTarget(.remoteBranch, !deleteSelection.remoteBranch)
+        }
       }
-
-      Divider().opacity(0.2)
-
-      deleteChecklistRow(
-        title: "Local branch",
-        subtitle: branchLabel,
-        symbol: "arrow.triangle.branch",
-        isSelected: deleteSelection.localBranch,
-        monoSubtitle: true
-      ) {
-        toggleDeleteTarget(.localBranch, !deleteSelection.localBranch)
-      }
-
-      Divider().opacity(0.2)
-
-      deleteChecklistRow(
-        title: "Remote branch",
-        subtitle: "origin · \(branchLabel)",
-        symbol: "cloud",
-        isSelected: deleteSelection.remoteBranch,
-        monoSubtitle: true
-      ) {
-        toggleDeleteTarget(.remoteBranch, !deleteSelection.remoteBranch)
-      }
+      .padding(.leading, 12)
+      .background(ADEColor.surfaceBackground.opacity(0.35), in: RoundedRectangle(cornerRadius: 12, style: .continuous))
+      .overlay(
+        RoundedRectangle(cornerRadius: 12, style: .continuous)
+          .stroke(ADEColor.border.opacity(0.16), lineWidth: 0.5)
+      )
     }
-    .background(ADEColor.surfaceBackground.opacity(0.35), in: RoundedRectangle(cornerRadius: 12, style: .continuous))
-    .overlay(
-      RoundedRectangle(cornerRadius: 12, style: .continuous)
-        .stroke(ADEColor.border.opacity(0.16), lineWidth: 0.5)
-    )
   }
 
   private enum DeleteTarget {


### PR DESCRIPTION
## Summary
- Opening Manage lane from the Work tab stays on Work instead of routing through the Lanes tab.
- The manage dialog title is now the lane name in that lane's color.
- On the Delete tab, Select everything is compact and separate from the indented worktree / local / remote targets. Same treatment on iOS; web client shares the desktop dialog.

## Test plan
- Right-click a Work chat or lane → Lane → Manage lane: dialog opens without leaving Work
- Dialog header shows the lane name in the lane color
- Delete tab: Select everything is shorter/separate; the three targets stay indented
- Same header/checklist on iOS manage sheet
- Lanes tab Manage lane still opens and can delete/archive as before

<!-- ade:link v=1 type=pr repo=arul28/ADE branch=ade%2Fmanage-lane-redesign num=1157 -->
<p>
  <img src="https://ade-app.dev/logo.png" height="18" align="left" alt="ADE">
  &nbsp;&nbsp;<strong>Open in ADE</strong>
  &nbsp;·&nbsp; <a href="https://ade-app.dev/open?type=branch&amp;repo=arul28%2FADE&amp;branch=ade%2Fmanage-lane-redesign&amp;pr=1157">ade/manage-lane-redesign branch</a>
  &nbsp;·&nbsp; <a href="https://ade-app.dev/open?type=pr&amp;repo=arul28%2FADE&amp;number=1157">PR #1157</a>
</p>
<!-- /ade:link -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated lane management dialogs and sheets with color-coded lane names and dirty-status indicators.
  * Added a dedicated “Select everything” control and clearer grouping for deletion options.
  * Improved lane management presentation for individual lanes, including inline rename controls.

* **Bug Fixes**
  * Managing a lane now preserves the current view instead of selecting or navigating away from it.
  * Disabled deletion selections when live actions are unavailable or busy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->