### PR TITLE
OpenCode chats: correct reasoning routing, visible provider retries, hardened turn lifecycle

### DIFF
--- a/apps/desktop/src/main/services/chat/agentChatService.test.ts
+++ b/apps/desktop/src/main/services/chat/agentChatService.test.ts
@@ -27937,6 +27937,76 @@ describe("createAgentChatService", () => {
   // --------------------------------------------------------------------------
 
   describe("session creation edge cases", () => {
+    /**
+     * Drives one OpenCode turn against the mocked event stream.
+     *
+     * Every OpenCode streaming test needs the same six steps before it can assert
+     * anything: gate `streamText`, create the session, send, wait for the started
+     * status, reach into the mocked session state, and wake the stream's waiters
+     * after pushing events. `finish` releases the gate and settles the send.
+     */
+    const startOpenCodeTurn = async (promptText: string) => {
+      const events: AgentChatEventEnvelope[] = [];
+      let releaseStream!: () => void;
+      const streamGate = new Promise<void>((resolve) => { releaseStream = () => resolve(); });
+      vi.mocked(streamText).mockImplementation(() => ({
+        fullStream: (async function* () {
+          await streamGate;
+          yield { type: "finish", usage: {} };
+        })(),
+      }) as any);
+
+      const { service } = createService({
+        onEvent: (event: AgentChatEventEnvelope) => events.push(event),
+      });
+      const session = await service.createSession({
+        laneId: "lane-1",
+        provider: "opencode",
+        model: "opencode/openai/gpt-5.4",
+        modelId: "opencode/openai/gpt-5.4",
+      });
+
+      const sendPromise = service.sendMessage({ sessionId: session.id, text: promptText });
+      const started = await waitForEvent(
+        events,
+        (event): event is AgentChatEventEnvelope =>
+          event.event.type === "status" && event.event.turnStatus === "started",
+      );
+
+      const [sessionID, state] = [...mockState.openCodeSessions.entries()][0]!;
+      // The casts live here so no test has to spell `as any` on every event.
+      const pushEvents = (...next: any[]): void => {
+        state.events.push(...next);
+        const waiters = [...state.waiters];
+        state.waiters.length = 0;
+        waiters.forEach((waiter) => waiter());
+      };
+      const joined = (type: "text" | "reasoning"): string => events
+        .filter((event) => event.event.type === type)
+        .map((event) => (event.event as { text: string }).text)
+        .join("");
+      const waitForDone = (): Promise<AgentChatEventEnvelope> => waitForEvent(
+        events,
+        (event): event is AgentChatEventEnvelope =>
+          event.event.type === "done" && event.event.turnId === started.event.turnId,
+      );
+      const finish = async (): Promise<void> => {
+        releaseStream();
+        await sendPromise;
+      };
+
+      return {
+        service,
+        session,
+        events,
+        sessionID,
+        pushEvents,
+        joined,
+        waitForDone,
+        finish,
+      };
+    };
+
     it("applies automationId and automationRunId when surface is automation", async () => {
       const { service } = createService();
       const session = await service.createSession({
@@ -28158,6 +28228,350 @@ describe("createAgentChatService", () => {
 
       releaseStream();
       await sendPromise;
+    });
+
+    it("routes OpenCode reasoning deltas (field \"text\") to reasoning, never to assistant text", async () => {
+      // OpenCode's delta events name the part PROPERTY being appended to, not the
+      // kind of part: a reasoning part's property is also called `text`, so its
+      // deltas arrive with `field: "text"`. Classifying on `field` printed the
+      // whole chain of thought as the assistant's answer, ran it together with
+      // the real reply, and then repeated it inside the "Thought" chip when the
+      // closing full part landed. Classify by the part kind instead.
+      const turn = await startOpenCodeTurn("Think, then answer.");
+      const { sessionID } = turn;
+
+      turn.pushEvents(
+        { type: "message.updated", properties: { info: { id: "msg-a", role: "assistant", sessionID } } },
+        // reasoning-start: an empty reasoning part.
+        { type: "message.part.updated", properties: { part: { id: "prt-r", type: "reasoning", text: "", messageID: "msg-a", sessionID } } },
+        // reasoning-delta: published with field "text", not "reasoning".
+        { type: "message.part.delta", properties: { sessionID, messageID: "msg-a", partID: "prt-r", field: "text", delta: "Let me weigh " } },
+        { type: "message.part.delta", properties: { sessionID, messageID: "msg-a", partID: "prt-r", field: "text", delta: "the options." } },
+        // text-start, then the real answer.
+        { type: "message.part.updated", properties: { part: { id: "prt-t", type: "text", text: "", messageID: "msg-a", sessionID } } },
+        { type: "message.part.delta", properties: { sessionID, messageID: "msg-a", partID: "prt-t", field: "text", delta: "Forty" } },
+        { type: "message.part.delta", properties: { sessionID, messageID: "msg-a", partID: "prt-t", field: "text", delta: "-two." } },
+      );
+
+      await vi.waitFor(() => { expect(turn.joined("text")).toBe("Forty-two."); });
+      expect(turn.joined("reasoning")).toBe("Let me weigh the options.");
+
+      turn.pushEvents(
+        // The closing full parts must diff to nothing, for both kinds.
+        { type: "message.part.updated", properties: { part: { id: "prt-r", type: "reasoning", text: "Let me weigh the options.", messageID: "msg-a", sessionID } } },
+        { type: "message.part.updated", properties: { part: { id: "prt-t", type: "text", text: "Forty-two.", messageID: "msg-a", sessionID } } },
+        { type: "session.idle", properties: { sessionID } },
+      );
+      await turn.waitForDone();
+
+      expect(turn.joined("reasoning")).toBe("Let me weigh the options.");
+      expect(turn.joined("text")).toBe("Forty-two.");
+
+      // The stored assistant message is the answer alone. Before the fix the
+      // reasoning was appended to it, so the transcript replayed thoughts as
+      // the reply.
+      const transcript = await turn.service.getChatTranscript({ sessionId: turn.session.id });
+      const assistantText = transcript.entries
+        .filter((entry) => entry.role === "assistant")
+        .map((entry) => entry.text)
+        .join("");
+      expect(assistantText).toContain("Forty-two.");
+      expect(assistantText).not.toContain("weigh");
+
+      await turn.finish();
+    });
+
+    it("surfaces OpenCode provider retries as a system notice instead of a silent spinner", async () => {
+      // OpenCode retries a failing provider with exponential backoff and
+      // publishes nothing but `session.status`. Without this handler the chat
+      // showed a spinner for minutes and looked wedged.
+      const turn = await startOpenCodeTurn("Ask a flaky provider.");
+      const { sessionID } = turn;
+      const providerMessage = "Upstream request failed: Endpoint is unavailable.";
+
+      turn.pushEvents(
+        {
+          type: "session.status",
+          properties: {
+            sessionID,
+            status: { type: "retry", attempt: 1, message: providerMessage, next: Date.now() + 8000 },
+          },
+        },
+        // The real sequence: OpenCode reports `busy` between two retry attempts.
+        // Resetting the throttle here — as the first version did — meant it never
+        // engaged and every attempt posted its own notice.
+        { type: "session.status", properties: { sessionID, status: { type: "busy" } } },
+        // Same message, next attempt, no time elapsed: throttled away.
+        {
+          type: "session.status",
+          properties: {
+            sessionID,
+            status: { type: "retry", attempt: 2, message: providerMessage, next: Date.now() + 16000 },
+          },
+        },
+        { type: "session.idle", properties: { sessionID } },
+      );
+      await turn.waitForDone();
+
+      const notices = turn.events
+        .map((event) => event.event)
+        .filter((event) => event.type === "system_notice" && event.noticeKind === "provider_health") as Array<{
+          message: string;
+          detail?: unknown;
+        }>;
+      expect(notices).toHaveLength(1);
+      expect(notices[0]!.message).toContain("retrying");
+      expect(String(notices[0]!.detail)).toContain(providerMessage);
+
+      await turn.finish();
+    });
+
+    it("keeps an OpenCode auto-compaction summary message out of the assistant's answer", async () => {
+      // Auto-compaction writes its recap into a REAL assistant message flagged
+      // `summary: true` and streams it as ordinary text parts, so the
+      // assistant-role gate alone let a summary of the whole conversation render
+      // as the model's reply. The compaction part and `session.compacted`
+      // already report that compaction happened.
+      const turn = await startOpenCodeTurn("Long conversation.");
+      const { sessionID } = turn;
+
+      turn.pushEvents(
+        // The compaction summary message.
+        { type: "message.updated", properties: { info: { id: "msg-sum", role: "assistant", sessionID, summary: true } } },
+        { type: "message.part.updated", properties: { part: { id: "prt-sum", type: "text", text: "", messageID: "msg-sum", sessionID } } },
+        { type: "message.part.delta", properties: { sessionID, messageID: "msg-sum", partID: "prt-sum", field: "text", delta: "SUMMARY_OF_EVERYTHING" } },
+        { type: "message.part.updated", properties: { part: { id: "prt-sum", type: "text", text: "SUMMARY_OF_EVERYTHING", messageID: "msg-sum", sessionID } } },
+        // The real reply that follows it.
+        { type: "message.updated", properties: { info: { id: "msg-a", role: "assistant", sessionID } } },
+        { type: "message.part.updated", properties: { part: { id: "prt-a", type: "text", text: "", messageID: "msg-a", sessionID } } },
+        { type: "message.part.delta", properties: { sessionID, messageID: "msg-a", partID: "prt-a", field: "text", delta: "Here is the answer." } },
+        { type: "message.part.updated", properties: { part: { id: "prt-a", type: "text", text: "Here is the answer.", messageID: "msg-a", sessionID } } },
+        { type: "session.idle", properties: { sessionID } },
+      );
+      await turn.waitForDone();
+
+      expect(turn.joined("text")).toBe("Here is the answer.");
+      expect(turn.joined("text")).not.toContain("SUMMARY_OF_EVERYTHING");
+
+      const transcript = await turn.service.getChatTranscript({ sessionId: turn.session.id });
+      const assistantText = transcript.entries
+        .filter((entry) => entry.role === "assistant")
+        .map((entry) => entry.text)
+        .join("");
+      expect(assistantText).not.toContain("SUMMARY_OF_EVERYTHING");
+
+      await turn.finish();
+    });
+
+    it("treats an OpenCode ContextOverflowError as recoverable instead of failing the turn", async () => {
+      // OpenCode usually publishes this error, compacts the conversation itself,
+      // and keeps going — it never idles at that point. Throwing killed a turn
+      // that was about to resume on its own.
+      const turn = await startOpenCodeTurn("Overflow the context.");
+      const { sessionID } = turn;
+
+      turn.pushEvents(
+        {
+          type: "session.error",
+          properties: {
+            sessionID,
+            error: { name: "ContextOverflowError", data: { message: "Context window exceeded." } },
+          },
+        },
+        // OpenCode compacts and carries on in the same turn.
+        { type: "message.updated", properties: { info: { id: "msg-a", role: "assistant", sessionID } } },
+        { type: "message.part.updated", properties: { part: { id: "prt-a", type: "text", text: "", messageID: "msg-a", sessionID } } },
+        { type: "message.part.delta", properties: { sessionID, messageID: "msg-a", partID: "prt-a", field: "text", delta: "Carried on." } },
+        { type: "session.idle", properties: { sessionID } },
+      );
+      const done = await turn.waitForDone();
+
+      expect((done.event as { status: string }).status).toBe("completed");
+      expect(turn.events.filter((event) => event.event.type === "error")).toHaveLength(0);
+      const notices = turn.events
+        .map((event) => event.event)
+        .filter((event) => event.type === "system_notice") as Array<{ message: string; detail?: unknown }>;
+      expect(notices).toHaveLength(1);
+      expect(notices[0]!.message).toContain("Context limit reached");
+      expect(String(notices[0]!.detail)).toContain("Context window exceeded.");
+
+      await turn.finish();
+    });
+
+    it("fails an OpenCode turn whose context overflow never recovered", async () => {
+      // The overflow is not always recoverable: with `compaction.auto` off
+      // OpenCode idles without compacting, and compaction itself can overflow
+      // again and stop. No further assistant text arrives, and calling that a
+      // completed turn tells the user their question was answered.
+      const turn = await startOpenCodeTurn("Overflow with auto-compaction off.");
+      const { sessionID } = turn;
+
+      turn.pushEvents(
+        {
+          type: "session.error",
+          properties: {
+            sessionID,
+            error: { name: "ContextOverflowError", data: { message: "Context window exceeded." } },
+          },
+        },
+        // No assistant text follows: OpenCode simply goes idle.
+        { type: "session.idle", properties: { sessionID } },
+      );
+      const done = await turn.waitForDone();
+
+      expect((done.event as { status: string }).status).toBe("failed");
+      const errors = turn.events
+        .map((event) => event.event)
+        .filter((event) => event.type === "error") as Array<{ message: string }>;
+      expect(errors).toHaveLength(1);
+      expect(errors[0]!.message).toContain("Context window exceeded.");
+
+      await turn.finish();
+    });
+
+    it("renders an OpenCode abort from another client as an interruption, not a failure", async () => {
+      // The OpenCode TUI or CLI sharing this server can stop a session ADE is
+      // streaming. OpenCode reports that as MessageAbortedError and then idles;
+      // rendering it red made somebody else's stop look like ADE breaking.
+      const turn = await startOpenCodeTurn("Start something long.");
+      const { sessionID } = turn;
+
+      turn.pushEvents(
+        {
+          type: "session.error",
+          properties: {
+            sessionID,
+            error: { name: "MessageAbortedError", data: { message: "aborted" } },
+          },
+        },
+        { type: "session.idle", properties: { sessionID } },
+      );
+      const done = await turn.waitForDone();
+
+      expect((done.event as { status: string }).status).toBe("interrupted");
+      expect(turn.events.filter((event) => event.event.type === "error")).toHaveLength(0);
+
+      await turn.finish();
+    });
+
+    it("keeps draining OpenCode events while a question waits for the user", async () => {
+      // Awaiting the answer inside the event loop stalled the whole stream: while
+      // the modal was open, nothing else drained — no subagent approval, no
+      // streamed text, no tool result — until the person answered.
+      const turn = await startOpenCodeTurn("Ask me something.");
+      const { sessionID } = turn;
+
+      turn.pushEvents(
+        {
+          type: "question.asked",
+          properties: {
+            id: "question-1",
+            sessionID,
+            tool: "ask",
+            questions: [{ question: "Which approach?", header: "Approach", options: [] }],
+          },
+        },
+        // Published while the question is still open.
+        { type: "message.updated", properties: { info: { id: "msg-a", role: "assistant", sessionID } } },
+        { type: "message.part.updated", properties: { part: { id: "prt-a", type: "text", text: "", messageID: "msg-a", sessionID } } },
+        { type: "message.part.delta", properties: { sessionID, messageID: "msg-a", partID: "prt-a", field: "text", delta: "Streamed while asking." } },
+      );
+
+      const approval = await waitForEvent(
+        turn.events,
+        (event): event is AgentChatEventEnvelope => event.event.type === "approval_request",
+      );
+
+      // This is the assertion that fails when the loop blocks on the answer.
+      await vi.waitFor(() => {
+        expect(turn.joined("text")).toBe("Streamed while asking.");
+      });
+
+      await turn.service.respondToInput({
+        sessionId: turn.session.id,
+        itemId: (approval.event as { itemId: string }).itemId,
+        decision: "decline",
+      });
+
+      turn.pushEvents({ type: "session.idle", properties: { sessionID } });
+      await turn.waitForDone();
+
+      await turn.finish();
+    });
+
+    it("cancels an open OpenCode question when the turn is interrupted", async () => {
+      // `requestChatInput` parks the card in `managed.localPendingInputs`, which
+      // the OpenCode interrupt path never drained. The leftover entry kept the
+      // session reported as blocked, so the next send was refused, and a late
+      // answer would have replied into an aborted session.
+      const turn = await startOpenCodeTurn("Ask me something I will not answer.");
+      const { sessionID } = turn;
+
+      turn.pushEvents({
+        type: "question.asked",
+        properties: {
+          id: "question-1",
+          sessionID,
+          tool: "ask",
+          questions: [{ question: "Which approach?", header: "Approach", options: [] }],
+        },
+      });
+      const approval = await waitForEvent(
+        turn.events,
+        (event): event is AgentChatEventEnvelope => event.event.type === "approval_request",
+      );
+
+      await turn.service.interrupt({ sessionId: turn.session.id });
+
+      // The card is resolved as cancelled rather than left waiting forever.
+      const resolved = await waitForEvent(
+        turn.events,
+        (event): event is AgentChatEventEnvelope =>
+          event.event.type === "pending_input_resolved"
+          && (event.event as { itemId?: string }).itemId === (approval.event as { itemId: string }).itemId,
+      );
+      expect((resolved.event as { resolution: string }).resolution).toBe("cancelled");
+
+      // And the session takes a new prompt instead of reporting itself blocked.
+      turn.pushEvents({ type: "session.idle", properties: { sessionID } });
+      await turn.waitForDone();
+      await expect(
+        turn.service.sendMessage({ sessionId: turn.session.id, text: "Next question." }),
+      ).resolves.not.toThrow();
+
+      await turn.finish();
+    });
+
+    it("shows generic progress after an OpenCode step finishes", async () => {
+      // Otherwise the activity line keeps naming the step's last tool until the
+      // next step-start, so a long gap between steps reads as a command that
+      // never finished.
+      const turn = await startOpenCodeTurn("Run a step.");
+      const { sessionID } = turn;
+
+      turn.pushEvents(
+        {
+          type: "message.part.updated",
+          properties: {
+            part: {
+              id: "prt-step",
+              type: "step-finish",
+              messageID: "msg-a",
+              sessionID,
+              tokens: { input: 10, output: 5, cache: { read: 0, write: 0 } },
+            },
+          },
+        },
+        { type: "session.idle", properties: { sessionID } },
+      );
+      await turn.waitForDone();
+
+      const activities = turn.events
+        .map((event) => event.event)
+        .filter((event) => event.type === "activity") as Array<{ activity: string }>;
+      expect(activities.some((activity) => activity.activity === "working")).toBe(true);
+
+      await turn.finish();
     });
 
     it("ignores part deltas that belong to a user message", async () => {
@@ -37330,6 +37744,16 @@ describe("createAgentChatService", () => {
       const request = ((questionEvent.event as any).detail as { request: PendingInputRequest }).request;
       expect(request.questions[0]?.question).toBe("Which surface should I inspect first?");
       expect(request.questions[0]?.options?.map((option) => option.value)).toEqual(["CLI", "Chat"]);
+
+      // Answer only AFTER the turn has completed. The ask runs detached, so the
+      // loop reaches idle without waiting, and this is the interleaving that pins
+      // the completion path's refusal to cancel an open question card: cancel
+      // there and the card is gone before the user answers.
+      await waitForEvent(
+        events,
+        (event): event is AgentChatEventEnvelope =>
+          event.event.type === "done" && event.event.status === "completed",
+      );
 
       await service.respondToInput({
         sessionId: session.id,

--- a/apps/desktop/src/main/services/chat/agentChatService.test.ts
+++ b/apps/desktop/src/main/services/chat/agentChatService.test.ts
@@ -28542,6 +28542,60 @@ describe("createAgentChatService", () => {
       await turn.finish();
     });
 
+    it("cancels an open OpenCode question when an external abort ends the turn", async () => {
+      // The other route to an interrupted turn. The OpenCode TUI or CLI on the
+      // same server aborts the session: `session.error` sets `interrupted` and
+      // the loop keeps going to idle, so the turn settles through the shared
+      // completion path rather than ADE's own interrupt branch. That path did not
+      // cancel, so the card survived a turn nobody could answer any more — and
+      // `hasLivePendingInput` then refused the next send.
+      const turn = await startOpenCodeTurn("Ask me something, then get aborted.");
+      const { sessionID } = turn;
+
+      turn.pushEvents({
+        type: "question.asked",
+        properties: {
+          id: "question-1",
+          sessionID,
+          tool: "ask",
+          questions: [{ question: "Which approach?", header: "Approach", options: [] }],
+        },
+      });
+      const approval = await waitForEvent(
+        turn.events,
+        (event): event is AgentChatEventEnvelope => event.event.type === "approval_request",
+      );
+
+      turn.pushEvents(
+        {
+          type: "session.error",
+          properties: {
+            sessionID,
+            error: { name: "MessageAbortedError", data: { message: "aborted" } },
+          },
+        },
+        { type: "session.idle", properties: { sessionID } },
+      );
+
+      const done = await turn.waitForDone();
+      expect((done.event as { status: string }).status).toBe("interrupted");
+
+      const resolved = await waitForEvent(
+        turn.events,
+        (event): event is AgentChatEventEnvelope =>
+          event.event.type === "pending_input_resolved"
+          && (event.event as { itemId?: string }).itemId === (approval.event as { itemId: string }).itemId,
+      );
+      expect((resolved.event as { resolution: string }).resolution).toBe("cancelled");
+
+      // And the session is not left reporting itself blocked.
+      await expect(
+        turn.service.sendMessage({ sessionId: turn.session.id, text: "Next question." }),
+      ).resolves.not.toThrow();
+
+      await turn.finish();
+    });
+
     it("shows generic progress after an OpenCode step finishes", async () => {
       // Otherwise the activity line keeps naming the step's last tool until the
       // next step-start, so a long gap between steps reads as a command that

--- a/apps/desktop/src/main/services/chat/agentChatService.ts
+++ b/apps/desktop/src/main/services/chat/agentChatService.ts
@@ -24643,17 +24643,22 @@ export function createAgentChatService(args: {
       }
 
       // ── Shared turn completion ──
-      // No `cancelPendingInputsFrom` here, deliberately and defensively. On
-      // 1.18.x the question tool blocks server-side, so a clean idle with a card
-      // still open is not an expected state. If it ever becomes one — an older
-      // binary, or a future async question API — cancelling here would discard a
-      // card the user may still be reading, and ADE can answer a card after the
-      // turn settles, which resumes the OpenCode session. The exclusion is pinned
-      // by "bridges OpenCode question events through ADE's question UI".
-      // Interrupt and turn failure are the paths where the turn is genuinely dead.
+      // The invariant for open OpenCode question cards: cancel them on EVERY
+      // turn end except a clean, non-interrupted completion. Only that one case
+      // can still be answered — ADE replies after the turn settles and OpenCode
+      // resumes the session — and it is pinned by "bridges OpenCode question
+      // events through ADE's question UI". Every other ending leaves a card
+      // nobody can answer: `hasLivePendingInput` then refuses the next send, and
+      // a late answer targets a session that is gone.
       persistDeliveredLaneDirectiveKey(managed, args.laneDirectiveKey);
       void emitTurnDiffSummaryIfChanged(managed, turnId);
       if (runtime.interrupted) {
+        // Reached both by ADE's own Stop (which also cancels in the interrupt
+        // branch, making this idempotent) and by an EXTERNAL abort: the OpenCode
+        // TUI or CLI on the same server aborts, `session.error` sets
+        // `interrupted`, and the loop settles here instead of throwing. Without
+        // this call that second route stranded the card.
+        cancelPendingInputsFrom(managed, "opencode");
         setOpenCodeRuntimeBusy(runtime, false);
         runtime.activeTurnId = null;
         runtime.eventAbortController = null;
@@ -24668,6 +24673,7 @@ export function createAgentChatService(args: {
         });
         persistChatState(managed);
       } else {
+        // No cancel here — this is the one ending whose card is still answerable.
         setOpenCodeRuntimeBusy(runtime, false);
         runtime.activeTurnId = null;
         runtime.eventAbortController = null;

--- a/apps/desktop/src/main/services/chat/agentChatService.ts
+++ b/apps/desktop/src/main/services/chat/agentChatService.ts
@@ -1869,10 +1869,12 @@ function openCodeTodoId(todo: unknown, index: number): string {
  * OpenCode 1.18.21 — the version ADE pins and bundles — publishes only
  * `permission.asked` and `permission.replied`; `permission.updated` is gone from
  * both its source and the current SDK types. But `resolveOpenCodeBinaryPath`
- * prefers a *user-installed* binary over the bundled one, so an older install
- * can still be the server ADE is talking to, and dropping this handler would
- * leave those users' approvals unanswered forever. It is declared here rather
- * than narrowed from the event union because the union no longer contains it.
+ * falls back to a *user-installed* binary when the tools cache and the bundle
+ * both miss, and `ADE_DISABLE_BUNDLED_OPENCODE=1` selects one outright, so an
+ * older install can still be the server ADE is talking to. Dropping this handler
+ * would leave those users' approvals unanswered forever. It is declared here
+ * rather than narrowed from the event union because the union no longer contains
+ * it.
  */
 type LegacyOpenCodePermissionUpdatedEvent = {
   type: "permission.updated";
@@ -1968,6 +1970,14 @@ type OpenCodeRuntime = {
   modelDescriptor: ModelDescriptor;
   textByPartId: Map<string, string>;
   reasoningByPartId: Map<string, string>;
+  /**
+   * Part id -> OpenCode part kind ("text", "reasoning", "tool", ...), recorded
+   * from the part-start `message.part.updated`. A `message.part.delta` names the
+   * *property* it appends to, not the kind of part: a reasoning part's deltas
+   * arrive with `field: "text"` because a reasoning part's property is also
+   * called `text`. The part kind is therefore the only correct classifier.
+   */
+  partTypeByPartId: Map<string, string>;
   toolStateByPartId: Map<string, string>;
   compactionStartedPartIds: Set<string>;
   /** OpenCode child sessions whose own terminal event has not arrived yet. */
@@ -3389,7 +3399,35 @@ const MAX_TRANSCRIPT_READ_LIMIT = 100;
 const DEFAULT_TRANSCRIPT_READ_CHARS = 8_000;
 const MAX_TRANSCRIPT_READ_CHARS = 120_000;
 const AUTO_TITLE_MAX_CHARS = 48;
+/**
+ * The new text a closing/updating OpenCode part adds to what was already
+ * rendered. A part update carries the whole part, so it has to diff against the
+ * running text or the answer prints twice.
+ */
+function openCodeFullPartDelta(previous: string, nextText: string, delta: string | undefined): string {
+  if (typeof delta === "string") return delta;
+  if (nextText.startsWith(previous)) return nextText.slice(previous.length);
+  return nextText;
+}
+
+/**
+ * Messages for OpenCode session errors whose payload carries none of its own.
+ * `MessageOutputLengthError.data` is an empty bag, so the generic fallback was
+ * the only thing a user ever saw for a truncated answer. Every other member of
+ * the union declares a required `data.message`.
+ */
+const OPEN_CODE_ERROR_MESSAGES_BY_NAME: Record<string, string | undefined> = {
+  MessageOutputLengthError: "The model hit its output length limit before it finished the answer.",
+};
+
+/** Ceiling on a raw provider response body shown as a chat error message. */
+const MAX_OPEN_CODE_ERROR_BODY_CHARS = 500;
+
 const REASONING_ACTIVITY_DETAIL = "Thinking through the answer";
+/** Shown while OpenCode backs off and retries a failing provider request. */
+const PROVIDER_RETRY_ACTIVITY_DETAIL = "Waiting for the provider";
+/** Minimum gap between two provider-retry notices in the same turn. */
+const PROVIDER_RETRY_NOTICE_MIN_INTERVAL_MS = 10_000;
 const WORKING_ACTIVITY_DETAIL = "Preparing response";
 const DEFAULT_RUN_SESSION_TURN_TIMEOUT_MS = 300_000;
 const DEFAULT_COLLABORATION_MODES_LIST_TIMEOUT_MS = 1_500;
@@ -12410,6 +12448,7 @@ export function createAgentChatService(args: {
       modelDescriptor: descriptor,
       textByPartId: new Map(),
       reasoningByPartId: new Map(),
+      partTypeByPartId: new Map(),
       toolStateByPartId: new Map(),
       compactionStartedPartIds: new Set(),
       subagentSessions: new Map(),
@@ -17472,15 +17511,22 @@ export function createAgentChatService(args: {
   };
 
   /**
-   * Cancel Pi cards that are still waiting on the user.
+   * Cancel one provider's input cards that are still waiting on the user.
    *
-   * The worker drains its own side when a turn aborts, but the desktop entry
-   * outlives it: without this the chat keeps rendering a card nobody can answer
-   * and `hasPendingInput` keeps reporting the session as blocked.
+   * Both providers park their cards in `managed.localPendingInputs`, and both
+   * leave them stranded when a turn ends early. For Pi, the worker drains its own
+   * side on abort but the desktop entry outlives it. For OpenCode, the interrupt
+   * path drained `pendingApprovals` only, never the question cards. Either way
+   * the chat keeps rendering a card nobody can answer, `hasPendingInput` keeps
+   * reporting the session as blocked so the next send is refused, and a late
+   * answer would reply into a session that is already gone.
    */
-  const cancelPendingPiInputs = (managed: ManagedChatSession): void => {
+  const cancelPendingInputsFrom = (
+    managed: ManagedChatSession,
+    source: "pi" | "opencode",
+  ): void => {
     for (const [itemId, pending] of [...managed.localPendingInputs]) {
-      if (pending.request.source !== "pi") continue;
+      if (pending.request.source !== source) continue;
       managed.localPendingInputs.delete(itemId);
       pending.resolve({ decision: "cancel" });
       emitPendingInputResolved(managed, {
@@ -17693,7 +17739,7 @@ export function createAgentChatService(args: {
       const rt = managed.runtime;
       rt.interrupted = true;
       cancelQueuedSteers(managed, rt, "interrupted");
-      cancelPendingPiInputs(managed);
+      cancelPendingInputsFrom(managed, "pi");
       if (preserveProviderResumeState) persistChatState(managed);
       if (isPiSdkPooledAlive(rt.sdk)) {
         void rt.sdk.abort().catch(() => {});
@@ -18997,26 +19043,50 @@ export function createAgentChatService(args: {
       if (typeof direct === "number" && Number.isFinite(direct)) return direct;
       return readStatusCode(record.cause, seen) ?? readStatusCode(record.error, seen);
     };
-    const collectMessages = (value: unknown, seen = new Set<unknown>()): string[] => {
+    // `isBody` marks a raw provider `responseBody` — a whole JSON payload, not a
+    // sentence — so the display path below can bound it without a second walk.
+    type CollectedMessage = { text: string; isBody: boolean };
+    const collectMessages = (value: unknown, seen = new Set<unknown>()): CollectedMessage[] => {
       if (value == null) return [];
-      if (typeof value === "string") return value.trim().length ? [value.trim()] : [];
+      if (typeof value === "string") {
+        return value.trim().length ? [{ text: value.trim(), isBody: false }] : [];
+      }
       if (typeof value !== "object" || seen.has(value)) return [];
       seen.add(value);
       const record = value as Record<string, unknown>;
       const data = asRecord(record.data);
-      const messages = [
-        typeof record.message === "string" ? record.message : null,
-        typeof data?.message === "string" ? data.message : null,
-        typeof record.responseBody === "string" ? record.responseBody : null,
-        typeof data?.responseBody === "string" ? data.responseBody : null,
-      ].filter((message): message is string => Boolean(message?.trim()));
+      const messages: CollectedMessage[] = [
+        { text: record.message, isBody: false },
+        { text: data?.message, isBody: false },
+        { text: record.responseBody, isBody: true },
+        { text: data?.responseBody, isBody: true },
+      ].flatMap(({ text, isBody }) => (
+        typeof text === "string" && text.trim().length ? [{ text: text.trim(), isBody }] : []
+      ));
       return [
         ...messages,
         ...collectMessages(record.cause, seen),
         ...collectMessages(record.error, seen),
       ];
     };
-    const rawMessage = collectMessages(error).join(" ") || (error instanceof Error ? error.message : String(error));
+    // A thrown OpenCode error carries the structured original as `cause`, so the
+    // walk reaches the same wording from the Error and from the payload. Keeping
+    // both printed the message twice in the chat. A duplicate keeps its first
+    // position but its `isBody` is the OR of every occurrence: the cap belongs to
+    // the value, so a raw payload cannot dodge it by also appearing as `message`.
+    const collectedMessages: CollectedMessage[] = [];
+    const collectedByText = new Map<string, CollectedMessage>();
+    for (const collected of collectMessages(error)) {
+      const existing = collectedByText.get(collected.text);
+      if (existing) {
+        existing.isBody = existing.isBody || collected.isBody;
+        continue;
+      }
+      collectedByText.set(collected.text, collected);
+      collectedMessages.push(collected);
+    }
+    const rawMessage = collectedMessages.map((collected) => collected.text).join(" ")
+      || (error instanceof Error ? error.message : String(error));
     const lower = rawMessage.toLowerCase();
 
     const statusCode = readStatusCode(error);
@@ -19065,8 +19135,20 @@ export function createAgentChatService(args: {
       };
     }
 
+    // Nothing classified it, so `rawMessage` is what the user reads. Classification
+    // above used the full text; the chat gets a bounded version of any raw body.
+    const displayMessage = collectedMessages.length
+      ? collectedMessages
+        .map(({ text, isBody }) => (
+          isBody && text.length > MAX_OPEN_CODE_ERROR_BODY_CHARS
+            ? `${text.slice(0, MAX_OPEN_CODE_ERROR_BODY_CHARS)}…`
+            : text
+        ))
+        .join(" ")
+      : rawMessage;
+
     return {
-      message: rawMessage,
+      message: displayMessage,
       errorInfo: { category: "unknown", provider: providerFamily, model: modelDisplayName },
     };
   };
@@ -19076,10 +19158,14 @@ export function createAgentChatService(args: {
     const data = asRecord(record?.data);
     const nested = asRecord(record?.error);
     const nestedData = asRecord(nested?.data);
+    const byName = typeof record?.name === "string"
+      ? OPEN_CODE_ERROR_MESSAGES_BY_NAME[record.name]
+      : undefined;
     return (
       (typeof data?.message === "string" && data.message.trim())
       || (typeof nestedData?.message === "string" && nestedData.message.trim())
       || (typeof record?.message === "string" && record.message.trim())
+      || byName
       || "OpenCode session failed."
     );
   };
@@ -23603,6 +23689,7 @@ export function createAgentChatService(args: {
       runtime.eventAbortController = abortController;
       runtime.textByPartId.clear();
       runtime.reasoningByPartId.clear();
+      runtime.partTypeByPartId.clear();
       runtime.toolStateByPartId.clear();
       runtime.compactionStartedPartIds.clear();
 
@@ -23655,6 +23742,19 @@ export function createAgentChatService(args: {
         client: runtime.handle.client,
         directory: runtime.handle.directory,
         signal: abortController.signal,
+        // The stream is bounded now (see OPENCODE_SSE_MAX_RETRY_ATTEMPTS), so a
+        // dropped socket ends the loop instead of hanging the turn forever. Log
+        // the cause: the turn then fails through the "ended before idle" path,
+        // whose message alone does not say the connection broke. Stop aborts the
+        // same socket, and that is the user getting what they asked for.
+        onSseError: (error) => {
+          if (abortController.signal.aborted) return;
+          logger.warn("agent_chat.opencode_event_stream_error", {
+            sessionId: managed.session.id,
+            turnId,
+            error: error instanceof Error ? error.message : String(error),
+          });
+        },
       });
 
       const promptAccepted = runtime.handle.client.session.promptAsync(
@@ -23676,6 +23776,42 @@ export function createAgentChatService(args: {
       // `message.updated` before the first part of a message, so the role is
       // always resolved by the time its parts arrive.
       const openCodeMessageRoleById = new Map<string, "assistant" | "user">();
+      // Assistant messages OpenCode created to hold an auto-compaction summary.
+      // They carry `summary: true` and stream the summary as ordinary text parts
+      // under the assistant role, so the role gate alone lets a recap of the
+      // conversation render as the model's reply to the user. The compaction
+      // part and `session.compacted` already show that compaction happened.
+      const openCodeSummaryMessageIds = new Set<string>();
+      /**
+       * Assistant output is what a message renders as when it is the model
+       * talking to the user — not a user-message part echoing back, and not an
+       * auto-compaction summary.
+       */
+      const rendersAsAssistantOutput = (messageID: string): boolean =>
+        openCodeMessageRoleById.get(messageID) === "assistant"
+        && !openCodeSummaryMessageIds.has(messageID);
+      // Throttle state for provider-retry notices. Turn-local: it has no meaning
+      // outside this loop and nothing else reads it.
+      //
+      // Three primitives rather than one nullable record, deliberately. The
+      // record form is read and then reassigned inside this loop, and the
+      // reassignment is reachable only through a value derived from the read —
+      // which makes TypeScript's control-flow analysis circular. It answers by
+      // pinning the read to its initializer (TS7022, or a `never` on the
+      // non-null branch). Non-nullable primitives make that pessimism harmless:
+      // every comparison below still typechecks whichever way the analysis goes.
+      let hasEmittedRetryNotice = false;
+      let retryNoticeAttempt = 0;
+      let retryNoticeMessage = "";
+      let retryNoticeAtMs = 0;
+      // A ContextOverflowError is usually recoverable — OpenCode compacts and
+      // carries on. It is NOT always: with `compaction.auto` off it idles without
+      // compacting, and the compaction turn can overflow again and stop. Either
+      // way the turn produces no further assistant text, and reporting that as a
+      // completed turn tells the user their question was answered when it was
+      // not. `finalAssistantText` already counts every emitted character, so
+      // marking its length at the overflow costs nothing in the streaming path.
+      let contextOverflow: { message: string; textLengthAtOverflow: number } | null = null;
       const emittedOpenCodeImagePartIds = new Set<string>();
       const emitOpenCodeImagePart = (part: unknown): void => {
         const imageEvent = mapOpenCodeImagePart({
@@ -23701,6 +23837,7 @@ export function createAgentChatService(args: {
               return event.properties.part.sessionID;
             case "message.part.delta":
             case "message.part.removed":
+            case "message.removed":
               return event.properties.sessionID;
             case "permission.asked":
               return event.properties.sessionID;
@@ -23745,7 +23882,44 @@ export function createAgentChatService(args: {
             continue;
           }
           if (!childKey || childKey === runtime.handle.sessionId) {
-            throw new Error(openCodeSessionErrorMessage(event.properties.error));
+            const sessionError = event.properties.error;
+            const errorName = sessionError?.name ?? null;
+
+            // Usually recoverable: OpenCode compacts the conversation itself and
+            // keeps going without idling, so throwing killed a turn that was
+            // about to continue. It is not a promise, though — see
+            // `contextOverflow` at the idle check below.
+            if (errorName === "ContextOverflowError") {
+              contextOverflow = {
+                message: openCodeSessionErrorMessage(sessionError),
+                textLengthAtOverflow: finalAssistantText.length,
+              };
+              emitChatEvent(managed, {
+                type: "system_notice",
+                noticeKind: "provider_health",
+                severity: "info",
+                message: "Context limit reached — OpenCode will try to compact the conversation.",
+                detail: contextOverflow.message,
+                turnId,
+              });
+              continue;
+            }
+
+            // Somebody else stopped this turn: the OpenCode TUI or CLI sharing
+            // this server can abort a session ADE is streaming. That is an
+            // interruption, not a failure, and OpenCode idles right after — so
+            // let the normal idle path render it the way ADE's own stop button
+            // renders.
+            if (errorName === "MessageAbortedError") {
+              runtime.interrupted = true;
+              continue;
+            }
+
+            // Keep the structured error reachable: classifyOpenCodeError walks
+            // `cause` for the status code and the nested messages that decide
+            // auth vs rate-limit vs network, and a bare message string throws
+            // all of that away.
+            throw new Error(openCodeSessionErrorMessage(sessionError), { cause: sessionError });
           }
           continue;
         }
@@ -23865,15 +24039,20 @@ export function createAgentChatService(args: {
         // an empty delta instead of re-emitting the entire message.
         if (event.type === "message.part.delta") {
           const { messageID, partID, field, delta } = event.properties;
-          if (openCodeMessageRoleById.get(messageID) !== "assistant") continue;
+          if (!rendersAsAssistantOutput(messageID)) continue;
           if (typeof delta !== "string" || !delta.length) continue;
-          if (field === "text") {
-            runtime.textByPartId.set(partID, (runtime.textByPartId.get(partID) ?? "") + delta);
-            finalAssistantText += delta;
-            emitChatEvent(managed, { type: "text", text: delta, turnId, itemId: partID });
-            continue;
-          }
-          if (field === "reasoning") {
+          // `field` is the name of the part property being appended to, NOT the
+          // kind of part. OpenCode's processor publishes reasoning deltas with
+          // `field: "text"`, because a reasoning part's property is also called
+          // `text`. Classifying on `field` therefore rendered the whole chain of
+          // thought as the assistant's answer (and re-rendered it as a thought
+          // when the closing full part arrived). The part-start
+          // `message.part.updated` always precedes the first delta of a part, so
+          // the recorded part kind is the correct classifier. Older binaries that
+          // never send the part-start fall back to the previous `field` rule.
+          const partKind = runtime.partTypeByPartId.get(partID)
+            ?? (runtime.reasoningByPartId.has(partID) || field === "reasoning" ? "reasoning" : "text");
+          if (partKind === "reasoning") {
             runtime.reasoningByPartId.set(partID, (runtime.reasoningByPartId.get(partID) ?? "") + delta);
             emitChatEvent(managed, {
               type: "activity",
@@ -23882,14 +24061,111 @@ export function createAgentChatService(args: {
               turnId,
             });
             emitChatEvent(managed, { type: "reasoning", text: delta, turnId, itemId: partID });
+            continue;
+          }
+          if (partKind === "text") {
+            runtime.textByPartId.set(partID, (runtime.textByPartId.get(partID) ?? "") + delta);
+            finalAssistantText += delta;
+            emitChatEvent(managed, { type: "text", text: delta, turnId, itemId: partID });
           }
           continue;
         }
 
         if (event.type === "message.updated") {
-          if (event.properties.info.role === "assistant" || event.properties.info.role === "user") {
-            openCodeMessageRoleById.set(event.properties.info.id, event.properties.info.role);
+          const info = event.properties.info;
+          if (info.role === "assistant" || info.role === "user") {
+            openCodeMessageRoleById.set(info.id, info.role);
           }
+          if (info.role === "assistant" && info.summary === true) {
+            openCodeSummaryMessageIds.add(info.id);
+          }
+          continue;
+        }
+
+        // Revert/undo. Drop the per-part accumulators so a later part id reused
+        // by OpenCode cannot diff against text that no longer exists, and so a
+        // removed reasoning part stops being treated as reasoning. No renderer
+        // event goes out: `transcript_retraction` matches rows by `messageId`,
+        // which OpenCode text events do not carry, and adding one would make
+        // every part of a message merge into a single row.
+        if (event.type === "message.part.removed") {
+          const removedPartId = event.properties.partID;
+          runtime.textByPartId.delete(removedPartId);
+          runtime.reasoningByPartId.delete(removedPartId);
+          runtime.partTypeByPartId.delete(removedPartId);
+          runtime.toolStateByPartId.delete(removedPartId);
+          runtime.compactionStartedPartIds.delete(removedPartId);
+          emittedOpenCodeImagePartIds.delete(removedPartId);
+          continue;
+        }
+
+        if (event.type === "message.removed") {
+          const removedMessageId = event.properties.messageID;
+          openCodeMessageRoleById.delete(removedMessageId);
+          openCodeSummaryMessageIds.delete(removedMessageId);
+          continue;
+        }
+
+        // A failing provider is otherwise invisible: OpenCode retries with
+        // exponential backoff and publishes nothing else, so the chat shows a
+        // spinner for minutes and the user assumes it is wedged. `session.status`
+        // retry events are the only signal, so surface them as a notice.
+        if (event.type === "session.status") {
+          const status = event.properties.status;
+          if (status.type !== "retry") {
+            // Reset on idle ONLY. OpenCode publishes `busy` between every two
+            // retry attempts (retry(1) → busy → retry(2) → …), so clearing the
+            // throttle on `busy` cleared it before every single retry and the
+            // throttle never engaged.
+            if (status.type === "idle") hasEmittedRetryNotice = false;
+            continue;
+          }
+          // The SDK declares these required, but this is the wire: a field that
+          // arrives missing or mistyped must not become "Retrying in NaNs."
+          const { attempt: wireAttempt, message: wireMessage, next: wireNext, action } = status;
+          const attempt = typeof wireAttempt === "number" ? wireAttempt : 0;
+          const providerMessage = typeof wireMessage === "string" ? wireMessage.trim() : "";
+          const nextAtMs = typeof wireNext === "number" ? wireNext : null;
+          const nowMs = Date.now();
+          // Emit the first retry, then only on a changed provider message or on a
+          // new attempt that is at least the throttle interval after the last
+          // notice. Backoff doubles from 2s, so a busy provider would otherwise
+          // post a notice every couple of seconds.
+          const shouldEmit = !hasEmittedRetryNotice
+            || providerMessage !== retryNoticeMessage
+            || (
+              attempt !== retryNoticeAttempt
+              && nowMs - retryNoticeAtMs >= PROVIDER_RETRY_NOTICE_MIN_INTERVAL_MS
+            );
+          if (!shouldEmit) continue;
+          hasEmittedRetryNotice = true;
+          retryNoticeAttempt = attempt;
+          retryNoticeMessage = providerMessage;
+          retryNoticeAtMs = nowMs;
+          const retryInSeconds = nextAtMs === null
+            ? null
+            : Math.max(0, Math.round((nextAtMs - nowMs) / 1000));
+          const detail = [
+            providerMessage.length ? providerMessage : "The provider request failed.",
+            retryInSeconds === null ? null : `Retrying in ${retryInSeconds}s.`,
+            action?.title?.trim() || null,
+            action?.message?.trim() || null,
+            action?.link?.trim() || null,
+          ].filter((line): line is string => Boolean(line)).join(" ");
+          emitChatEvent(managed, {
+            type: "activity",
+            activity: "working",
+            detail: PROVIDER_RETRY_ACTIVITY_DETAIL,
+            turnId,
+          });
+          emitChatEvent(managed, {
+            type: "system_notice",
+            noticeKind: "provider_health",
+            severity: "warning",
+            message: `OpenCode hit a provider error and is retrying automatically (attempt ${attempt}).`,
+            detail,
+            turnId,
+          });
           continue;
         }
 
@@ -23917,16 +24193,20 @@ export function createAgentChatService(args: {
           const delta = openCodePartUpdatedDelta(event.properties);
           markFirstStreamEvent(part.type);
 
+          // Record the part kind so the delta branch above can classify by it.
+          // OpenCode publishes this part-start update (with an empty body) before
+          // the first delta of every part.
+          runtime.partTypeByPartId.set(part.id, part.type);
+
           // Compaction begin marker. OpenCode has no dedicated "started" event, but it
           // streams a compaction part as soon as it begins summarizing; the matching
           // session.compacted lands when it finishes. Surface this as a live begin so
           // the chat shows "compacting…" instead of feeling stuck.
           if (part.type === "compaction") {
-            const partId = typeof (part as { id?: unknown }).id === "string" ? (part as { id: string }).id : null;
-            const compactionKey = partId ?? `turn:${turnId}`;
+            const compactionKey = part.id || `turn:${turnId}`;
             if (runtime.compactionStartedPartIds.has(compactionKey)) continue;
             runtime.compactionStartedPartIds.add(compactionKey);
-            const trigger = (part as { auto?: boolean }).auto === false ? "manual" : "auto";
+            const trigger = part.auto === false ? "manual" : "auto";
             runtime.lastCompactionTrigger = trigger;
             emitChatEvent(managed, {
               type: "context_compact",
@@ -23960,34 +24240,28 @@ export function createAgentChatService(args: {
               cacheReadTokens: part.tokens.cache.read,
               cacheCreationTokens: part.tokens.cache.write,
             };
+            // Without this the activity line keeps naming the step's last tool
+            // until the next step-start, so a long gap between steps reads as a
+            // command that never finished.
+            emitChatEvent(managed, {
+              type: "activity",
+              activity: "working",
+              detail: WORKING_ACTIVITY_DETAIL,
+              turnId,
+            });
             continue;
           }
-
-          // Only assistant messages produce rendered content. User-message text
-          // parts stream through the same event; without this role gate the
-          // user's own prompt (or injected system context) would echo into the
-          // transcript as an assistant bubble. OpenCode announces every message
-          // (with its role) before its parts, so an unknown role means "not
-          // announced yet" — those stay unrendered too.
-          const openCodePartMessageRole = openCodeMessageRoleById.get(part.messageID);
 
           if (part.type === "text") {
             // Skip synthetic/ignored prompt parts (e.g. ADE launch directives
             // injected as system context) — they should not be rendered in chat.
-            if ((part as { synthetic?: boolean }).synthetic || (part as { ignored?: boolean }).ignored) {
-              continue;
-            }
-            if (openCodePartMessageRole !== "assistant") {
+            if (part.synthetic || part.ignored) continue;
+            if (!rendersAsAssistantOutput(part.messageID)) {
               continue;
             }
             const previous = runtime.textByPartId.get(part.id) ?? "";
-            const nextText = part.text;
-            const nextDelta = typeof delta === "string"
-              ? delta
-              : nextText.startsWith(previous)
-                ? nextText.slice(previous.length)
-                : nextText;
-            runtime.textByPartId.set(part.id, nextText);
+            const nextDelta = openCodeFullPartDelta(previous, part.text, delta);
+            runtime.textByPartId.set(part.id, part.text);
             if (nextDelta.length) {
               finalAssistantText += nextDelta;
               emitChatEvent(managed, {
@@ -24001,17 +24275,12 @@ export function createAgentChatService(args: {
           }
 
           if (part.type === "reasoning") {
-            if (openCodePartMessageRole !== "assistant") {
+            if (!rendersAsAssistantOutput(part.messageID)) {
               continue;
             }
             const previous = runtime.reasoningByPartId.get(part.id) ?? "";
-            const nextText = part.text;
-            const nextDelta = typeof delta === "string"
-              ? delta
-              : nextText.startsWith(previous)
-                ? nextText.slice(previous.length)
-                : nextText;
-            runtime.reasoningByPartId.set(part.id, nextText);
+            const nextDelta = openCodeFullPartDelta(previous, part.text, delta);
+            runtime.reasoningByPartId.set(part.id, part.text);
             if (nextDelta.length) {
               emitChatEvent(managed, {
                 type: "activity",
@@ -24031,8 +24300,11 @@ export function createAgentChatService(args: {
 
           if (part.type === "file") {
             // Prompt attachments use the same wire part. Only assistant-owned
-            // files are output; tool attachments are handled below directly.
-            if (openCodePartMessageRole === "assistant") {
+            // files are output; tool attachments are handled below directly. Role
+            // alone is the right gate here, not `rendersAsAssistantOutput`: a
+            // compaction summary carries no attachments to suppress, and an
+            // unannounced message has no role yet, so it stays unrendered.
+            if (openCodeMessageRoleById.get(part.messageID) === "assistant") {
               emitOpenCodeImagePart(part);
             }
             continue;
@@ -24136,43 +24408,69 @@ export function createAgentChatService(args: {
           const questionRequest = event.properties;
           const questions = openCodeQuestionsToPendingQuestions(questionRequest.questions ?? []);
           const firstQuestion = questions[0];
-          const response = await requestChatInput({
-            chatSessionId: managed.session.id,
-            title: questions.length === 1 ? "Question from OpenCode" : "Questions from OpenCode",
-            body: firstQuestion?.question ?? "OpenCode needs input before it can continue.",
-            source: "opencode",
-            providerMetadata: {
-              openCodeQuestion: true,
-              requestId: questionRequest.id,
-              tool: questionRequest.tool ?? null,
-            },
-            eventDescription: "OpenCode question",
-            eventDetail: { openCodeQuestion: questionRequest },
-            questions: questions.map(({ options, ...question }) => ({
-              ...question,
-              ...(options ? { options } : {}),
-            })),
-          });
-          if (managed.runtime !== runtime) {
-            continue;
-          }
-          if (response.decision === "decline" || response.decision === "cancel") {
+          // Ask on a detached task. Awaiting the user here stalled the whole
+          // event stream: while the modal was open nothing else drained, so a
+          // subagent's approval prompt, its streamed text, and every tool result
+          // sat in the socket until the person answered. On 1.18.x OpenCode's
+          // question tool blocks server-side until it gets a reply, so the parent
+          // session is not expected to idle underneath an open card — see the
+          // completion path, which does NOT cancel these cards for that reason.
+          const rejectOpenCodeQuestion = async (): Promise<void> => {
             await runtime.handle.client.question.reject({
               requestID: questionRequest.id,
               directory: runtime.handle.directory,
             }, { throwOnError: true });
-            continue;
-          }
-          const answerList = questions.map((question) => {
-            const answers = ownQuestionValue(response.answers, question.id) ?? [];
-            if (answers.length > 0) return answers;
-            return response.responseText?.trim() ? [response.responseText.trim()] : [];
+          };
+          const resolveOpenCodeQuestion = async (): Promise<void> => {
+            const response = await requestChatInput({
+              chatSessionId: managed.session.id,
+              title: questions.length === 1 ? "Question from OpenCode" : "Questions from OpenCode",
+              body: firstQuestion?.question ?? "OpenCode needs input before it can continue.",
+              source: "opencode",
+              providerMetadata: {
+                openCodeQuestion: true,
+                requestId: questionRequest.id,
+                tool: questionRequest.tool ?? null,
+              },
+              eventDescription: "OpenCode question",
+              eventDetail: { openCodeQuestion: questionRequest },
+              questions: questions.map(({ options, ...question }) => ({
+                ...question,
+                ...(options ? { options } : {}),
+              })),
+            });
+            if (managed.runtime !== runtime) return;
+            if (response.decision === "decline" || response.decision === "cancel") {
+              await rejectOpenCodeQuestion();
+              return;
+            }
+            const answerList = questions.map((question) => {
+              const answers = ownQuestionValue(response.answers, question.id) ?? [];
+              if (answers.length > 0) return answers;
+              return response.responseText?.trim() ? [response.responseText.trim()] : [];
+            });
+            await runtime.handle.client.question.reply({
+              requestID: questionRequest.id,
+              directory: runtime.handle.directory,
+              answers: answerList,
+            }, { throwOnError: true });
+          };
+          void resolveOpenCodeQuestion().catch(async (error) => {
+            // Stop already cancelled this card and aborted the session, so the
+            // rejection would fail against a dead session and the warning would
+            // report the user's own action as a failure.
+            if (runtime.interrupted) return;
+            logger.warn("agent_chat.opencode_question_failed", {
+              sessionId: managed.session.id,
+              turnId,
+              requestId: questionRequest.id,
+              error: error instanceof Error ? error.message : String(error),
+            });
+            // The turn no longer fails on this path, so reject the question
+            // rather than leave OpenCode waiting for an answer that is not coming.
+            if (managed.runtime !== runtime) return;
+            await rejectOpenCodeQuestion().catch(() => {});
           });
-          await runtime.handle.client.question.reply({
-            requestID: questionRequest.id,
-            directory: runtime.handle.directory,
-            answers: answerList,
-          }, { throwOnError: true });
           continue;
         }
 
@@ -24332,7 +24630,27 @@ export function createAgentChatService(args: {
         throw new Error("OpenCode event stream ended before the parent and child sessions became idle");
       }
 
+      // The overflow did NOT recover: OpenCode went idle without answering. That
+      // happens when the user turned `compaction.auto` off, and when compaction
+      // itself overflows. Reporting it as a completed turn would tell the user
+      // their question was answered.
+      if (
+        contextOverflow
+        && finalAssistantText.length === contextOverflow.textLengthAtOverflow
+        && !runtime.interrupted
+      ) {
+        throw new Error(contextOverflow.message);
+      }
+
       // ── Shared turn completion ──
+      // No `cancelPendingInputsFrom` here, deliberately and defensively. On
+      // 1.18.x the question tool blocks server-side, so a clean idle with a card
+      // still open is not an expected state. If it ever becomes one — an older
+      // binary, or a future async question API — cancelling here would discard a
+      // card the user may still be reading, and ADE can answer a card after the
+      // turn settles, which resumes the OpenCode session. The exclusion is pinned
+      // by "bridges OpenCode question events through ADE's question UI".
+      // Interrupt and turn failure are the paths where the turn is genuinely dead.
       persistDeliveredLaneDirectiveKey(managed, args.laneDirectiveKey);
       void emitTurnDiffSummaryIfChanged(managed, turnId);
       if (runtime.interrupted) {
@@ -24392,6 +24710,7 @@ export function createAgentChatService(args: {
       setOpenCodeRuntimeBusy(runtime, false);
       runtime.activeTurnId = null;
       runtime.eventAbortController = null;
+      cancelPendingInputsFrom(managed, "opencode");
       void emitTurnDiffSummaryIfChanged(managed, turnId);
 
       if (runtime.interrupted) {
@@ -40937,6 +41256,7 @@ export function createAgentChatService(args: {
         rejectOpenCodePendingApproval(managed.runtime.handle, pending).catch(() => {});
       }
       managed.runtime.pendingApprovals.clear();
+      cancelPendingInputsFrom(managed, "opencode");
       return result;
     }
 
@@ -40990,7 +41310,7 @@ export function createAgentChatService(args: {
         // ignore
       }
       if (mode === "stop_and_clear") cancelQueuedSteers(managed, rt, "interrupted");
-      cancelPendingPiInputs(managed);
+      cancelPendingInputsFrom(managed, "pi");
       persistChatState(managed);
       return result;
     }

--- a/apps/desktop/src/main/services/opencode/openCodeRuntime.test.ts
+++ b/apps/desktop/src/main/services/opencode/openCodeRuntime.test.ts
@@ -7,11 +7,18 @@ const mockState = vi.hoisted(() => {
   let nextSessionId = 1;
   const makeStream = (sessionId: string) => (async function* () {
     yield {
+      type: "message.updated",
+      properties: {
+        info: { id: `msg-${sessionId}`, role: "assistant", sessionID: sessionId },
+      },
+    };
+    yield {
       type: "message.part.updated",
       properties: {
         part: {
           id: `part-${sessionId}`,
           sessionID: sessionId,
+          messageID: `msg-${sessionId}`,
           type: "text",
           text: "pong",
         },
@@ -116,6 +123,7 @@ vi.mock("./openCodeServerManager", () => ({
 
 import {
   __resetOpenCodeRuntimeDiagnosticsForTests,
+  OPENCODE_SSE_MAX_RETRY_ATTEMPTS,
   buildOpenCodeConfig,
   buildOpenCodePromptParts,
   getOpenCodeRuntimeSnapshot,
@@ -141,6 +149,16 @@ function openCodePromptParams(): Record<string, unknown> {
     [Record<string, unknown> | undefined] | undefined;
   return call?.[0] ?? {};
 }
+
+/** The model descriptor the one-shot prompt tests share. */
+const ONE_SHOT_MODEL_DESCRIPTOR = {
+  id: "opencode/openai/gpt-5-mini",
+  family: "openai",
+  providerRoute: "opencode",
+  providerModelId: "openai/gpt-5-mini",
+  openCodeProviderId: "openai",
+  openCodeModelId: "gpt-5-mini",
+} as any;
 
 describe("openCodeRuntime", () => {
   afterEach(() => {
@@ -188,6 +206,40 @@ describe("openCodeRuntime", () => {
 
     await handle.close("handle_close");
     expect(mockState.sharedLease.close).toHaveBeenCalledWith("handle_close");
+  });
+
+  it("never states external_directory on any ADE ruleset", async () => {
+    // OpenCode's own default for this key is
+    // `{"*": "ask", <tmp>: "allow", <skill dirs>: "allow", <reference dirs>: "allow"}`.
+    // A bare string expands to one `{pattern: "*"}` rule, an agent block's rules
+    // are appended after the defaults, and lookup is a `findLast` over the merged
+    // list — so stating `external_directory` at all wins for every path and
+    // silently revokes OpenCode's access to its own temp, skill, and reference
+    // directories, whether ADE spelled it "ask" or "deny". Omitting the key
+    // already means "ask outside the worktree".
+    const config = buildOpenCodeConfig({ projectConfig: { ai: {} } as any }) as Record<string, any>;
+    const agents = config.agent as Record<string, { permission: Record<string, unknown> }>;
+
+    for (const agentName of ["ade-edit", "ade-full-auto", "ade-plan", "ade-helper"]) {
+      expect(agents[agentName]!.permission).not.toHaveProperty("external_directory");
+    }
+    // The rest of each ruleset is unchanged. Plan in particular keeps the denials
+    // that make plan mean plan, and `skill: "deny"` already stops it reaching into
+    // skill directories, so the default's allowances cost it nothing.
+    expect(agents["ade-edit"]!.permission).toMatchObject({ edit: "ask", bash: "ask" });
+    expect(agents["ade-full-auto"]!.permission).toMatchObject({ edit: "allow", bash: "allow" });
+    expect(agents["ade-plan"]!.permission).toMatchObject({
+      edit: "deny",
+      task: "deny",
+      websearch: "deny",
+      skill: "deny",
+    });
+    expect(agents["ade-helper"]!.permission).toMatchObject({
+      edit: "deny",
+      bash: "deny",
+      webfetch: "deny",
+      question: "deny",
+    });
   });
 
   it("passes lead isolation through to a dedicated OpenCode server", async () => {
@@ -246,6 +298,97 @@ describe("openCodeRuntime", () => {
     expect(mockState.promptAsync).toHaveBeenCalledWith(
       expect.not.objectContaining({ tools: expect.anything() }),
       expect.objectContaining({ throwOnError: true }),
+    );
+  });
+
+  it("keeps the caller's prompt, reasoning, and injected context out of a one-shot result", async () => {
+    // This helper names lanes and titles chats. Part events carry no role and the
+    // caller's own prompt streams back through the same channel, so an ungated
+    // accumulator put the user's words — and the model's chain of thought — into
+    // those names.
+    mockState.eventSubscribe.mockImplementationOnce((async () => {
+      const sessionID = "opencode-session-1";
+      return {
+        stream: (async function* () {
+          yield {
+            type: "message.updated",
+            properties: { info: { id: "msg-user", role: "user", sessionID } },
+          };
+          yield {
+            type: "message.part.updated",
+            properties: {
+              part: { id: "p-user", sessionID, messageID: "msg-user", type: "text", text: "PROMPT_ECHO" },
+            },
+          };
+          yield {
+            type: "message.updated",
+            properties: { info: { id: "msg-a", role: "assistant", sessionID } },
+          };
+          yield {
+            type: "message.part.updated",
+            properties: {
+              part: { id: "p-think", sessionID, messageID: "msg-a", type: "reasoning", text: "THOUGHTS" },
+            },
+          };
+          yield {
+            type: "message.part.updated",
+            properties: {
+              part: {
+                id: "p-ctx",
+                sessionID,
+                messageID: "msg-a",
+                type: "text",
+                text: "INJECTED_CONTEXT",
+                synthetic: true,
+              },
+            },
+          };
+          yield {
+            type: "message.part.updated",
+            properties: {
+              part: { id: "p-answer", sessionID, messageID: "msg-a", type: "text", text: "Real answer" },
+            },
+          };
+          yield { type: "session.idle", properties: { sessionID } };
+        })(),
+      };
+    }) as any);
+
+    const result = await runOpenCodeTextPrompt({
+      directory: "/repo",
+      title: "Name this lane",
+      modelDescriptor: ONE_SHOT_MODEL_DESCRIPTOR,
+      prompt: "PROMPT_ECHO",
+      projectConfig: { ai: {} },
+    });
+
+    expect(result.text).toBe("Real answer");
+    expect(result.text).not.toContain("PROMPT_ECHO");
+    expect(result.text).not.toContain("THOUGHTS");
+    expect(result.text).not.toContain("INJECTED_CONTEXT");
+  });
+
+  it("bounds the event stream's silent reconnects", async () => {
+    // The generated SSE client reconnects forever without this, and OpenCode
+    // sends no event ids — so a reconnect replays nothing and a `session.idle`
+    // published during the gap is lost, leaving the consuming `for await` to
+    // hang the turn permanently.
+    await runOpenCodeTextPrompt({
+      directory: "/repo",
+      title: "Bounded stream",
+      modelDescriptor: ONE_SHOT_MODEL_DESCRIPTOR,
+      prompt: "ping",
+      projectConfig: { ai: {} },
+    });
+
+    // The count includes the first connection and the client stops at
+    // `attempt >= max`, so this must stay above 1 or no reconnect happens at all.
+    expect(OPENCODE_SSE_MAX_RETRY_ATTEMPTS).toBeGreaterThan(1);
+    // And a ceiling: a large value reintroduces the long silent stall this bounds.
+    expect(OPENCODE_SSE_MAX_RETRY_ATTEMPTS).toBeLessThan(5);
+    expect(mockState.eventSubscribe).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ sseMaxRetryAttempts: OPENCODE_SSE_MAX_RETRY_ATTEMPTS }),
     );
   });
 

--- a/apps/desktop/src/main/services/opencode/openCodeRuntime.test.ts
+++ b/apps/desktop/src/main/services/opencode/openCodeRuntime.test.ts
@@ -73,6 +73,7 @@ const mockState = vi.hoisted(() => {
     getSession: vi.fn(async () => {
       throw new Error("session not found");
     }),
+    permissionReply: vi.fn(async () => ({})),
   };
 });
 
@@ -94,7 +95,7 @@ vi.mock("@opencode-ai/sdk/v2/client", () => ({
       reject: vi.fn(),
     },
     permission: {
-      reply: vi.fn(),
+      reply: mockState.permissionReply,
       respond: vi.fn(),
     },
   })),
@@ -223,9 +224,10 @@ describe("openCodeRuntime", () => {
     for (const agentName of ["ade-edit", "ade-full-auto", "ade-plan", "ade-helper"]) {
       expect(agents[agentName]!.permission).not.toHaveProperty("external_directory");
     }
-    // The rest of each ruleset is unchanged. Plan in particular keeps the denials
-    // that make plan mean plan, and `skill: "deny"` already stops it reaching into
-    // skill directories, so the default's allowances cost it nothing.
+    // The rest of each ruleset is unchanged: plan keeps the denials that make plan
+    // mean plan. Omitting the key does loosen plan and the helper from "deny" to
+    // "ask" for outside-worktree paths — plan raises an approval card, and a
+    // helper ask is auto-rejected by `runOpenCodeTextPrompt`.
     expect(agents["ade-edit"]!.permission).toMatchObject({ edit: "ask", bash: "ask" });
     expect(agents["ade-full-auto"]!.permission).toMatchObject({ edit: "allow", bash: "allow" });
     expect(agents["ade-plan"]!.permission).toMatchObject({
@@ -366,6 +368,58 @@ describe("openCodeRuntime", () => {
     expect(result.text).not.toContain("PROMPT_ECHO");
     expect(result.text).not.toContain("THOUGHTS");
     expect(result.text).not.toContain("INJECTED_CONTEXT");
+  });
+
+  it("rejects an approval request during a one-shot prompt instead of hanging on it", async () => {
+    // A one-shot prompt has no UI and nobody to ask. ADE states no
+    // `external_directory` rule any more, so OpenCode's default ASKS for a path
+    // outside the worktree rather than denying it — and an unanswered ask would
+    // sit there until the caller's abort fires minutes later. Rejecting at once
+    // reproduces the old hard deny.
+    mockState.eventSubscribe.mockImplementationOnce((async () => {
+      const sessionID = "opencode-session-1";
+      return {
+        stream: (async function* () {
+          yield {
+            type: "permission.asked",
+            properties: {
+              id: "perm-1",
+              sessionID,
+              permission: "external_directory",
+              patterns: ["/etc/*"],
+              metadata: {},
+              always: [],
+            },
+          };
+          yield {
+            type: "message.updated",
+            properties: { info: { id: "msg-a", role: "assistant", sessionID } },
+          };
+          yield {
+            type: "message.part.updated",
+            properties: {
+              part: { id: "p-a", sessionID, messageID: "msg-a", type: "text", text: "done" },
+            },
+          };
+          yield { type: "session.idle", properties: { sessionID } };
+        })(),
+      };
+    }) as any);
+
+    // The run completes on its own rather than stalling on the unanswered ask.
+    const result = await runOpenCodeTextPrompt({
+      directory: "/repo",
+      title: "Approval during a one-shot",
+      modelDescriptor: ONE_SHOT_MODEL_DESCRIPTOR,
+      prompt: "ping",
+      projectConfig: { ai: {} },
+    });
+
+    expect(result.text).toBe("done");
+    expect(mockState.permissionReply).toHaveBeenCalledWith(
+      expect.objectContaining({ requestID: "perm-1", reply: "reject" }),
+      expect.objectContaining({ throwOnError: true }),
+    );
   });
 
   it("bounds the event stream's silent reconnects", async () => {

--- a/apps/desktop/src/main/services/opencode/openCodeRuntime.ts
+++ b/apps/desktop/src/main/services/opencode/openCodeRuntime.ts
@@ -219,10 +219,10 @@ function buildPermissionConfig(
       // deny), i.e. edit ALLOWED — so leaving `task` open let plan mode write
       // files indirectly through a child session. Plan has to mean plan.
       task: "deny",
-      // No `external_directory` here either — see the note on the edit ruleset
-      // below. Plan's other denials are unaffected: `skill: "deny"` already stops
-      // plan mode reaching into skill directories, so the default's allowances
-      // cost plan nothing.
+      // No `external_directory` here either — see the canonical note on the edit
+      // ruleset below, including what plan gives up: it now ASKS for a path
+      // outside the worktree where it used to deny outright, and the user
+      // answers that card.
       question: "allow",
       // Replaces the deprecated agent-level `tools` map. OpenCode desugars that
       // map into exactly these permission entries, and an explicit `permission`
@@ -238,15 +238,22 @@ function buildPermissionConfig(
     webfetch: "allow",
     doom_loop: "ask",
     // Never state `external_directory` in ANY ADE ruleset — this note is the
-    // canonical one and the other three point at it. OpenCode's own default is
-    // `{"*": "ask", <tmp>: "allow", <skill dirs>: "allow", <reference dirs>:
-    // "allow"}`, and a bare string expands to a single `{pattern: "*"}` rule
-    // that an agent block appends AFTER those defaults. Rule lookup is a
-    // `findLast` over the merged list, so the bare rule wins for every path and
-    // silently revokes OpenCode's access to its own temp, skill, and reference
-    // directories — whether ADE spelled it "ask" or "deny". Omitting the key
-    // leaves the default in place, which already asks for anything outside the
-    // worktree — exactly what ADE wants.
+    // canonical one and the other three point at it.
+    //
+    // OpenCode's own default is `{"*": "ask", <tmp>: "allow", <skill dirs>:
+    // "allow", <reference dirs>: "allow"}`. A bare string expands to a single
+    // `{pattern: "*"}` rule that an agent block appends AFTER those defaults,
+    // and rule lookup is a `findLast` over the merged list — so the bare rule
+    // wins for every path and silently revokes OpenCode's access to its own
+    // temp, skill, and reference directories. That is equally true of "deny"
+    // and "ask", which is why all four rulesets omit the key.
+    //
+    // The trade, stated honestly: plan and helper used to hard-DENY every path
+    // outside the worktree, and now they ASK for one. That is a real loosening,
+    // not a no-op. It is acceptable because each ask still has an answer — plan
+    // raises an approval card the user decides, and a helper ask is rejected
+    // immediately by the `permission.asked` responder in `runOpenCodeTextPrompt`,
+    // which is a one-shot with no UI. Change either of those and revisit this.
     question: "allow",
   };
 }
@@ -510,9 +517,10 @@ export function buildOpenCodeConfig(args: BuildOpenCodeConfigArgs): OpenCodeConf
     bash: "deny",
     webfetch: "deny",
     doom_loop: "deny",
-    // No `external_directory`, matching every other ADE ruleset. The helper
-    // denies edit, bash, and webfetch outright, so there is nothing left for a
-    // directory rule to gate.
+    // No `external_directory`, matching every other ADE ruleset — see the
+    // canonical note in `buildPermissionConfig`. The helper has no UI to show an
+    // approval card, so `runOpenCodeTextPrompt` answers any ask by rejecting it
+    // at once, which is what the old bare "deny" achieved.
     question: "deny",
   } as const satisfies OpenCodePermissionConfig;
 
@@ -943,6 +951,29 @@ export async function runOpenCodeTextPrompt(
         if (roleByMessageId.get(part.messageID) !== "assistant") continue;
         if (part.synthetic || part.ignored) continue;
         text += typeof delta === "string" ? delta : part.text;
+        continue;
+      }
+
+      // A one-shot prompt has no UI and nobody to ask, so an approval request
+      // must fail fast rather than hang. ADE states no `external_directory`
+      // rule any more, which means OpenCode's default ASKS for a path outside
+      // the worktree instead of denying it outright — without this responder
+      // that ask would sit unanswered until the caller's abort fires, minutes
+      // later. Rejecting immediately reproduces the old hard deny: the tool
+      // call fails and the turn errors or idles on its own.
+      if (event.type === "permission.asked" && event.properties.sessionID === handle.sessionId) {
+        void handle.client.permission.reply(
+          {
+            requestID: event.properties.id,
+            directory: handle.directory,
+            reply: "reject",
+          },
+          { throwOnError: true },
+        ).catch(() => {
+          // Best effort. If the reply never lands the turn still ends through
+          // its own error or idle path, and the caller's abort remains the
+          // backstop.
+        });
         continue;
       }
 

--- a/apps/desktop/src/main/services/opencode/openCodeRuntime.ts
+++ b/apps/desktop/src/main/services/opencode/openCodeRuntime.ts
@@ -199,10 +199,11 @@ function buildPermissionConfig(
       // means no prompts.
       read: "allow",
       task: "allow",
-      // external_directory stays "ask". That boundary is ADE's lane worktree,
-      // not a permission tier the user picked — the same reason the system
-      // prompt confines edits to the lane.
-      external_directory: "ask",
+      // external_directory is deliberately NOT stated here, and "ask" is what
+      // omitting it means. That boundary is ADE's lane worktree, not a
+      // permission tier the user picked — the same reason the system prompt
+      // confines edits to the lane. See the note on the edit ruleset below for
+      // why the key must be absent rather than spelled out.
       question: "allow",
     };
   }
@@ -218,7 +219,10 @@ function buildPermissionConfig(
       // deny), i.e. edit ALLOWED — so leaving `task` open let plan mode write
       // files indirectly through a child session. Plan has to mean plan.
       task: "deny",
-      external_directory: "deny",
+      // No `external_directory` here either — see the note on the edit ruleset
+      // below. Plan's other denials are unaffected: `skill: "deny"` already stops
+      // plan mode reaching into skill directories, so the default's allowances
+      // cost plan nothing.
       question: "allow",
       // Replaces the deprecated agent-level `tools` map. OpenCode desugars that
       // map into exactly these permission entries, and an explicit `permission`
@@ -233,7 +237,16 @@ function buildPermissionConfig(
     bash: "ask",
     webfetch: "allow",
     doom_loop: "ask",
-    external_directory: "ask",
+    // Never state `external_directory` in ANY ADE ruleset — this note is the
+    // canonical one and the other three point at it. OpenCode's own default is
+    // `{"*": "ask", <tmp>: "allow", <skill dirs>: "allow", <reference dirs>:
+    // "allow"}`, and a bare string expands to a single `{pattern: "*"}` rule
+    // that an agent block appends AFTER those defaults. Rule lookup is a
+    // `findLast` over the merged list, so the bare rule wins for every path and
+    // silently revokes OpenCode's access to its own temp, skill, and reference
+    // directories — whether ADE spelled it "ask" or "deny". Omitting the key
+    // leaves the default in place, which already asks for anything outside the
+    // worktree — exactly what ADE wants.
     question: "allow",
   };
 }
@@ -497,7 +510,9 @@ export function buildOpenCodeConfig(args: BuildOpenCodeConfigArgs): OpenCodeConf
     bash: "deny",
     webfetch: "deny",
     doom_loop: "deny",
-    external_directory: "deny",
+    // No `external_directory`, matching every other ADE ruleset. The helper
+    // denies edit, bash, and webfetch outright, so there is nothing left for a
+    // directory rule to gate.
     question: "deny",
   } as const satisfies OpenCodePermissionConfig;
 
@@ -799,14 +814,35 @@ export function openCodePartUpdatedDelta(properties: unknown): string | undefine
   return typeof candidate === "string" ? candidate : undefined;
 }
 
+/**
+ * The generated SSE client's attempt ceiling for one `/event` subscription.
+ *
+ * Left undefined it reconnects forever, and OpenCode publishes no event ids, so
+ * a reconnect replays nothing: a `session.idle` published while the socket was
+ * down is simply gone and the consuming `for await` never ends. That is a chat
+ * that spins until the user kills it.
+ *
+ * The count includes the FIRST connection, and the client stops once
+ * `attempt >= max` — so 1 would permit no reconnect at all. 2 buys exactly one
+ * real reconnect, which covers a momentary blip; past that the stream must end
+ * so the caller can report a failure.
+ */
+export const OPENCODE_SSE_MAX_RETRY_ATTEMPTS = 2;
+
 export async function openCodeEventStream(args: {
   client: OpencodeClient;
   directory: string;
   signal?: AbortSignal;
+  /** Called for every connection failure, including ones the SDK retries. */
+  onSseError?: (error: unknown) => void;
 }): Promise<AsyncGenerator<OpenCodeRuntimeEvent>> {
   const result = await args.client.event.subscribe(
     { directory: args.directory },
-    { signal: args.signal },
+    {
+      signal: args.signal,
+      sseMaxRetryAttempts: OPENCODE_SSE_MAX_RETRY_ATTEMPTS,
+      onSseError: args.onSseError,
+    },
   );
   return result.stream as AsyncGenerator<OpenCodeRuntimeEvent>;
 }
@@ -876,18 +912,37 @@ export async function runOpenCodeTextPrompt(
     let text = "";
     let inputTokens: number | null = null;
     let outputTokens: number | null = null;
+    // Part events carry no role, so the caller's own prompt streams back through
+    // the same channel. The result of this helper names lanes and titles chats,
+    // so an ungated accumulator put the user's prompt — and the model's chain of
+    // thought — into those names. OpenCode announces every message with its role
+    // before any of its parts, so this map is always populated in time.
+    const roleByMessageId = new Map<string, "assistant" | "user">();
     for await (const event of stream) {
+      if (event.type === "message.updated") {
+        const info = event.properties.info;
+        if (info.sessionID !== handle.sessionId) continue;
+        if (info.role === "assistant" || info.role === "user") {
+          roleByMessageId.set(info.id, info.role);
+        }
+        continue;
+      }
+
       if (event.type === "message.part.updated") {
         const { part } = event.properties;
         const delta = openCodePartUpdatedDelta(event.properties);
         if (part.sessionID !== handle.sessionId) continue;
-        if (part.type === "text" || part.type === "reasoning") {
-          text += typeof delta === "string" ? delta : part.text;
-        }
         if (part.type === "step-finish") {
           inputTokens = part.tokens.input;
           outputTokens = part.tokens.output;
+          continue;
         }
+        // Answer text only: reasoning is the model thinking aloud, and a
+        // synthetic/ignored part is injected context, not output.
+        if (part.type !== "text") continue;
+        if (roleByMessageId.get(part.messageID) !== "assistant") continue;
+        if (part.synthetic || part.ignored) continue;
+        text += typeof delta === "string" ? delta : part.text;
         continue;
       }
 

--- a/apps/ios/ADE/Models/RemoteModels.swift
+++ b/apps/ios/ADE/Models/RemoteModels.swift
@@ -3203,10 +3203,13 @@ extension AgentChatEvent {
       // detail can carry a spawn completion, so a failed probe means "not one".
       // The replay path already treats it this way — see
       // `workSpawnCompletionEvent` in WorkTranscriptParser.swift.
-      let detailSpawnCompletion = ((try? container.decodeIfPresent(
+      // `decode`, not `decodeIfPresent`: a missing key throws `keyNotFound`,
+      // which `try?` turns into the same nil the optional-of-optional flattening
+      // produced. One level of optionality, identical behaviour.
+      let detailSpawnCompletion = (try? container.decode(
         AgentChatSpawnCompletionContainer.self,
         forKey: .detail
-      )) ?? nil)?.spawnCompletion
+      ))?.spawnCompletion
       if let completion = detailSpawnCompletion,
          completion.spawnKind == .subagent {
         self = completion.event(fallbackTurnId: eventTurnId)

--- a/apps/ios/ADE/Models/RemoteModels.swift
+++ b/apps/ios/ADE/Models/RemoteModels.swift
@@ -3192,7 +3192,22 @@ extension AgentChatEvent {
       )
     case "system_notice":
       let eventTurnId = try container.decodeIfPresent(String.self, forKey: .turnId)
-      if let completion = try container.decodeIfPresent(AgentChatSpawnCompletionContainer.self, forKey: .detail)?.spawnCompletion,
+      // Probe `detail` for a spawn completion WITHOUT letting the probe throw.
+      // The host declares `detail?: string | AgentChatNoticeDetail`
+      // (apps/desktop/src/shared/types/chat.ts), and a plain-string detail is
+      // common — every `provider_health` notice carries one. Decoding a string
+      // as a keyed container raises `typeMismatch`, and a thrown event is
+      // dropped whole: `ADELossyArray` skips the element and
+      // `syncDecodeChatEventEnvelope` returns nil. The notice then never
+      // renders on iOS even though the kind is fully supported. Only an object
+      // detail can carry a spawn completion, so a failed probe means "not one".
+      // The replay path already treats it this way — see
+      // `workSpawnCompletionEvent` in WorkTranscriptParser.swift.
+      let detailSpawnCompletion = ((try? container.decodeIfPresent(
+        AgentChatSpawnCompletionContainer.self,
+        forKey: .detail
+      )) ?? nil)?.spawnCompletion
+      if let completion = detailSpawnCompletion,
          completion.spawnKind == .subagent {
         self = completion.event(fallbackTurnId: eventTurnId)
       } else {

--- a/apps/ios/ADETests/ADETests.swift
+++ b/apps/ios/ADETests/ADETests.swift
@@ -4634,6 +4634,66 @@ final class ADETests: XCTestCase {
     }
   }
 
+  func testSystemNoticeWithStringDetailDecodesInsteadOfBeingDropped() throws {
+    // Regression: the host declares `detail?: string | AgentChatNoticeDetail`,
+    // and every `provider_health` notice carries a plain string — Codex retry
+    // notices, and now the OpenCode provider-retry and context-overflow notices.
+    // The decoder probed `detail` for a spawn completion with a hard `try`, so a
+    // string raised `typeMismatch`. A thrown event is dropped whole
+    // (`ADELossyArray` skips it, `syncDecodeChatEventEnvelope` returns nil), so
+    // the notice never reached the transcript even though `provider_health` is a
+    // fully supported kind.
+    let json = """
+    {
+      "sessionId": "chat-1",
+      "timestamp": "2026-03-17T00:00:00.000Z",
+      "event": {
+        "type": "system_notice",
+        "noticeKind": "provider_health",
+        "severity": "warning",
+        "message": "OpenCode hit a provider error and is retrying automatically (attempt 2).",
+        "detail": "The provider request failed. Retrying in 4s.",
+        "turnId": "turn-1"
+      }
+    }
+    """
+    let envelope = try JSONDecoder().decode(AgentChatEventEnvelope.self, from: Data(json.utf8))
+    guard case .systemNotice(let kind, let message, let detail, let turnId, _) = envelope.event else {
+      return XCTFail("Expected a system notice for a string detail.")
+    }
+    XCTAssertEqual(kind, .providerHealth)
+    XCTAssertEqual(message, "OpenCode hit a provider error and is retrying automatically (attempt 2).")
+    XCTAssertEqual(detail, .string("The provider request failed. Retrying in 4s."))
+    XCTAssertEqual(turnId, "turn-1")
+
+    // The lenient probe must not cost the spawn-completion routing it guards.
+    let spawnJSON = """
+    {
+      "sessionId": "chat-1",
+      "timestamp": "2026-03-17T00:00:01.000Z",
+      "event": {
+        "type": "system_notice",
+        "noticeKind": "info",
+        "message": "Subagent finished",
+        "detail": {
+          "spawnCompletion": {
+            "childSessionId": "child-1",
+            "childTitle": "Child",
+            "spawnKind": "subagent",
+            "status": "completed"
+          }
+        }
+      }
+    }
+    """
+    let spawnEnvelope = try JSONDecoder().decode(AgentChatEventEnvelope.self, from: Data(spawnJSON.utf8))
+    guard case .subagentResult(_, let agentId, _, _, _, let status, _, _, _, _, _, _) = spawnEnvelope.event else {
+      return XCTFail("Expected an object detail to still route to a subagent result.")
+    }
+    XCTAssertEqual(agentId, "child-1")
+    XCTAssertEqual(status, .completed)
+  }
+
   func testChatEventHistorySnapshotSurvivesWarningNoticeAlongsidePlanApproval() throws {
     // Regression: a single `system_notice` with an out-of-enum noticeKind used to
     // throw during the strict `[AgentChatEventEnvelope]` array decode, discarding

--- a/docs/features/chat/README.md
+++ b/docs/features/chat/README.md
@@ -91,9 +91,9 @@ for its separate RPC, sync, storage, and UI contracts.
 | `apps/desktop/src/main/services/chat/piSessionLease.ts` | The `<session>.ade-lease` live-writer lock: a pid + process-start-keyed cross-process claim (`owner: "sdk" \| "cli"`) removed on release and reclaimable once its owner is gone. `piSessionLeaseIsHeld` is the cheap pre-launch probe; `piSessionCreationLeaseTarget(sessionRoot, cwd)` is the synthetic per-cwd token held while a session has no JSONL yet (hashed per working directory so one lane's starting chat cannot block every other lane's). |
 | `apps/desktop/src/main/services/chat/piSessionOwnership.ts` | The `<session>.ade-owner` durable claim — `{ owner, ownerSessionId }`, never removed, because chat and the tracked CLI share one store and creation-time proximity cannot tell their sessions apart. `piSessionIsAdoptableByTerminal` leaves unclaimed sessions adoptable (a `pi` run started outside ADE) and `piSessionCouldBelongToTerminal` rejects a stored resume pointer at a session older than the terminal itself. |
 | `apps/desktop/src/main/services/ai/piAuthService.ts` | In-app Pi sign-in on a dedicated inventory-only worker: provider enumeration, one flow per provider, prompt/notice fan-out through `addPiAuthStatusListener`, prompt answers, cancellation, and a 10-minute bound. A user-pressed cancel gives Pi `PI_LOGIN_CANCEL_GRACE_MS` to report a login it had already completed; a supersede (a replacement attempt) settles the outgoing flow at once and silently, so it cannot clear the card the newer attempt owns. Relays credentials, never retains them. |
-| `apps/desktop/src/main/services/opencode/openCodeBinaryManager.ts` | Resolves the OpenCode CLI: PATH first, then the bundled `node_modules/.bin/opencode`. Cache entries are re-validated with `canRunBinaryCandidate` on every lookup so user installs after launch are picked up; missing-binary lookups are intentionally not cached. `clearOpenCodeBinaryCache()` is wired into the AI integration's full cache reset. |
+| `apps/desktop/src/main/services/opencode/openCodeBinaryManager.ts` | Resolves the OpenCode CLI, and the order is **pinned runtime first**: the machine tools cache (`cachedToolEntryPath("opencode")`), then the bundled platform package, and only then a user-installed binary on PATH / `~/.opencode/bin`. `ADE_DISABLE_BUNDLED_OPENCODE=1` skips both pinned candidates and selects the user install outright; `ADE_OPENCODE_BUNDLE_ROOT` is a hermetic override that suppresses the cache and the user install as well. `resolveOpenCodeBinary` returns the `OpenCodeBinarySource` that won, so callers can tell a pinned runtime from a user install. Cache entries are re-validated with `canRunBinaryCandidate` on every lookup so user installs after launch are picked up; missing-binary lookups are intentionally not cached. `clearOpenCodeBinaryCache()` is wired into the AI integration's full cache reset. |
 | `apps/desktop/src/main/services/opencode/openCodeInventory.ts` | OpenCode provider/model probe. Now classifies model variants into `reasoningTiers` + `serviceTiers` (alias map covering `minimal`/`mini`/`med`/`xhigh`/`extra-high`), reads `capabilities` (tools/vision/reasoning) into descriptor capabilities, and exposes `modelIds` — the selectable ids for connected providers only. (Descriptors are still registered for every catalog entry, so an id from an unconnected provider resolves; it just is not offered as a pick.) Anthropic rows normalize generic `opus` to Opus 5 with its `high` default reasoning effort and Fast capability; retired Sonnet 4.6 / basic Opus 4.7 ids still resolve to Sonnet 5 / Opus 4.8 so runtime catalogs cannot reintroduce removed picker rows. `OpenCodeProviderInfo.availableModelCount` exposes the connected count separately from `modelCount`. **Cross-launch persistence:** `persistOpenCodeInventory(projectRoot, providers)` writes each successful probe's provider list (keyed by project root, with `savedAt`) to `opencode-inventory-cache.json` under Electron `userData` (override via `ADE_OPENCODE_INVENTORY_CACHE_FILE`); on a cold start the Settings page reloads that persisted list flagged stale (`opencodeProvidersStale`) so the ~160-provider chip cloud renders immediately instead of blanking until the first live probe (stale-while-revalidate). Writes are best-effort and never break the probe. |
-| `apps/desktop/src/main/services/opencode/openCodeRuntime.ts` | OpenCode server session runtime: the single `@opencode-ai/sdk/v2/client` every OpenCode call goes through, session handles over shared/dedicated server leases, the `buildOpenCodeConfig` / `OPENCODE_CONFIG_CONTENT` permission config (`OpenCodePermissionKey`), prompt assembly (`buildOpenCodePromptParts`), and event-stream helpers. Two contracts are load-bearing. **Re-attach is 404-gated:** when a persisted session id fails `session.get`, only a confirmed "session does not exist" (`isOpenCodeNotFoundError`, HTTP 404 / `NotFoundError`, walking a bounded chain of `cause`/`body`/`error`/`data` wrapper shapes with any explicit non-404 status sealing the walk) may fall through to fresh-session creation; any other failure closes the server lease and surfaces, because silently starting an empty session would strand the user's thread. **System prompts ride the prompt body:** ADE's system prompt travels on the prompt body's first-class `system` field and is never injected as a synthetic/ignored text part — OpenCode drops `ignored` parts from model context entirely, so a part-shaped transport silently never reaches the model. |
+| `apps/desktop/src/main/services/opencode/openCodeRuntime.ts` | OpenCode server session runtime: the single `@opencode-ai/sdk/v2/client` every OpenCode call goes through, session handles over shared/dedicated server leases, the `buildOpenCodeConfig` / `OPENCODE_CONFIG_CONTENT` permission config (`OpenCodePermissionKey`), prompt assembly (`buildOpenCodePromptParts`), event-stream helpers, and the one-shot `runOpenCodeTextPrompt` behind `runProviderTask`. Three contracts are load-bearing. **Re-attach is 404-gated:** when a persisted session id fails `session.get`, only a confirmed "session does not exist" (`isOpenCodeNotFoundError`, HTTP 404 / `NotFoundError`, walking a bounded chain of `cause`/`body`/`error`/`data` wrapper shapes with any explicit non-404 status sealing the walk) may fall through to fresh-session creation; any other failure closes the server lease and surfaces, because silently starting an empty session would strand the user's thread. **System prompts ride the prompt body:** ADE's system prompt travels on the prompt body's first-class `system` field and is never injected as a synthetic/ignored text part — OpenCode drops `ignored` parts from model context entirely, so a part-shaped transport silently never reaches the model. **The `/event` subscription is bounded:** `openCodeEventStream` passes `OPENCODE_SSE_MAX_RETRY_ATTEMPTS` and forwards `onSseError`, because the generated SSE client reconnects forever by default and OpenCode sends no event ids, so a reconnect replays nothing. |
 | `apps/desktop/src/main/services/opencode/openCodeAuthService.ts` | Drives the managed OpenCode server's auth API for subscription connect + API-key seeding, reusing the shared inventory server lease (never spawning its own process). `listAuthMethods` reads `GET /provider/auth`; `startOAuth` authorizes (`POST /provider/{id}/oauth/authorize`), opens the returned URL, and polls `provider.list().connected` every 2s until connected or a 5-min timeout, re-probing inventory on success; `cancelOAuth` stops the poller; `setProviderKey` does `PUT /auth/{id}` and mirrors the key into ADE's `apiKeyStore` so it is re-injected on future launches. One flow per `providerId` at a time (a new start supersedes the prior). Transitions are published through `addOpenCodeOAuthStatusListener` (`pending`/`connected`/`cancelled`/`timeout`/`failed`), a multi-sink fan-out so the same event reaches desktop windows and the remote/web runtime event buffer. Seeded credentials land in ADE's isolated managed OpenCode dir (XDG roots under `userData/opencode-runtime/xdg-v*`), never the user's `~/.local/share/opencode`. |
 | `apps/desktop/src/shared/chatTranscript.ts` | Pure JSON-lines parser for `AgentChatEventEnvelope` values. Used by both the main process and the renderer. |
 | `apps/desktop/src/shared/chatEventCompaction.ts` | The single compaction policy for heavy chat-event payloads, owned by the two consumers that must never disagree: the stored transcript (`compactChatEventForStorage`, called by `agentChatService`) and the mobile/web sync wire (`compactChatEventForWire`, called by the sync host's `compactChatEventEnvelopeForSync`). It owns the whole cap table — command output (4 KB running / 16 KB completed / 64 KB failed), `tool_result.result` (16 KB, 64 KB when failed or interrupted), `tool_result.structured` (8 KB), file diffs (32 KB), reasoning text (8 KB), and inline `data:image/*` URIs (64 KB) — plus `compactRunningCommandOutput`, exported as a whole operation so no caller re-derives the label/budget pairing. Shortened payloads keep original/omitted byte counts on the event (`outputOriginalBytes`, `resultOmittedBytes`, `diffOmittedBytes`, `textOmittedBytes`, `urlOmittedBytes`, …). The wire variant runs storage compaction first, then drops `structured` and `toolResultMeta` from `tool_result` entirely — no renderer, TUI, web, or iOS client decodes either field, so removing them needs no capability gate. |
@@ -842,7 +842,9 @@ resolve to `null`, so a Pi callback awaiting an answer degrades to "no answer"
 instead of throwing through the SDK's error channel. The desktop side has the
 matching obligation: the worker is holding a Pi callback open, so every path out
 of `presentPiUiRequest` must end in exactly one `respondToUi` — including
-interrupt and teardown, which `cancelPendingPiInputs` drains.
+interrupt and teardown, which `cancelPendingInputsFrom(managed, "pi")` drains.
+That helper is shared: OpenCode passes `"opencode"` to drain its own question
+cards on the same paths.
 
 Requests become ordinary ADE pending inputs with `source: "pi"`, so they reuse
 the existing question-card, approval-card, and `respondToInput` machinery rather
@@ -1937,10 +1939,13 @@ Provider connection management lives on the `ade.ai.*` surface (handled in `regi
   transport blips, timeouts, and server-restart failures must surface instead
   of resetting the thread into an empty session. And because
   `message.part.updated` carries no message role, the service keys every seen
-  message id on `message.updated` and renders text/reasoning/file parts only
-  when that map says `assistant` — user-message parts (including synthetic or
-  ignored prompt context) stream through the same channel and would otherwise
-  echo into the transcript as assistant bubbles. Incremental text arrives on a
+  message id on `message.updated` and renders parts only when that map says
+  `assistant` — user-message parts (including synthetic or ignored prompt
+  context) stream through the same channel and would otherwise echo into the
+  transcript as assistant bubbles. Text and reasoning use the stricter
+  `rendersAsAssistantOutput`, which also excludes auto-compaction summary
+  messages (see the bullet below); file parts keep the plain role check, because
+  a summary message carries no attachments to suppress. Incremental text arrives on a
   **different** event: OpenCode's processor calls `updatePartDelta` for every
   `text-delta` and only calls `updatePart` at text-start and text-end, so
   `message.part.updated` carries an empty part and then the finished one with
@@ -1950,6 +1955,131 @@ Provider connection management lives on the `ade.ai.*` surface (handled in `regi
   full-part update diffs to an empty delta instead of repeating the whole
   answer. Without that branch the transcript renders nothing until the turn
   ends and the reply lands in one jump.
+- **A delta's `field` names the part property, not the part kind.** OpenCode
+  publishes reasoning deltas with `field: "text"`, because a reasoning part's
+  property is also called `text`. Classify every `message.part.delta` by the
+  **part kind** recorded from the part-start `message.part.updated`
+  (`partTypeByPartId`), never by `field`. Classifying by `field` renders the
+  whole chain of thought as the assistant's answer, runs it together with the
+  real reply, stores it in the assistant transcript message, and then repeats it
+  inside the "Thought" chip when the closing full part arrives. The fallback runs
+  only when no part kind was recorded, which happens on older OpenCode binaries
+  that never send the part-start: it reads the part as reasoning when
+  `reasoningByPartId` already holds text for it or `field` is `"reasoning"`, and
+  as text otherwise.
+- **Auto-compaction summaries arrive as an ordinary assistant message.** OpenCode
+  writes the summary into a real assistant message flagged `summary: true` and
+  streams it as normal text parts, so the assistant-role gate alone lets a recap
+  of the whole conversation render as the model's reply. Track the flag from
+  `message.updated` and suppress that message's text and reasoning; the
+  `compaction` part and `session.compacted` already report the compaction. File
+  parts keep the plain role check — a summary message carries no attachments to
+  suppress.
+- **Not every parent `session.error` ends the turn.** `ContextOverflowError` is
+  *usually* recoverable — OpenCode compacts and continues without idling, so
+  throwing kills a turn that was about to resume. ADE posts an info
+  `provider_health` notice instead and keeps reading the stream. Recovery is not
+  a guarantee, though: with the user's `compaction.auto` off OpenCode idles
+  without compacting, and compaction can itself overflow and stop. So track the
+  overflow and, if the turn reaches
+  idle with no assistant text emitted after it, finish the turn as failed rather
+  than reporting a completed turn that answered nothing. `MessageAbortedError` means
+  something else (the OpenCode TUI or CLI on the same server) stopped the turn,
+  which is an interruption rather than a failure. Everything else throws, and the
+  throw must carry the structured error as `cause`, because
+  `classifyOpenCodeError` reads the status code and nested messages out of it to
+  tell auth from rate-limit from network.
+- **Bound the SSE reconnect.** The generated SSE client reconnects forever unless
+  a request passes `sseMaxRetryAttempts`, and OpenCode's `/event` sends no event
+  ids, so a reconnect replays nothing: a `session.idle` published while the
+  socket was down is lost and the `for await` never ends. `openCodeEventStream`
+  caps the attempts and forwards `onSseError` so a dropped stream fails the turn
+  with a logged cause instead of spinning forever. The count includes the FIRST
+  connection and the client stops at `attempt >= max`, so the ceiling has to be
+  2 to allow one real reconnect — 1 permits none. The `onSseError` log is skipped
+  when the turn's abort signal already fired, because that is the user's Stop.
+- **Cancel OpenCode question cards on interrupt and on turn failure, never on a
+  clean completion.** `requestChatInput` parks the card in
+  `managed.localPendingInputs`, which the interrupt path did not drain — it
+  drained `pendingApprovals` only. A stranded card keeps `hasPendingInput`
+  reporting the session as blocked, so the next send is refused, and a late answer
+  replies into an aborted session. `cancelPendingInputsFrom(managed, "opencode")`
+  runs on the interrupt path and the turn-failure path. It deliberately does NOT
+  run on clean completion: on 1.18.x the question tool blocks server-side, so a
+  clean idle with a card still open is not an expected state, and if it ever
+  became one, cancelling would discard a card the user may still be reading — ADE
+  can answer a card after the turn settles, which resumes the session. The
+  exclusion is pinned by the test "bridges OpenCode question events through ADE's
+  question UI".
+- **Answer an OpenCode question on a detached task, never inline.** The event
+  loop used to await `requestChatInput` while the card was open, so nothing else
+  drained: a subagent's approval prompt, its streamed text, and every tool result
+  sat in the socket until the person answered. `resolveOpenCodeQuestion` runs as a
+  detached promise and the loop keeps reading. Failure handling moves with it —
+  the turn no longer fails on this path, so the catch rejects the request through
+  `question.reject` rather than leaving OpenCode waiting for an answer that is not
+  coming, and it stays silent when `runtime.interrupted` is set, because Stop
+  already cancelled the card and aborted the session. The test is "keeps draining
+  OpenCode events while a question waits for the user".
+- **Handle `message.part.removed` and `message.removed`.** OpenCode publishes
+  both on a revert or an undo. The part event drops that part id from
+  `textByPartId`, `reasoningByPartId`, `partTypeByPartId`, `toolStateByPartId`,
+  `compactionStartedPartIds`, and the emitted-image set, so a part id OpenCode
+  reuses later cannot diff against text that no longer exists, and a removed
+  reasoning part stops classifying as reasoning. The message event drops the id
+  from the role map and the summary set. Neither emits a renderer event:
+  `transcript_retraction` matches rows by `messageId`, which OpenCode text events
+  do not carry, and giving them one would merge every part of a message into a
+  single row.
+- **An unclassified OpenCode error is what the user reads, so bound it and
+  de-duplicate it.** `classifyOpenCodeError` walks `message`, `data.message`, and
+  `responseBody` down the `cause`/`error` chain. A thrown OpenCode error carries
+  the structured original as `cause`, so the walk reaches the same wording twice
+  and the chat printed it twice; a duplicate now keeps its first position only.
+  Classification still reads the full text, but the displayed message truncates
+  any raw `responseBody` to 500 characters, and a duplicate inherits the `isBody`
+  flag from every occurrence, so a payload cannot dodge the cap by also arriving
+  as `message`. `OPEN_CODE_ERROR_MESSAGES_BY_NAME` supplies wording for the one
+  union member with no `data.message` of its own, `MessageOutputLengthError`,
+  which otherwise reached the user as the generic fallback.
+- **Reset the activity line at `step-finish`.** The line otherwise keeps naming
+  the step's last tool until the next step starts, so a long gap between steps
+  reads as a command that never finished. The `step-finish` part emits a generic
+  `working` activity as well as recording token usage.
+- **`runOpenCodeTextPrompt` gates its own accumulator.** Part events carry no
+  role, so the caller's own prompt streams back through the same channel — and
+  this helper's result names lanes and titles chats. It tracks roles from
+  `message.updated` and keeps only non-synthetic, non-ignored `text` parts of
+  assistant messages. Without that gate the user's prompt and the model's chain of
+  thought landed in those names.
+- **Never state `external_directory` in an ADE agent's permission block.**
+  OpenCode's own default is `{"*": "ask", <tmp>: "allow", <skill dirs>: "allow",
+  <reference dirs>: "allow"}`. A bare string expands to a single `{pattern: "*"}`
+  rule, and an agent block's rules are appended after the defaults, with lookup
+  being a `findLast` over the merged list — so `external_directory: "ask"` wins
+  for every path and silently revokes OpenCode's access to its own temp, skill,
+  and reference directories. Omitting the key already means "ask outside the
+  worktree", which is what ADE wants. This binds all four ADE rulesets, `deny`
+  included: `ade-plan` and `ade-helper` state no `external_directory` either,
+  because a bare `"deny"` revokes the same built-in allowances a bare `"ask"`
+  does, and their own `edit`/`bash`/`skill` denials already impose the boundary
+  those rulesets exist for.
+- **`session.status` retry events are the only sign OpenCode is retrying.** When
+  a provider fails, OpenCode retries with exponential backoff (2s, 4s, 8s, …)
+  and publishes nothing else — no error, no text, no activity. A chat therefore
+  shows a spinner for minutes and looks wedged. ADE handles
+  `session.status` with `status.type === "retry"` and shows a
+  `system_notice` with `noticeKind: "provider_health"` that carries the attempt
+  number, the provider message, the wait computed from `status.next` (an epoch
+  ms timestamp), and any `status.action` guidance, plus a `working` activity
+  reading "Waiting for the provider". Every wire field is re-checked here even
+  though the SDK declares it required, so a missing `next` cannot render
+  "Retrying in NaNs." The first retry of a turn always posts a notice; after
+  that a notice needs a changed provider message, or a new attempt at least 10s
+  after the last notice. Reset
+  that throttle on `status.type === "idle"` ONLY: OpenCode publishes `busy`
+  between every two retry attempts (retry(1) → busy → retry(2) → …), so clearing
+  it on `busy` clears it before every retry and the throttle never engages.
 - **One OpenCode client, and it is the v2 one.** ADE talks to OpenCode
   exclusively through `@opencode-ai/sdk/v2/client`; the legacy entry point is
   imported for nothing but the `Config` type. The two clients call the *same*
@@ -1968,9 +2098,10 @@ Provider connection management lives on the `ade.ai.*` surface (handled in `regi
 - **`permission.updated` is gone from OpenCode, but not from ADE.** 1.18.21
   publishes only `permission.asked` / `permission.replied`, so the legacy event
   is absent from the v2 union. ADE still handles it through an explicit runtime
-  guard rather than a union case, because `resolveOpenCodeBinaryPath` prefers a
-  *user-installed* binary over the bundled one — dropping the handler would
-  leave an older install's approvals unanswered forever.
+  guard rather than a union case, because `resolveOpenCodeBinaryPath` falls back
+  to a *user-installed* binary when the tools cache and the bundle both miss (and
+  `ADE_DISABLE_BUNDLED_OPENCODE=1` selects one outright) — dropping the handler
+  would leave an older install's approvals unanswered forever.
 - **New `ai.*` config fields must be added to BOTH `coerceAiConfig` and
   `mergeAiConfig`.** In `projectConfigService.ts`, `coerceAiConfig`
   validates/parses a config field off disk and `mergeAiConfig` folds the

--- a/docs/features/chat/README.md
+++ b/docs/features/chat/README.md
@@ -2062,8 +2062,12 @@ Provider connection management lives on the `ade.ai.*` surface (handled in `regi
   worktree", which is what ADE wants. This binds all four ADE rulesets, `deny`
   included: `ade-plan` and `ade-helper` state no `external_directory` either,
   because a bare `"deny"` revokes the same built-in allowances a bare `"ask"`
-  does, and their own `edit`/`bash`/`skill` denials already impose the boundary
-  those rulesets exist for.
+  does. Name the trade rather than glossing it — plan and the helper used to
+  hard-deny every outside-worktree path and now ask for one, which is a real
+  loosening. It holds because each ask has an answer: plan raises an approval
+  card the user decides, and a helper ask is rejected immediately by the
+  `permission.asked` responder in `runOpenCodeTextPrompt`, since a one-shot
+  prompt has no UI and would otherwise stall until its caller's abort.
 - **`session.status` retry events are the only sign OpenCode is retrying.** When
   a provider fails, OpenCode retries with exponential backoff (2s, 4s, 8s, …)
   and publishes nothing else — no error, no text, no activity. A chat therefore

--- a/docs/features/chat/agent-routing.md
+++ b/docs/features/chat/agent-routing.md
@@ -654,9 +654,13 @@ an index signature, so a misspelled key compiles and silently fails to apply
   list — so a bare value wins for every path and silently revokes OpenCode's
   access to its own temp, skill, and reference directories. That is true of
   `"deny"` as much as `"ask"`, which is why `ade-plan` and `ade-helper` drop the
-  key too: their `skill`/`edit`/`bash` denials already impose the boundary those
-  rulesets exist for. The rule binds all four rulesets and is pinned by the test
-  "never states external_directory on any ADE ruleset".
+  key too. That does loosen them: both used to hard-deny every outside-worktree
+  path and now ask for one. Each ask has an answer, which is what makes it
+  acceptable — plan raises an approval card the user decides, and a helper ask is
+  rejected on arrival by the `permission.asked` responder in
+  `runOpenCodeTextPrompt`, because a one-shot prompt has no UI and an unanswered
+  ask would hang it until the caller aborts. The rule binds all four rulesets and
+  is pinned by the test "never states external_directory on any ADE ruleset".
 
 ### Pi
 

--- a/docs/features/chat/agent-routing.md
+++ b/docs/features/chat/agent-routing.md
@@ -644,9 +644,19 @@ an index signature, so a misspelled key compiles and silently fails to apply
 - **`full-auto` states `read: "allow"` and `task: "allow"`.** Most ungated keys
   resolve to `allow` from OpenCode's base `*` rule, but `read` does not: the base
   ruleset asks before reading `*.env` / `*.env.*`, so full access still prompted.
-- **`external_directory` stays `ask` even in `full-auto`.** That boundary is
-  ADE's lane worktree, not a permission tier the user picked — the same reason
-  the system prompt confines edits to the lane.
+- **No ADE ruleset states `external_directory` at all.** The boundary itself
+  still holds — it is ADE's lane worktree, not a permission tier the user picked,
+  the same reason the system prompt confines edits to the lane — but omitting the
+  key is how ADE gets it. OpenCode's own default for the key is
+  `{"*": "ask", <tmp>: "allow", <skill dirs>: "allow", <reference dirs>: "allow"}`.
+  A bare string expands to a single `{pattern: "*"}` rule, an agent block's rules
+  are appended *after* the defaults, and lookup is a `findLast` over the merged
+  list — so a bare value wins for every path and silently revokes OpenCode's
+  access to its own temp, skill, and reference directories. That is true of
+  `"deny"` as much as `"ask"`, which is why `ade-plan` and `ade-helper` drop the
+  key too: their `skill`/`edit`/`bash` denials already impose the boundary those
+  rulesets exist for. The rule binds all four rulesets and is pinned by the test
+  "never states external_directory on any ADE ruleset".
 
 ### Pi
 


### PR DESCRIPTION


<!-- ade:link v=1 type=pr repo=arul28/ADE branch=ade%2Fopencode-thoughts-bug num=1161 -->
<p>
  <img src="https://ade-app.dev/logo.png" height="18" align="left" alt="ADE">
  &nbsp;&nbsp;<strong>Open in ADE</strong>
  &nbsp;·&nbsp; <a href="https://ade-app.dev/open?type=branch&amp;repo=arul28%2FADE&amp;branch=ade%2Fopencode-thoughts-bug&amp;pr=1161">ade/opencode-thoughts-bug branch</a>
  &nbsp;·&nbsp; <a href="https://ade-app.dev/open?type=pr&amp;repo=arul28%2FADE&amp;number=1161">PR #1161</a>
</p>
<!-- /ade:link -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the OpenCode event loop, permission defaults, and cross-client notice decoding in a security-sensitive chat path; behavior is heavily regression-tested but misclassification could still affect transcripts or session blocking.
> 
> **Overview**
> **OpenCode chat streaming** now classifies `message.part.delta` by recorded part kind (not delta `field`), so reasoning no longer leaks into assistant text or transcripts. Auto-compaction `summary: true` assistant messages are excluded from rendered answers, and revert/undo clears per-part accumulators on `message.part.removed` / `message.removed`.
> 
> **Turn lifecycle and UX:** Provider retries surface as throttled `provider_health` notices instead of a silent spinner; `ContextOverflowError` and `MessageAbortedError` are handled as recoverable notice / interrupted rather than always failing. OpenCode questions are resolved on a detached task so the event loop keeps draining; interrupt and turn-failure paths cancel stranded OpenCode question cards via shared `cancelPendingInputsFrom`. The SSE `/event` subscription is capped (`OPENCODE_SSE_MAX_RETRY_ATTEMPTS`) with error logging so dropped streams fail the turn instead of hanging.
> 
> **Errors and one-shot prompts:** OpenCode error messages are de-duplicated and raw response bodies truncated for display; `runOpenCodeTextPrompt` filters assistant-only text and auto-rejects `permission.asked` during one-shot runs. ADE agent permission blocks **omit** `external_directory` so OpenCode’s default temp/skill/reference allowances stay intact (plan/helper now ask outside the worktree instead of hard-deny).
> 
> **iOS:** `system_notice` events with a string `detail` (e.g. provider retry notices) decode correctly instead of being dropped when probing for spawn completions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 26a1d387ae6f3dd6c647d61024ffaff82af7ac8d. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved streaming so reasoning and text appear correctly.
  - Fixed interruptions, unanswered questions, approval rejections, and context-overflow handling.
  - Added clearer, shorter error messages and provider retry notices.
  - Improved OpenCode permission prompts and prevented stalled requests.
  - Fixed iOS decoding of provider-health notices and subagent completion events.

- **Reliability**
  - OpenCode connections now report stream errors and stop retrying after repeated failures.
  - Improved handling of message updates, removals, and compaction summaries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->