### PR TITLE
fix(chat): settle Claude idle turn and subagents on quota rejection so fork is not blocked

### DIFF
--- a/apps/desktop/src/main/services/chat/agentChatService.test.ts
+++ b/apps/desktop/src/main/services/chat/agentChatService.test.ts
@@ -9706,6 +9706,20 @@ describe("createAgentChatService", () => {
         },
         {
           sessionId: wedgedId,
+          timestamp: "2026-03-25T00:01:00.200Z",
+          event: {
+            type: "subagent_started",
+            taskId: "sub-wedge-1",
+            agentId: "sub-wedge-1",
+            agentType: "general-purpose",
+            parentToolUseId: null,
+            description: "Root-cause bug 12 disk twins",
+            background: false,
+            turnId: "turn-wedge",
+          } as any,
+        },
+        {
+          sessionId: wedgedId,
           timestamp: "2026-03-25T00:02:00.000Z",
           event: {
             type: "ade_card",
@@ -9726,14 +9740,20 @@ describe("createAgentChatService", () => {
       });
       expect(handoff.session.id).toBeTruthy();
 
-      // The wedge was terminalized from the transcript: status + done pair.
+      // The wedge was terminalized from the transcript: the turn's terminal
+      // pair is exact, and the transcript-derived running subagent row settled.
       const raw = fs.readFileSync(
         path.join(tmpRoot, ".ade", "transcripts", "chat", `${wedgedId}.jsonl`),
         "utf8",
       );
       const settledEvents = raw.trim().split("\n").map((line) => JSON.parse(line) as AgentChatEventEnvelope);
+      const wedgedDone = settledEvents.find((e) => e.event.type === "done" && (e.event as any).turnId === "turn-wedge");
+      expect(wedgedDone?.event).toMatchObject({ type: "done", status: "interrupted", turnId: "turn-wedge" });
       expect(settledEvents.some((e) => e.event.type === "status" && (e.event as any).turnStatus === "interrupted")).toBe(true);
-      expect(settledEvents.some((e) => e.event.type === "done" && (e.event as any).turnId === "turn-wedge")).toBe(true);
+      const orphanResult = settledEvents.find(
+        (e) => e.event.type === "subagent_result" && (e.event as any).taskId === "sub-wedge-1",
+      );
+      expect(orphanResult?.event).toMatchObject({ type: "subagent_result", status: "stopped" });
     });
 
     it("still refuses handoff for a dead claude run when no live quota card proves the wedge", async () => {
@@ -9769,6 +9789,7 @@ describe("createAgentChatService", () => {
       ]);
 
       const debugTranscriptPath = path.join(tmpRoot, ".ade", "transcripts", "chat", `${wedgedId}.jsonl`);
+      const rawBefore = fs.readFileSync(debugTranscriptPath, "utf8");
 
       await expect(
         service.handoffSession({
@@ -9777,7 +9798,8 @@ describe("createAgentChatService", () => {
           mode: "brief",
         }),
       ).rejects.toThrow("Wait for the current response to finish before handing off this chat.");
-      expect(fs.existsSync(debugTranscriptPath)).toBe(true);
+      // A refused handoff must not mutate the transcript.
+      expect(fs.readFileSync(debugTranscriptPath, "utf8")).toBe(rawBefore);
     });
 
     it("surfaces Claude SDK retry, refusal fallback, informational, memory, notification, mirror, and denial events", async () => {

--- a/apps/desktop/src/main/services/chat/agentChatService.test.ts
+++ b/apps/desktop/src/main/services/chat/agentChatService.test.ts
@@ -9555,6 +9555,231 @@ describe("createAgentChatService", () => {
       expect(close.mock.calls.length).toBeGreaterThan(0);
     });
 
+    it("settles the idle turn, its subagents, and stays forkable when the idle reader hits a quota rejection", async () => {
+      // Regression (Versic 21559791): a plan-limit rejection received by the
+      // idle reader reset the query but never finalized the open idle turn —
+      // busy/activeTurnId stayed set for two hours and every fork attempt was
+      // refused with "Wait for the current response to finish". The settlement
+      // pass also raced the emittedSubagentStartIds clear, so the running
+      // subagent row never got its stopped result.
+      const events: AgentChatEventEnvelope[] = [];
+      let streamCall = 0;
+      let warmupComplete = false;
+      const send = vi.fn().mockResolvedValue(undefined);
+      const close = vi.fn();
+      const stream = vi.fn(() => (async function* () {
+        streamCall += 1;
+        if (streamCall === 1) {
+          // Warmup.
+          yield { type: "system", subtype: "init", session_id: "sdk-quota-idle", slash_commands: [] };
+          warmupComplete = true;
+          yield { type: "result", usage: { input_tokens: 1, output_tokens: 1 } };
+          return;
+        }
+        // The kick-off turn ends at its result. An unrecognized post-result
+        // frame stops the foreground pump, so the remaining frames — a
+        // background wake opening an idle turn, a native subagent row, then
+        // the plan-limit rejection — are consumed by the idle reader. That is
+        // the exact shape that wedged Versic session 21559791 for two hours.
+        yield { type: "result", usage: { input_tokens: 1, output_tokens: 1 } };
+        yield { type: "mystery_unrecognized_frame" };
+        yield {
+          type: "assistant",
+          session_id: "sdk-quota-idle",
+          message: {
+            id: "msg-idle-wake",
+            content: [{ type: "text", text: "Resuming background work." }],
+          },
+        };
+        yield {
+          type: "system",
+          subtype: "task_started",
+          task_id: "sub-quota-1",
+          parent_tool_use_id: "toolu_idle_sub_1",
+          subagent_type: "general-purpose",
+          description: "Root-cause bug 12 disk twins",
+        };
+        yield {
+          type: "rate_limit_event",
+          session_id: "sdk-quota-idle",
+          rate_limit_info: {
+            status: "rejected",
+            utilization: 1,
+            resetsAt: 1_770_000_000,
+          },
+        };
+      })());
+      vi.mocked(claudeSdkCreateSessionCompat).mockReturnValue({
+        send,
+        stream,
+        close,
+        sessionId: "sdk-quota-idle",
+      } as any);
+
+      const onEvent = vi.fn((event: AgentChatEventEnvelope) => { events.push(event); });
+      const { service } = createService({ onEvent });
+      const session = await service.createSession({
+        laneId: "lane-1",
+        provider: "claude",
+        model: "sonnet",
+      });
+      await vi.waitFor(() => { expect(warmupComplete).toBe(true); });
+      await service.runSessionTurn({
+        sessionId: session.id,
+        text: "kick off background work",
+        timeoutMs: 15_000,
+      });
+
+      let doneInterrupted: AgentChatEventEnvelope | null = null;
+      await vi.waitFor(() => {
+        doneInterrupted = events.find(
+          (e): e is AgentChatEventEnvelope =>
+            e.event.type === "done" && e.event.status === "interrupted",
+        ) ?? null;
+        expect(doneInterrupted).toBeTruthy();
+      }, 3000);
+      // The interrupted turn is the idle turn, not the foreground kick-off.
+      expect(doneInterrupted!.event.turnId).toMatch(/^claude-idle-/);
+
+      const stoppedSubagent = events.find(
+        (e) => e.event.type === "subagent_result" && (e.event as any).taskId === "sub-quota-1",
+      );
+      expect(stoppedSubagent).toBeTruthy();
+      expect((stoppedSubagent!.event as any).status).toBe("stopped");
+      expect((stoppedSubagent!.event as any).finalSummary).toContain("restarted");
+
+      // With the turn settled, the advertised "fork this thread" escape
+      // hatch must actually work instead of refusing the handoff.
+      vi.mocked(streamText).mockReturnValue({
+        fullStream: (async function* () {
+          yield { type: "finish", totalUsage: { inputTokens: 1, outputTokens: 1 } };
+        })(),
+      } as any);
+      const handoff = await service.handoffSession({
+        sourceSessionId: session.id,
+        targetModelId: "opencode/openai/gpt-5.4-mini",
+        mode: "brief",
+      });
+      expect(handoff.session.id).toBeTruthy();
+      expect(handoff.session.id).not.toBe(session.id);
+    });
+
+    it("recovers a persisted quota-wedged chat at handoff time when no runtime is attached", async () => {
+      // Post-restart shape of the same wedge: the transcript holds a started
+      // turn with no terminal pair plus a live quota card, and the fresh
+      // process has no runtime for the source yet. Fork must settle it rather
+      // than refuse forever.
+      vi.mocked(streamText).mockReturnValue({
+        fullStream: (async function* () {
+          yield { type: "finish", totalUsage: { inputTokens: 1, outputTokens: 1 } };
+        })(),
+      } as any);
+
+      const wedgedId = "wedged-quota-claude";
+      const { service, sessionService } = createService();
+      installRealTranscriptParser();
+      sessionService.create({
+        sessionId: wedgedId,
+        laneId: "lane-1",
+        toolType: "claude-chat",
+        title: "Wedged claude chat",
+        startedAt: "2026-03-25T00:00:00.000Z",
+      });
+      writePersistedChatState(wedgedId, {
+        version: 2,
+        sessionId: wedgedId,
+        laneId: "lane-1",
+        provider: "claude",
+        model: "sonnet",
+        updatedAt: "2026-03-25T00:05:00.000Z",
+      });
+      writeTestTranscriptEnvelopes(wedgedId, [
+        {
+          sessionId: wedgedId,
+          timestamp: "2026-03-25T00:01:00.000Z",
+          event: { type: "user_message", text: "keep going", turnId: "turn-wedge" } as any,
+        },
+        {
+          sessionId: wedgedId,
+          timestamp: "2026-03-25T00:01:00.100Z",
+          event: { type: "status", turnStatus: "started", turnId: "turn-wedge" } as any,
+        },
+        {
+          sessionId: wedgedId,
+          timestamp: "2026-03-25T00:02:00.000Z",
+          event: {
+            type: "ade_card",
+            cardId: `claude-session-quota:${wedgedId}`,
+            variant: "claude_session_quota",
+            state: "live",
+            title: "Claude session limit · resets 10:20 PM",
+            subtitle: "Send again after reset, or fork this thread.",
+            fallbackText: "Claude session limit reached.",
+          } as any,
+        },
+      ]);
+
+      const handoff = await service.handoffSession({
+        sourceSessionId: wedgedId,
+        targetModelId: "opencode/openai/gpt-5.4-mini",
+        mode: "brief",
+      });
+      expect(handoff.session.id).toBeTruthy();
+
+      // The wedge was terminalized from the transcript: status + done pair.
+      const raw = fs.readFileSync(
+        path.join(tmpRoot, ".ade", "transcripts", "chat", `${wedgedId}.jsonl`),
+        "utf8",
+      );
+      const settledEvents = raw.trim().split("\n").map((line) => JSON.parse(line) as AgentChatEventEnvelope);
+      expect(settledEvents.some((e) => e.event.type === "status" && (e.event as any).turnStatus === "interrupted")).toBe(true);
+      expect(settledEvents.some((e) => e.event.type === "done" && (e.event as any).turnId === "turn-wedge")).toBe(true);
+    });
+
+    it("still refuses handoff for a dead claude run when no live quota card proves the wedge", async () => {
+      const wedgedId = "wedged-no-quota-claude";
+      const { service, sessionService } = createService();
+      installRealTranscriptParser();
+      sessionService.create({
+        sessionId: wedgedId,
+        laneId: "lane-1",
+        toolType: "claude-chat",
+        title: "Wedged claude chat without quota proof",
+        startedAt: "2026-03-25T00:00:00.000Z",
+      });
+      writePersistedChatState(wedgedId, {
+        version: 2,
+        sessionId: wedgedId,
+        laneId: "lane-1",
+        provider: "claude",
+        model: "sonnet",
+        updatedAt: "2026-03-25T00:05:00.000Z",
+      });
+      writeTestTranscriptEnvelopes(wedgedId, [
+        {
+          sessionId: wedgedId,
+          timestamp: "2026-03-25T00:01:00.000Z",
+          event: { type: "user_message", text: "keep going", turnId: "turn-wedge" } as any,
+        },
+        {
+          sessionId: wedgedId,
+          timestamp: "2026-03-25T00:01:00.100Z",
+          event: { type: "status", turnStatus: "started", turnId: "turn-wedge" } as any,
+        },
+      ]);
+
+      const debugTranscriptPath = path.join(tmpRoot, ".ade", "transcripts", "chat", `${wedgedId}.jsonl`);
+
+      await expect(
+        service.handoffSession({
+          sourceSessionId: wedgedId,
+          targetModelId: "opencode/openai/gpt-5.4-mini",
+          mode: "brief",
+        }),
+      ).rejects.toThrow("Wait for the current response to finish before handing off this chat.");
+      expect(fs.existsSync(debugTranscriptPath)).toBe(true);
+    });
+
     it("surfaces Claude SDK retry, refusal fallback, informational, memory, notification, mirror, and denial events", async () => {
       const events: AgentChatEventEnvelope[] = [];
       const send = vi.fn().mockResolvedValue(undefined);

--- a/apps/desktop/src/main/services/chat/agentChatService.ts
+++ b/apps/desktop/src/main/services/chat/agentChatService.ts
@@ -32417,6 +32417,47 @@ export function createAgentChatService(args: {
         ),
       );
     }
+    // Transcript-derived orphans (a post-restart wedge has an empty live map,
+    // so the pass above cannot settle rows recorded only in the transcript).
+    // Buffered events are merged so rows just settled above are not re-emitted.
+    const wedgeEnvelopes = readTranscriptEnvelopes(managed, { includeBuffered: true });
+    const orphanBackground = deriveBackgroundItems(wedgeEnvelopes).filter(
+      (snapshot) => snapshot.status === "scheduled" || snapshot.status === "running",
+    );
+    const orphanSubagents = subagentSnapshotsFromEvents(wedgeEnvelopes).filter(
+      (snapshot) => snapshot.kind === "subagent"
+        && snapshot.status === "running"
+        && snapshot.background !== true,
+    );
+    for (const snapshot of orphanBackground) {
+      emitChatEvent(managed, {
+        type: "scheduled_work_update",
+        id: snapshot.id,
+        kind: "background_task",
+        status: "stopped",
+        origin: "background_task",
+        title: snapshot.title,
+        summary: snapshot.summary ?? "lost while Claude was wedged",
+        ...(snapshot.sourceTaskId ? { sourceTaskId: snapshot.sourceTaskId } : {}),
+        ...(snapshot.sourceToolUseId ? { sourceToolUseId: snapshot.sourceToolUseId } : {}),
+      });
+    }
+    for (const snapshot of orphanSubagents) {
+      const summary = snapshot.summary && snapshot.summary !== snapshot.name
+        ? snapshot.summary
+        : "Stopped: Claude was stuck after a plan-limit reset";
+      emitChatEvent(managed, {
+        type: "subagent_result",
+        taskId: snapshot.id,
+        ...(snapshot.parentToolUseId ? { parentToolUseId: snapshot.parentToolUseId } : { parentToolUseId: null }),
+        status: "stopped",
+        summary,
+        finalSummary: summary,
+        ...(snapshot.turnId ? { turnId: snapshot.turnId } : {}),
+      });
+    }
+    // Keep the parent terminal pair last: renderer turn state is derived in
+    // event order, so no later reconciliation row may revive the stopped turn.
     terminalizeUnsettledClaudeParentTurn(managed, "handoff_recovery");
     markSessionIdleWithFreshCache(managed);
     persistChatState(managed);

--- a/apps/desktop/src/main/services/chat/agentChatService.ts
+++ b/apps/desktop/src/main/services/chat/agentChatService.ts
@@ -17686,13 +17686,15 @@ export function createAgentChatService(args: {
       runtime.warmupDone = null;
       // Query is already null, so settle every visible background/native task
       // without trying provider stopTask on the dead control channel.
-      void stopActiveClaudeSubagents(
-        managed,
+      void clearClaudeSubagentStartIdsAfterSettlement(
         runtime,
-        runtime.activeTurnId ?? undefined,
-        "The Claude session ended before this task reported completion.",
+        stopActiveClaudeSubagents(
+          managed,
+          runtime,
+          runtime.activeTurnId ?? undefined,
+          "The Claude session ended before this task reported completion.",
+        ),
       );
-      runtime.emittedSubagentStartIds.clear();
       runtime.taskToolInputByToolUseId.clear();
       runtime.workflowAgentsByTask.clear();
       runtime.dispatchingSteerIds.clear();
@@ -19399,6 +19401,22 @@ export function createAgentChatService(args: {
     }
   };
 
+  /**
+   * Settlement contract when Claude rejects the plan quota mid-idle-turn: the
+   * rejected quota cannot run queued steers, a bare query reset leaves the open
+   * idle turn wedged busy forever (no reader restart, no finalization), and
+   * only finishing the turn lands the chat idle — and forkable — again.
+   */
+  const settleClaudeQuotaRejectedIdleTurn = async (
+    managed: ManagedChatSession,
+    runtime: ClaudeRuntime,
+    state: ClaudeIdleTurnState,
+  ): Promise<void> => {
+    cancelQueuedSteers(managed, runtime, "interrupted");
+    await resetClaudeQuerySession(managed, runtime, "session_reset");
+    await finishClaudeIdleTurn(managed, runtime, state, "interrupted");
+  };
+
   const handleClaudeIdleTaskMessage = (
     managed: ManagedChatSession,
     runtime: ClaudeRuntime,
@@ -19999,7 +20017,7 @@ export function createAgentChatService(args: {
       if (classified.kind === "ignore") return;
       if (classified.kind === "rejected") {
         noteClaudeSessionQuota(managed, classified.snapshot, state.turnId);
-        void resetClaudeQuerySession(managed, runtime, "session_reset");
+        await settleClaudeQuotaRejectedIdleTurn(managed, runtime, state);
         return;
       }
       if (managed.claudeRateLimitWarningEmitted) return;
@@ -20055,8 +20073,10 @@ export function createAgentChatService(args: {
           const text = typeof block.text === "string" ? block.text : "";
           if (isClaudeSessionQuotaText(text)) {
             noteClaudeSessionQuota(managed, snapshotFromClaudeSessionQuotaText(text), turnId);
-            void resetClaudeQuerySession(managed, runtime, "session_reset");
-            continue;
+            await settleClaudeQuotaRejectedIdleTurn(managed, runtime, state);
+            // The turn just settled; later blocks of this message belong to a
+            // finalized turn and must not append to it.
+            break;
           }
           const emittedRecord = providerMessageId && !resumedFromIncompleteThinking
             ? claudeEmittedTextRecord(runtime, providerMessageId)
@@ -25666,6 +25686,25 @@ export function createAgentChatService(args: {
   };
 
   /**
+   * Clear the dedupe-gate ids owned by a torn-down query, but only after its
+   * settlement pass finishes: settlement emissions gate on these ids, so an
+   * earlier synchronous clear silently dropped every stopped subagent_result.
+   * Deleting the snapshot (not the whole set) keeps ids registered by a newer
+   * query generation — started while a live-query settlement was still
+   * stopping tasks — intact.
+   */
+  const clearClaudeSubagentStartIdsAfterSettlement = (
+    runtime: ClaudeRuntime,
+    settlement: Promise<void>,
+  ): Promise<void> => {
+    const staleIds = [...runtime.emittedSubagentStartIds];
+    const removeStale = () => {
+      for (const id of staleIds) runtime.emittedSubagentStartIds.delete(id);
+    };
+    return settlement.then(removeStale, removeStale);
+  };
+
+  /**
    * Emit one workflow-agent transition (from claudeWorkflowProgress.ts) as
    * the matching legacy `subagent_*` event so Workflow runs flow through the
    * exact snapshot folds, panel, and TUI pane the Task tool already uses.
@@ -30231,11 +30270,14 @@ export function createAgentChatService(args: {
     // arrive on THIS query, so settle background shells, native subagents, and
     // workflow agents before clearing their tracking maps. Query is already
     // null, so this performs no provider stopTask calls.
-    void stopActiveClaudeSubagents(
-      managed,
+    void clearClaudeSubagentStartIdsAfterSettlement(
       runtime,
-      runtime.activeTurnId ?? undefined,
-      "The Claude session restarted before this task reported completion.",
+      stopActiveClaudeSubagents(
+        managed,
+        runtime,
+        runtime.activeTurnId ?? undefined,
+        "The Claude session restarted before this task reported completion.",
+      ),
     );
     if (hadOpenBackgroundTasks) {
       emitChatEvent(managed, {
@@ -30246,7 +30288,7 @@ export function createAgentChatService(args: {
     }
     runtime.scheduledWorkKindById.clear();
     runtime.scheduledWorkSignatures.clear();
-    runtime.emittedSubagentStartIds.clear();
+    // emittedSubagentStartIds is cleared by the settlement chain above.
     resetClaudeProcessBackgroundLevel(runtime);
     runtime.seenBackgroundTaskIds.clear();
     runtime.stoppingBackgroundTaskIds.clear();
@@ -31083,7 +31125,7 @@ export function createAgentChatService(args: {
 
   const terminalizeUnsettledClaudeParentTurn = (
     managed: ManagedChatSession,
-    reason: "restart" | "idle_interrupt",
+    reason: "restart" | "idle_interrupt" | "handoff_recovery",
     candidate?: UnsettledParentTurn | null,
   ): string | null => {
     const unsettled = candidate === undefined ? findUnsettledParentTurn(managed) : candidate;
@@ -32326,6 +32368,66 @@ export function createAgentChatService(args: {
   const createSession = async (args: AgentChatCreateArgs): Promise<AgentChatSession> =>
     createSessionInternal(args);
 
+  /**
+   * Escape hatch for a claude chat wedged mid-turn with no live query — the
+   * signature a quota session-reset (or any dead query) leaves behind when the
+   * turn was never finalized: busy/activeTurnId stuck or a transcript turn
+   * with no terminal pair, fork refused forever. The quota card explicitly
+   * advertises "Send again after reset, or fork this thread", so settle the
+   * dead run locally instead of refusing the handoff. Requires the live quota
+   * card as proof, and skips runtimes still spawning or holding a live query,
+   * so genuinely streaming chats are never touched.
+   */
+  const recoverWedgedClaudeSessionForHandoff = async (managed: ManagedChatSession): Promise<void> => {
+    const runtime = managed.runtime;
+    if (runtime && runtime.kind !== "claude") return;
+    if (runtime?.query || runtime?.queryStartPromise) return;
+    if (!latestQuotaCardIsLive(managed)) return;
+    const transcriptTurnActive = deriveTranscriptTurnActive(readTranscriptEnvelopes(managed));
+    if (!transcriptTurnActive && !(runtime?.busy || runtime?.activeTurnId)) return;
+    logger.warn("agent_chat.claude_wedged_runtime_recovered_for_handoff", {
+      sessionId: managed.session.id,
+      turnId: runtime?.activeTurnId ?? null,
+      busy: runtime?.busy ?? false,
+      transcriptTurnActive,
+      hadRuntime: Boolean(runtime),
+    });
+    if (runtime) {
+      const interruptedTurnId = runtime.activeTurnId;
+      runtime.interrupted = true;
+      runtime.busy = false;
+      runtime.activeTurnId = null;
+      if (interruptedTurnId) {
+        emitChatEvent(managed, { type: "status", turnStatus: "interrupted", turnId: interruptedTurnId });
+        emitChatEvent(managed, { type: "done", turnId: interruptedTurnId, status: "interrupted" });
+      }
+      // Approvals registered through canUseTool can only be answered on their
+      // now-dead query; settle them like teardown so the gate below passes.
+      for (const pending of runtime.approvals.values()) {
+        pending.resolve({ decision: "cancel" });
+      }
+      runtime.approvals.clear();
+      await clearClaudeSubagentStartIdsAfterSettlement(
+        runtime,
+        stopActiveClaudeSubagents(
+          managed,
+          runtime,
+          interruptedTurnId ?? undefined,
+          "This chat was handed off while Claude was stuck after a plan-limit reset.",
+        ),
+      );
+    }
+    terminalizeUnsettledClaudeParentTurn(managed, "handoff_recovery");
+    markSessionIdleWithFreshCache(managed);
+    persistChatState(managed);
+    // The handoff gate re-reads the transcript from disk; flush the queued
+    // settlement events so the just-terminalized turn is visible to it.
+    await Promise.all([
+      flushQueuedTranscriptWrite(managed.transcriptPath),
+      flushQueuedTranscriptWrite(path.join(chatTranscriptsDir, `${managed.session.id}.jsonl`)),
+    ]);
+  };
+
   const handoffSession = async (args: AgentChatHandoffArgs): Promise<AgentChatHandoffResult> => {
     const sourceId = args.sourceSessionId.trim();
     const targetId = args.targetModelId.trim();
@@ -32345,6 +32447,8 @@ export function createAgentChatService(args: {
     if ((sourceSession.surface ?? managed.session.surface ?? "work") !== "work") {
       throw new Error("Chat handoff is only available for work chats.");
     }
+
+    await recoverWedgedClaudeSessionForHandoff(managed);
 
     ensureSessionIdleForHandoff(managed);
 
@@ -32895,6 +32999,9 @@ export function createAgentChatService(args: {
   };
 
   const requireCrossMachineSourceReady = async (managed: ManagedChatSession) => {
+    // Same wedge settlement as the local handoff: a quota-wedged source must
+    // not refuse the cross-machine send either.
+    await recoverWedgedClaudeSessionForHandoff(managed);
     ensureSessionIdleForHandoff(managed);
     const lane = await laneService.getSummary(managed.session.laneId, { includeStatus: true });
     if (!lane) throw new Error("The source lane could not be loaded.");


### PR DESCRIPTION
## Problem

When Claude hit the plan limit mid-turn, ADE showed the quota card ("Send again after reset, **or fork this thread**") — but forking was refused with "Wait for the current response to finish before handing off this chat." The subagent row stayed "running" even though its process had been reaped. Proven on Versic session 21559791: wedged 01:01→03:04 UTC with zero settlement events.

Root cause (two stacked defects):
1. The idle reader's quota path reset the SDK query but never finalized the open idle turn; the reader exited via generation bump without finalizing → busy/activeTurnId stuck forever.
2. `resetClaudeQuerySession` cleared `emittedSubagentStartIds` synchronously past the settlement's first await, so every stopped `subagent_result` was silently gated out.

## Fix

- Both idle quota paths share `settleClaudeQuotaRejectedIdleTurn`: cancel queued steers → await query reset → finalize turn as interrupted.
- `emittedSubagentStartIds` clears only after settlement finishes, scoped to the torn-down generation (`clearClaudeSubagentStartIdsAfterSettlement`) so newer-generation ids survive and stopped rows actually land.
- New `recoverWedgedClaudeSessionForHandoff` escape hatch (live quota card as proof; skips live/spawning runtimes) settles dead claude runs before the handoff/cross-machine gates — including approvals and transcript-only wedges post-restart.
- Teardown swept to the same scoped cleanup; quota text in an assistant block breaks after settling.

## Verification

- 3 new regression tests pin the wedge shape end-to-end (idle quota settle + stopped subagent result + fork succeeds; persisted wedge recovery; negative control without quota proof)
- Full agentChatService suite: 893/893 · desktop typecheck clean · lint clean
- /quality dual-review: 9 findings applied, gate empty · /test parity passes (docs/mobile/CLI/TUI none required) · shard 1/8: 1844 passed

<!-- ade:link v=1 type=pr repo=arul28/ADE branch=ade%2Fstale-subagent-run-state num=1162 -->
<p>
  <img src="https://ade-app.dev/logo.png" height="18" align="left" alt="ADE">
  &nbsp;&nbsp;<strong>Open in ADE</strong>
  &nbsp;·&nbsp; <a href="https://ade-app.dev/open?type=branch&amp;repo=arul28%2FADE&amp;branch=ade%2Fstale-subagent-run-state&amp;pr=1162">ade/stale-subagent-run-state branch</a>
  &nbsp;·&nbsp; <a href="https://ade-app.dev/open?type=pr&amp;repo=arul28%2FADE&amp;number=1162">PR #1162</a>
</p>
<!-- /ade:link -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches Claude idle-turn lifecycle, query teardown, and handoff gates in a large chat service; behavior is narrowly gated on quota proof and dead queries, with strong test coverage.
> 
> **Overview**
> Fixes a wedge where Claude **plan-limit rejection** during the idle reader reset the SDK query but left the idle turn busy and blocked **fork/handoff** with “wait for the current response,” while subagent rows never got a **stopped** result.
> 
> **Idle quota handling** now goes through `settleClaudeQuotaRejectedIdleTurn`: cancel queued steers, await query reset, then finalize the idle turn as **interrupted**. The same path applies to quota text in assistant blocks (with a `break` so later blocks don’t attach to a settled turn).
> 
> **Subagent settlement** no longer clears `emittedSubagentStartIds` synchronously on teardown/reset. `clearClaudeSubagentStartIdsAfterSettlement` removes only the ids from the torn-down generation after `stopActiveClaudeSubagents` finishes, so gated `subagent_result` events actually emit.
> 
> **Handoff escape hatch:** `recoverWedgedClaudeSessionForHandoff` runs before local handoff and cross-machine send when a **live quota card** proves a dead-query wedge (including transcript-only state after restart). It interrupts the stuck turn, settles subagents/approvals, terminalizes unsettled parent turns (`handoff_recovery`), flushes transcript writes, then the normal idle gate proceeds. Wedges without quota proof still fail handoff.
> 
> Three regression tests cover idle quota → interrupted turn + stopped subagent + successful handoff, persisted recovery, and the negative control.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2784f16e592df2905b9b7f15c6879a681835fb00. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved recovery when Claude usage limits interrupt an idle chat turn.
  * Prevented chats from becoming stuck during handoffs, restarts, or session recovery.
  * Preserved handoff and fork functionality after quota-related interruptions.
  * Resolved pending approvals and finalized interrupted turns during recovery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->