### PR TITLE
Keep auto-created lanes from stealing mentioned-lane PR badges

### DIFF
--- a/apps/desktop/src/main/services/chat/agentChatService.test.ts
+++ b/apps/desktop/src/main/services/chat/agentChatService.test.ts
@@ -41940,7 +41940,32 @@ describe("suggestLaneNameFromPrompt", () => {
     });
 
     expect(result.laneTitle).toBe("Claude OAuth Login");
-    expect(result.branchFragment).toBe("claude-auth-login-button-hangs");
+    expect(result.branchFragment).toBe("claude-oauth-login");
+  });
+
+  it("does not let a mentioned lane's branch fragment override this prompt's title", async () => {
+    vi.mocked(detectAllAuth).mockResolvedValue([
+      { type: "cli-subscription" as any, cli: "codex", authenticated: true, path: "/usr/bin/codex", verified: true },
+    ]);
+    const { service, aiIntegrationService } = createSuggestService();
+    vi.mocked(aiIntegrationService.summarizeTerminal).mockResolvedValueOnce({
+      text: JSON.stringify({
+        laneTitle: "Ok Something Super Weird Happened",
+        branchFragment: "chat-mention-tags",
+      }),
+    } as any);
+
+    const result = await service.generateAutoLaneIdentity({
+      prompt: "ok something super weird happened. why is Chat Mention Tags showing pr 1068?",
+      modelId: "openai/gpt-5.4",
+      laneId: "lane-1",
+      fallbackName: "Ok Something Super Weird Happened",
+      temporaryBranch: "ade/1a2b3c4d",
+    });
+
+    expect(result.laneTitle).toBe("Ok Something Super Weird Happened");
+    expect(result.branchFragment).toBe("ok-something-super-weird-happened");
+    expect(result.source).toBe("ai");
   });
 
   it("clamps an over-long AI identity instead of discarding it for a slug", async () => {
@@ -42013,6 +42038,29 @@ describe("suggestLaneNameFromPrompt", () => {
 
     expect(aiIntegrationService.summarizeTerminal).toHaveBeenNthCalledWith(1, expect.objectContaining({
       model: "openai/gpt-5.4-mini",
+    }));
+  });
+
+  it("uses the default title model before the launched chat model", async () => {
+    vi.mocked(detectAllAuth).mockResolvedValue([
+      { type: "cli-subscription" as any, cli: "claude", authenticated: true, path: "/usr/bin/claude", verified: true },
+      { type: "cli-subscription" as any, cli: "codex", authenticated: true, path: "/usr/bin/codex", verified: true },
+    ]);
+    const { service, aiIntegrationService } = createSuggestService();
+    vi.mocked(aiIntegrationService.summarizeTerminal).mockResolvedValueOnce({
+      text: JSON.stringify({ laneTitle: "Lane Naming", branchFragment: "lane-naming" }),
+    } as any);
+
+    await service.generateAutoLaneIdentity({
+      prompt: "Rename automatic lanes",
+      modelId: "openai/gpt-5.4",
+      chatModelId: "openai/gpt-5.4",
+      laneId: "lane-1",
+      temporaryBranch: "ade/1a2b3c4d",
+    });
+
+    expect(aiIntegrationService.summarizeTerminal).toHaveBeenNthCalledWith(1, expect.objectContaining({
+      model: "anthropic/claude-haiku-4-5",
     }));
   });
 

--- a/apps/desktop/src/main/services/chat/agentChatService.ts
+++ b/apps/desktop/src/main/services/chat/agentChatService.ts
@@ -563,6 +563,7 @@ import {
   GENERIC_LANE_FALLBACK_TITLE,
   genericLaneFallbackName,
   genericSuffixFromLaneFallbackName,
+  resolveCoherentAutoLaneIdentity,
 } from "../../../shared/laneNameFallback";
 import { resolveSubagentCapability } from "../../../shared/subagentCapabilities";
 import {
@@ -12625,19 +12626,18 @@ export function createAgentChatService(args: {
         if (config.titleGenerationEnabled !== false) {
           const auth = await detectAuth();
           const availableModels = getRegistryModels(auth).filter((descriptor) => !descriptor.deprecated);
-          // Chain: configured naming model -> the model this chat was launched
-          // with -> a different provider -> deterministic. The launched model is
-          // always present (not only when no naming model is configured) and a
-          // cross-provider candidate is always reachable, so an outage confined
-          // to one provider (auth, missing binary, account-rejected model) can no
-          // longer end naming outright.
+          // Same chain as chat auto-title: configured naming model -> default
+          // title model (haiku) -> launched chat model -> requested model ->
+          // first available -> deterministic. Haiku stays ahead of the chat
+          // model so a JSON miss on the configured namer does not send lane
+          // identity to grok while chat titles still use haiku.
           const candidateModelIds = buildNamingModelCandidates({
             availableModels,
             preferred: [
               config.titleModelId,
+              DEFAULT_AUTO_TITLE_MODEL_ID,
               chatModelId,
               requestedModelId,
-              DEFAULT_AUTO_TITLE_MODEL_ID,
               availableModels[0]?.id,
             ],
           });
@@ -12658,10 +12658,7 @@ export function createAgentChatService(args: {
               });
               const parsed = parseAutoLaneIdentity(result.text);
               if (!parsed || (!parsed.laneTitle && !parsed.branchFragment)) return null;
-              return {
-                laneTitle: parsed.laneTitle ?? fallback.laneTitle,
-                branchFragment: parsed.branchFragment ?? fallback.branchFragment,
-              };
+              return resolveCoherentAutoLaneIdentity(parsed, fallback);
             },
             onFailure: ({ descriptor, provider, providerLevelFailure, error }) => {
               logger.warn("agent_chat.suggest_lane_name_failed", {

--- a/apps/desktop/src/main/services/chat/sessionNaming.ts
+++ b/apps/desktop/src/main/services/chat/sessionNaming.ts
@@ -42,10 +42,11 @@ laneTitle:
 - Avoid generic leading verbs such as Fix, Update, Improve, Handle, or Work On when a specific noun phrase is available.
 - Do not repeat the user's sentence verbatim. No quotes, emoji, or trailing punctuation.
 branchFragment:
-- Describe the same workstream in 2 to ${MAX_NAMING_WORDS} short specific words.
+- Describe the SAME new workstream as laneTitle, in 2 to ${MAX_NAMING_WORDS} short specific words.
 - Lowercase ASCII and hyphen-separated. Do not include the ade/ prefix.
 - No spaces, quotes, refs/heads/, punctuation-heavy text, or leading/trailing separators.
 - Keep it concise and safe for GitHub, PR lists, terminals, and Git branch naming.
+- Never copy the title or branch of an existing lane, chat, or pull request mentioned in the request. Those are context, not this workspace's identity.
 Attached images are primary context for visual and UI requests.`;
 
 export const LEGACY_LANE_NAME_SYSTEM_PROMPT = `Name a git worktree lane.

--- a/apps/desktop/src/main/services/lanes/laneService.test.ts
+++ b/apps/desktop/src/main/services/lanes/laneService.test.ts
@@ -787,6 +787,26 @@ describe("laneService automatic lane identity", () => {
     vi.mocked(runGitOrThrow).mockReset();
   });
 
+  const stubUnpublishedTempBranchGit = (currentBranch = "ade/1a2b3c4d") => {
+    vi.mocked(runGit).mockImplementation(async (args: string[]) => {
+      if (args[0] === "branch" && args[1] === "--show-current") {
+        return { exitCode: 0, stdout: `${currentBranch}\n`, stderr: "" };
+      }
+      if (args[0] === "rev-parse" && args.includes("@{upstream}")) {
+        return { exitCode: 1, stdout: "", stderr: "" };
+      }
+      if (args[0] === "remote" && args[1] === "get-url") {
+        return { exitCode: 2, stdout: "", stderr: "" };
+      }
+      if (args[0] === "check-ref-format") return { exitCode: 0, stdout: "", stderr: "" };
+      if (args[0] === "show-ref") return { exitCode: 1, stdout: "", stderr: "" };
+      if (args[0] === "branch" && args[1] === "-m") {
+        return { exitCode: 0, stdout: "", stderr: "" };
+      }
+      throw new Error(`Unexpected git call: ${args.join(" ")}`);
+    });
+  };
+
   it("serializes duplicate completions and renames the exact temporary branch once", async () => {
     const repoRoot = makeTempRepoRoot("ade-auto-lane-identity-");
     const db = await openKvDb(path.join(repoRoot, "kv.sqlite"), createLogger());
@@ -862,6 +882,183 @@ describe("laneService automatic lane identity", () => {
         branch_ref: "ade/naming-auto-created-lanes",
       });
       expect(identityUpdateBranchRefs).toEqual(["ade/naming-auto-created-lanes"]);
+    } finally {
+      db.close();
+      fs.rmSync(repoRoot, { recursive: true, force: true });
+    }
+  });
+
+  it("skips a detached merged PR head branch even when git refs are gone", async () => {
+    const repoRoot = makeTempRepoRoot("ade-auto-lane-identity-pr-");
+    const db = await openKvDb(path.join(repoRoot, "kv.sqlite"), createLogger());
+    try {
+      await seedProjectAndStack(db, { projectId: "proj-auto-identity-pr", repoRoot });
+      db.run("update lanes set name = ?, branch_ref = ? where id = ?", [
+        "Ok Something Super Weird Happened",
+        "ade/1a2b3c4d",
+        "lane-child",
+      ]);
+      db.run(
+        `
+          insert into pull_requests(
+            id, project_id, lane_id, repo_owner, repo_name, github_pr_number, github_url,
+            title, state, base_branch, head_branch, created_at, updated_at, detached_at
+          ) values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        `,
+        [
+          "pr-1068",
+          "proj-auto-identity-pr",
+          "lane-parent",
+          "acme",
+          "demo",
+          1068,
+          "https://example.com/pr/1068",
+          "Chat Mention Tags",
+          "merged",
+          "main",
+          "ade/chat-mention-tags",
+          "2026-08-10T12:55:38.000Z",
+          "2026-08-10T12:55:38.000Z",
+          "2026-08-10T13:00:00.000Z",
+        ],
+      );
+
+      stubUnpublishedTempBranchGit();
+
+      const service = createLaneService({
+        db,
+        projectRoot: repoRoot,
+        projectId: "proj-auto-identity-pr",
+        defaultBaseRef: "main",
+        worktreesDir: path.join(repoRoot, "worktrees"),
+      });
+      const completed = await service.applyAutoLaneIdentity({
+        laneId: "lane-child",
+        expectedLaneName: "Ok Something Super Weird Happened",
+        temporaryBranch: "ade/1a2b3c4d",
+        laneTitle: "Ok Something Super Weird Happened",
+        branchFragment: "chat-mention-tags",
+      });
+
+      expect(completed).toMatchObject({
+        branchRenameOutcome: "renamed",
+        branchRef: "ade/ok-something-super-weird-happened",
+      });
+      expect(vi.mocked(runGit).mock.calls.some(([gitArgs]) => (
+        gitArgs[0] === "branch" && gitArgs[1] === "-m" && gitArgs[2] === "ade/ok-something-super-weird-happened"
+      ))).toBe(true);
+    } finally {
+      db.close();
+      fs.rmSync(repoRoot, { recursive: true, force: true });
+    }
+  });
+
+  it("skips a projected GitHub PR head branch with no mapped pull_requests row", async () => {
+    const repoRoot = makeTempRepoRoot("ade-auto-lane-identity-proj-");
+    const db = await openKvDb(path.join(repoRoot, "kv.sqlite"), createLogger());
+    try {
+      await seedProjectAndStack(db, { projectId: "proj-auto-identity-proj", repoRoot });
+      db.run("update lanes set name = ?, branch_ref = ? where id = ?", [
+        "Ok Something Super Weird Happened",
+        "ade/1a2b3c4d",
+        "lane-child",
+      ]);
+      db.run(
+        `
+          insert into github_pr_projections(
+            project_id, repo_owner, repo_name, github_pr_number, title, state,
+            is_draft, labels_json, comment_count, created_at, updated_at, synced_at, head_branch
+          ) values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        `,
+        [
+          "proj-auto-identity-proj",
+          "acme",
+          "demo",
+          1068,
+          "Chat Mention Tags",
+          "merged",
+          0,
+          "[]",
+          0,
+          "2026-08-10T12:55:38.000Z",
+          "2026-08-10T12:55:38.000Z",
+          "2026-08-10T12:55:38.000Z",
+          "ade/chat-mention-tags",
+        ],
+      );
+
+      stubUnpublishedTempBranchGit();
+
+      const service = createLaneService({
+        db,
+        projectRoot: repoRoot,
+        projectId: "proj-auto-identity-proj",
+        defaultBaseRef: "main",
+        worktreesDir: path.join(repoRoot, "worktrees"),
+      });
+      const completed = await service.applyAutoLaneIdentity({
+        laneId: "lane-child",
+        expectedLaneName: "Ok Something Super Weird Happened",
+        temporaryBranch: "ade/1a2b3c4d",
+        laneTitle: "Ok Something Super Weird Happened",
+        branchFragment: "chat-mention-tags",
+      });
+
+      expect(completed).toMatchObject({
+        branchRenameOutcome: "renamed",
+        branchRef: "ade/ok-something-super-weird-happened",
+      });
+    } finally {
+      db.close();
+      fs.rmSync(repoRoot, { recursive: true, force: true });
+    }
+  });
+
+  it("keeps the fallback title and title-derived branch when the AI identity duplicates a live lane", async () => {
+    const repoRoot = makeTempRepoRoot("ade-auto-lane-identity-dup-");
+    const db = await openKvDb(path.join(repoRoot, "kv.sqlite"), createLogger());
+    try {
+      await seedProjectAndStack(db, { projectId: "proj-auto-identity-dup", repoRoot });
+      db.run("update lanes set name = ?, branch_ref = ? where id = ?", [
+        "Chat Mention Tags",
+        "ade/chat-mention-tags",
+        "lane-parent",
+      ]);
+      db.run("update lanes set name = ?, branch_ref = ? where id = ?", [
+        "Ok Something Super Weird Happened",
+        "ade/1a2b3c4d",
+        "lane-child",
+      ]);
+
+      stubUnpublishedTempBranchGit();
+
+      const service = createLaneService({
+        db,
+        projectRoot: repoRoot,
+        projectId: "proj-auto-identity-dup",
+        defaultBaseRef: "main",
+        worktreesDir: path.join(repoRoot, "worktrees"),
+      });
+      const completed = await service.applyAutoLaneIdentity({
+        laneId: "lane-child",
+        expectedLaneName: "Ok Something Super Weird Happened",
+        temporaryBranch: "ade/1a2b3c4d",
+        laneTitle: "Chat Mention Tags",
+        branchFragment: "chat-mention-tags",
+      });
+
+      expect(completed).toMatchObject({
+        laneRenameOutcome: "failed",
+        branchRenameOutcome: "renamed",
+        branchRef: "ade/ok-something-super-weird-happened",
+      });
+      expect(db.get("select name, branch_ref from lanes where id = ?", ["lane-child"])).toMatchObject({
+        name: "Ok Something Super Weird Happened",
+        branch_ref: "ade/ok-something-super-weird-happened",
+      });
+      expect(vi.mocked(runGit).mock.calls.some(([gitArgs]) => (
+        gitArgs[0] === "branch" && gitArgs[1] === "-m" && gitArgs[2] === "ade/chat-mention-tags-2"
+      ))).toBe(false);
     } finally {
       db.close();
       fs.rmSync(repoRoot, { recursive: true, force: true });

--- a/apps/desktop/src/main/services/lanes/laneService.ts
+++ b/apps/desktop/src/main/services/lanes/laneService.ts
@@ -10,7 +10,7 @@ import { fetchRemoteTrackingBranch } from "../shared/remoteTrackingBranch";
 import { pathsEqual } from "../shared/pathCompare";
 import { detectConflictKind } from "../git/gitConflictState";
 import { invalidateProjectPathInspectionCache } from "../projects/projectPathInspector";
-import { shouldLaneTrackParent } from "../../../shared/laneBaseResolution";
+import { branchNameFromLaneRef, shouldLaneTrackParent } from "../../../shared/laneBaseResolution";
 import { PRIMARY_LANE_COLOR, allocateLaneColor } from "../../../shared/laneColorPalette";
 import { linearIssueBranchName, sanitizeLinearIssueBranchName } from "../../../shared/linearIssueBranch";
 import {
@@ -87,7 +87,10 @@ import {
   laneNameAdvertisesBranch,
   parseWorktreeStatusPorcelainV2,
 } from "./laneBranchDrift";
-import { isAutoLaneTemporaryBranch } from "../../../shared/laneNameFallback";
+import {
+  isAutoLaneTemporaryBranch,
+  resolveAppliedAutoLaneBranchFragment,
+} from "../../../shared/laneNameFallback";
 
 type LaneRow = {
   id: string;
@@ -6228,14 +6231,15 @@ export function createLaneService({
         branchRef,
         reason,
       });
-      if (!isAutoLaneTemporaryBranch(args.temporaryBranch)) return skipBranch("invalid_temporary_branch");
-      if (lane.branch_ref !== args.temporaryBranch) return skipBranch("persisted_branch_changed");
+      const temporaryBranch = branchNameFromLaneRef(args.temporaryBranch);
+      if (!isAutoLaneTemporaryBranch(temporaryBranch)) return skipBranch("invalid_temporary_branch");
+      if (normalizeBranchKey(lane.branch_ref) !== temporaryBranch) return skipBranch("persisted_branch_changed");
 
       const currentBranch = await runGit(["branch", "--show-current"], {
         cwd: lane.worktree_path,
         timeoutMs: 8_000,
       });
-      if (currentBranch.exitCode !== 0 || currentBranch.stdout.trim() !== args.temporaryBranch) {
+      if (currentBranch.exitCode !== 0 || branchNameFromLaneRef(currentBranch.stdout.trim()) !== temporaryBranch) {
         return skipBranch("checked_out_branch_changed");
       }
       const upstream = await runGit(
@@ -6250,7 +6254,7 @@ export function createLaneService({
       const hasOrigin = origin.exitCode === 0 && origin.stdout.trim().length > 0;
       if (hasOrigin) {
         const remoteTemp = await runGit(
-          ["ls-remote", "--exit-code", "--heads", "origin", args.temporaryBranch],
+          ["ls-remote", "--exit-code", "--heads", "origin", temporaryBranch],
           { cwd: lane.worktree_path, timeoutMs: 12_000 },
         );
         if (remoteTemp.exitCode === 0 && remoteTemp.stdout.trim()) return skipBranch("temporary_branch_pushed");
@@ -6262,7 +6266,60 @@ export function createLaneService({
       );
       if (pr) return skipBranch("pull_request_exists");
 
-      const baseRef = `ade/${args.branchFragment}`;
+      const autoIdentityBranchOccupied = (ref: string): boolean => {
+        const normalized = normalizeBranchKey(ref);
+        if (!normalized) return true;
+        if (findActiveBranchOwner(normalized, args.laneId)) return true;
+        const headVariants = [normalized, `refs/heads/${normalized}`, `origin/${normalized}`];
+        const historical = db.get<{ id: string }>(
+          `
+            select id from pull_requests
+            where project_id = ?
+              and (
+                head_branch = ?
+                or head_branch = ?
+                or head_branch = ?
+              )
+            limit 1
+          `,
+          [projectId, ...headVariants],
+        );
+        if (historical) return true;
+        const projected = db.get<{ github_pr_number: number }>(
+          `
+            select github_pr_number from github_pr_projections
+            where project_id = ?
+              and (
+                head_branch = ?
+                or head_branch = ?
+                or head_branch = ?
+              )
+            limit 1
+          `,
+          [projectId, ...headVariants],
+        );
+        return Boolean(projected);
+      };
+
+      // Only keep the AI fragment when this lane actually took the AI title.
+      // A duplicate-name failure (or a user rename mid-flight) must not still
+      // claim `ade/chat-mention-tags-2` for a lane that stayed on its fallback
+      // title. Occupied fragments also lose to the applied title's slug rather
+      // than suffixing a name that belongs to another live lane or merged PR.
+      const adoptedAiTitle = laneRenameOutcome === "renamed"
+        || (laneRenameOutcome === "kept" && args.laneTitle === lane.name);
+      const identityTitle = laneRenameOutcome === "skipped"
+        ? lane.name
+        : laneRenameOutcome === "failed"
+          ? args.expectedLaneName
+          : args.laneTitle;
+      const branchFragment = resolveAppliedAutoLaneBranchFragment({
+        adoptedAiTitle,
+        aiBranchFragment: args.branchFragment,
+        identityTitle,
+        occupied: autoIdentityBranchOccupied,
+      });
+      const baseRef = `ade/${branchFragment}`;
       const validRef = await runGit(["check-ref-format", "--branch", baseRef], {
         cwd: lane.worktree_path,
         timeoutMs: 8_000,
@@ -6285,7 +6342,7 @@ export function createLaneService({
         if (remote.exitCode !== 0 && remote.exitCode !== 2) {
           return skipBranch("remote_state_unavailable");
         }
-        if (local.exitCode !== 0 && remote.exitCode === 2) {
+        if (local.exitCode !== 0 && remote.exitCode === 2 && !autoIdentityBranchOccupied(candidate)) {
           targetRef = candidate;
           break;
         }
@@ -6293,12 +6350,14 @@ export function createLaneService({
       if (!targetRef) return skipBranch("branch_collision_limit_reached");
 
       const latestLane = getLaneRow(args.laneId);
-      if (latestLane?.branch_ref !== args.temporaryBranch) return skipBranch("persisted_branch_changed");
+      if (normalizeBranchKey(latestLane?.branch_ref ?? "") !== temporaryBranch) {
+        return skipBranch("persisted_branch_changed");
+      }
       const latestBranch = await runGit(["branch", "--show-current"], {
         cwd: lane.worktree_path,
         timeoutMs: 8_000,
       });
-      if (latestBranch.exitCode !== 0 || latestBranch.stdout.trim() !== args.temporaryBranch) {
+      if (latestBranch.exitCode !== 0 || branchNameFromLaneRef(latestBranch.stdout.trim()) !== temporaryBranch) {
         return skipBranch("checked_out_branch_changed");
       }
 
@@ -6309,27 +6368,27 @@ export function createLaneService({
       if (renamed.exitCode !== 0) {
         logger.warn("lane.auto_identity_branch_rename_failed", {
           laneId: args.laneId,
-          temporaryBranch: args.temporaryBranch,
+          temporaryBranch,
           targetRef,
           error: renamed.stderr.trim(),
         });
         return {
           laneRenameOutcome,
           branchRenameOutcome: "failed",
-          branchRef: args.temporaryBranch,
+          branchRef: temporaryBranch,
           reason: "git_rename_failed",
         };
       }
       try {
         laneServiceApi.updateBranchRef(args.laneId, targetRef);
       } catch (error) {
-        const rollback = await runGit(["branch", "-m", args.temporaryBranch], {
+        const rollback = await runGit(["branch", "-m", temporaryBranch], {
           cwd: lane.worktree_path,
           timeoutMs: 15_000,
         });
         logger.error("lane.auto_identity_branch_persist_failed", {
           laneId: args.laneId,
-          temporaryBranch: args.temporaryBranch,
+          temporaryBranch,
           targetRef,
           rollbackSucceeded: rollback.exitCode === 0,
           error: error instanceof Error ? error.message : String(error),
@@ -6360,7 +6419,7 @@ export function createLaneService({
         return {
           laneRenameOutcome,
           branchRenameOutcome: "failed",
-          branchRef: args.temporaryBranch,
+          branchRef: temporaryBranch,
           reason: "persistence_failed_git_rolled_back",
         };
       }

--- a/apps/desktop/src/shared/laneNameFallback.test.ts
+++ b/apps/desktop/src/shared/laneNameFallback.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  branchFragmentFromLaneTitle,
   cleanPromptForNaming,
   deriveDeterministicAutoLaneIdentity,
   deriveDeterministicLaneNameFromPrompt,
@@ -8,6 +9,8 @@ import {
   genericLaneFallbackName,
   genericSuffixFromLaneFallbackName,
   isAutoLaneTemporaryBranch,
+  resolveAppliedAutoLaneBranchFragment,
+  resolveCoherentAutoLaneIdentity,
 } from "./laneNameFallback";
 
 describe("automatic lane identity fallback", () => {
@@ -29,6 +32,67 @@ describe("automatic lane identity fallback", () => {
     expect(isAutoLaneTemporaryBranch("ade/naming-auto-created-lanes")).toBe(false);
     expect(isAutoLaneTemporaryBranch("feature/1a2b3c4d")).toBe(false);
     expect(isAutoLaneTemporaryBranch("ade/ABCDEF12")).toBe(false);
+  });
+
+  it("keeps a title and derives the branch when AI copies a mentioned lane's fragment", () => {
+    const fallback = deriveDeterministicAutoLaneIdentity(
+      "ok something super weird happened. @lane Chat Mention Tags is showing pr 1068",
+    );
+    expect(fallback.laneTitle).toBe("Ok Something Super Weird Happened");
+    expect(resolveCoherentAutoLaneIdentity({
+      laneTitle: "Ok Something Super Weird Happened",
+      branchFragment: "chat-mention-tags",
+    }, fallback)).toEqual({
+      laneTitle: "Ok Something Super Weird Happened",
+      branchFragment: "ok-something-super-weird-happened",
+    });
+  });
+
+  it("does not mix a fallback title with a mention-copied branch fragment", () => {
+    const fallback = {
+      laneTitle: "Ok Something Super Weird Happened",
+      branchFragment: "ok-something-super-weird-happened",
+    };
+    expect(resolveCoherentAutoLaneIdentity({
+      laneTitle: null,
+      branchFragment: "chat-mention-tags",
+    }, fallback)).toEqual(fallback);
+  });
+
+  it("keeps a coherent AI title/branch pair", () => {
+    expect(resolveCoherentAutoLaneIdentity({
+      laneTitle: "Chat Mention Tags",
+      branchFragment: "chat-mention-tags",
+    }, {
+      laneTitle: "Start Skill Image Wann Highlihgt",
+      branchFragment: "start-skill-image-wann-highlihgt",
+    })).toEqual({
+      laneTitle: "Chat Mention Tags",
+      branchFragment: "chat-mention-tags",
+    });
+  });
+
+  it("slugs titles without the prompt stopword list", () => {
+    expect(branchFragmentFromLaneTitle("Chat Mention Tags")).toBe("chat-mention-tags");
+    expect(branchFragmentFromLaneTitle("!!!")).toBe("parallel-task");
+  });
+
+  it("drops a stolen AI fragment when the title was not adopted", () => {
+    expect(resolveAppliedAutoLaneBranchFragment({
+      adoptedAiTitle: false,
+      aiBranchFragment: "chat-mention-tags",
+      identityTitle: "Ok Something Super Weird Happened",
+      occupied: () => false,
+    })).toBe("ok-something-super-weird-happened");
+  });
+
+  it("prefers the applied title slug over suffixing an occupied stolen fragment", () => {
+    expect(resolveAppliedAutoLaneBranchFragment({
+      adoptedAiTitle: true,
+      aiBranchFragment: "chat-mention-tags",
+      identityTitle: "Ok Something Super Weird Happened",
+      occupied: (ref) => ref === "ade/chat-mention-tags",
+    })).toBe("ok-something-super-weird-happened");
   });
 });
 

--- a/apps/desktop/src/shared/laneNameFallback.ts
+++ b/apps/desktop/src/shared/laneNameFallback.ts
@@ -177,6 +177,45 @@ export function deriveDeterministicAutoLaneIdentity(prompt: string): {
   };
 }
 
+export function branchFragmentFromLaneTitle(title: string): string {
+  const slug = (String(title ?? "").toLowerCase().match(/[a-z0-9]+/g) ?? [])
+    .join("-")
+    .replace(/-+/g, "-")
+    .replace(/^-|-$/g, "")
+    .slice(0, 48)
+    .replace(/^-|-$/g, "");
+  return slug.length ? slug : GENERIC_LANE_FALLBACK_NAME;
+}
+
+export function resolveCoherentAutoLaneIdentity(
+  parsed: { laneTitle: string | null; branchFragment: string | null } | null | undefined,
+  fallback: { laneTitle: string; branchFragment: string },
+): { laneTitle: string; branchFragment: string } {
+  const laneTitle = parsed?.laneTitle?.trim() || null;
+  const branchFragment = parsed?.branchFragment?.trim().toLowerCase() || null;
+  if (!laneTitle) return fallback;
+  const titleSlug = branchFragmentFromLaneTitle(laneTitle);
+  if (branchFragment && branchFragment === titleSlug) {
+    return { laneTitle, branchFragment };
+  }
+  return { laneTitle, branchFragment: titleSlug };
+}
+
+export function resolveAppliedAutoLaneBranchFragment(args: {
+  adoptedAiTitle: boolean;
+  aiBranchFragment: string;
+  identityTitle: string;
+  occupied: (branchRef: string) => boolean;
+}): string {
+  const fromTitle = branchFragmentFromLaneTitle(args.identityTitle);
+  const aiFragment = String(args.aiBranchFragment ?? "").trim().toLowerCase();
+  const branchFragment = args.adoptedAiTitle && aiFragment ? aiFragment : fromTitle;
+  if (args.occupied(`ade/${branchFragment}`) && fromTitle !== branchFragment) {
+    return fromTitle;
+  }
+  return branchFragment;
+}
+
 export function isAutoLaneTemporaryBranch(branchRef: string): boolean {
   return AUTO_LANE_TEMP_BRANCH_RE.test(branchRef);
 }

--- a/docs/features/lanes/README.md
+++ b/docs/features/lanes/README.md
@@ -207,9 +207,19 @@ iOS companion (`apps/ios/ADE/Views/Lanes/`):
   generates one structured lane/branch identity.
   The backend applies the readable lane title independently, then renames the
   temporary branch only while the lane record, checked-out worktree branch,
-  upstream/remote state, and PR state still prove it is safe. Collisions receive
-  `-2`, `-3`, and later suffixes. A manual lane or branch rename wins over a late
-  result. Mobile calls the same host operation through `SyncService.suggestLaneName`
+  upstream/remote state, and PR state still prove it is safe. Title and branch
+  have to name the same new workstream: a mention-copied fragment next to an
+  unrelated title is dropped, and if the AI title collides with a live lane the
+  fallback title stays and the branch is derived from that title rather than
+  suffixing the stolen name (`ade/chat-mention-tags-2`). Collision checks
+  include live lane branches, historical `pull_requests.head_branch` rows
+  (including detached merged PRs whose git refs are gone), and
+  `github_pr_projections.head_branch`. Occupied names lose to the applied
+  title's slug first; only then do remaining collisions receive `-2`, `-3`,
+  and later suffixes. A manual lane or branch rename wins over a late
+  result. Automatic lane identity uses the same model chain as chat auto-title
+  (configured naming model → default title model → launched chat model). Mobile
+  calls the same host operation through `SyncService.suggestLaneName`
   (the non-queueable `lanes.suggestName` sync command →
   `agentChatService.generateAutoLaneIdentity` on the host).
   Deterministic fallback (`apps/desktop/src/shared/laneNameFallback.ts`)


### PR DESCRIPTION
## Summary
- Auto-created lanes no longer mix a new prompt's title with a mentioned lane's branch (`chat-mention-tags`), and they no longer keep that stolen fragment after a duplicate-name rename failure.
- Branch occupancy now includes live lanes, detached/historical `pull_requests.head_branch` rows, and `github_pr_projections.head_branch`, so a merged PR whose git refs were deleted cannot badge a new lane.
- Lane identity uses the same naming model chain as chat titles (configured namer → default title model → launched chat model).

## Test plan
- [x] Duplicate live lane name "Chat Mention Tags" keeps the fallback title and `ade/ok-something-super-weird-happened`, not `ade/chat-mention-tags-2`
- [x] Detached merged PR head and projections-only occupancy skip the stolen fragment
- [x] Unaligned AI title/fragment derives the branch from the title
- [x] Default title model is tried before the launched chat model when both are available

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes git branch rename and lane DB identity logic with new collision rules; scope is naming/heuristics rather than auth or payments, but wrong occupancy checks could still pick bad branch names.
> 
> **Overview**
> Fixes automatic lane naming so **title and branch always describe the same new workstream**, instead of pairing a user’s prompt title with a branch slug copied from a mentioned lane or merged PR (e.g. `chat-mention-tags`).
> 
> **Generation:** Lane identity AI output is normalized via `resolveCoherentAutoLaneIdentity` (branch slug derived from the chosen title when it doesn’t match). The naming **model chain matches chat auto-title**: configured namer → default Haiku → launched chat model, so a bad JSON response on the namer doesn’t skip Haiku. Prompt rules explicitly forbid copying mentioned lane/PR names into `branchFragment`.
> 
> **Apply:** `applyAutoLaneIdentity` only keeps the AI branch fragment when the AI title was actually adopted; on duplicate title failure it renames the branch from the **fallback title** slug. **Occupied** `ade/…` names now include live lanes, historical `pull_requests.head_branch` (detached merged PRs), and `github_pr_projections`; stolen or occupied fragments fall back to the applied title’s slug before `-2`/`‑3` suffixing. Temporary branch matching is normalized with `branchNameFromLaneRef`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 62198b243d6bff58f5cf21bec12bd259f5dd9108. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved automatic lane naming and branch creation for clearer, more consistent identities.
  * Lane titles and branch names now remain aligned, including when requests mention existing lane, chat, or pull request names.
  * Added stronger handling for temporary branches and existing or unavailable branch names.

* **Bug Fixes**
  * Prevented naming and branch collisions across active lanes, historical pull requests, and projected branches.
  * Improved automatic title model selection for more reliable lane naming.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->