### PR TITLE
Park same-branch Work lanes together across machines

### DIFF
--- a/apps/desktop/src/renderer/components/terminals/SessionListPane.test.tsx
+++ b/apps/desktop/src/renderer/components/terminals/SessionListPane.test.tsx
@@ -3387,3 +3387,242 @@ describe("shortcutChipLabel", () => {
     expect(shortcutChipLabel("Mod+Shift+Alt+P")).toBe("Ctrl+Alt+Shift+P");
   });
 });
+
+describe("SessionListPane shared-branch clusters", () => {
+  afterEach(() => {
+    cleanup();
+    lanePrsByLaneIdForTest.clear();
+    useAppStore.setState({ crossMachineLanesByMachineId: {}, crossMachineLaneScopeKey: null });
+    resetCrossMachineLaneSyncForTest();
+    Reflect.deleteProperty(window, "ade");
+  });
+
+  function seedStudioLane(args: {
+    lane: LaneSummary;
+    session: TerminalSessionSummary;
+  }) {
+    useAppStore.setState({
+      crossMachineLanesByMachineId: {
+        "target-studio": {
+          machineId: "target-studio",
+          machineName: "Mac Studio (12)",
+          targetId: "target-studio",
+          projectId: "project-a",
+          binding: {
+            kind: "remote",
+            key: "remote:target-studio:project-a",
+            targetId: "target-studio",
+            runtimeName: "Mac Studio (12)",
+            projectId: "project-a",
+            rootPath: "/repo-a",
+            displayName: "Repo A",
+          },
+          online: true,
+          lanes: [args.lane],
+          sessions: [args.session],
+          prs: [],
+          lastSyncedAtMs: 1,
+          error: null,
+        },
+      },
+    });
+  }
+
+  it("parks same-branch local and foreign lanes together inside a dashed cluster", () => {
+    const localLane = makeLane({
+      id: "lane-local-mobile",
+      name: "ade/mobile-chat-scrolling",
+      branchRef: "refs/heads/ade/mobile-chat-scrolling",
+    });
+    const unrelatedLane = makeLane({
+      id: "lane-unrelated",
+      name: "Unrelated lane",
+      branchRef: "refs/heads/ade/unrelated",
+    });
+    const localSession = makeSession({
+      id: "session-local-mobile",
+      laneId: localLane.id,
+      laneName: localLane.name,
+      title: "iPhone 16 Pro Chat Scroll",
+    });
+    const unrelatedSession = makeSession({
+      id: "session-unrelated",
+      laneId: unrelatedLane.id,
+      laneName: unrelatedLane.name,
+      title: "Something else",
+    });
+    const studioLane = makeLane({
+      id: "lane-studio-mobile",
+      name: "Mobile Chat Scrolling",
+      branchRef: "refs/heads/ade/mobile-chat-scrolling",
+    });
+    const studioSession = makeSession({
+      id: "session-studio-mobile",
+      laneId: studioLane.id,
+      laneName: studioLane.name,
+      title: "Fix Mobile Chat Issues",
+    });
+    seedStudioLane({ lane: studioLane, session: studioSession });
+
+    const { container } = renderPane({
+      lanes: [unrelatedLane, localLane],
+      runningFiltered: [unrelatedSession, localSession],
+      allSessionsUnfiltered: [unrelatedSession, localSession],
+      sessionsGroupedByLane: new Map([
+        [unrelatedLane.id, [unrelatedSession]],
+        [localLane.id, [localSession]],
+      ]),
+    });
+
+    const cluster = container.querySelector('[data-testid="shared-branch-cluster"]') as HTMLElement;
+    expect(cluster).toBeTruthy();
+    expect(cluster.getAttribute("data-branch-cluster")).toBe("ade/mobile-chat-scrolling");
+    expect(cluster.className).toContain("border-dashed");
+
+    const groupIds = Array.from(cluster.querySelectorAll("[data-group-id]"))
+      .map((el) => el.getAttribute("data-group-id"));
+    expect(groupIds).toEqual(["lane-local-mobile", "target-studio:lane-studio-mobile"]);
+
+    const allGroupIds = Array.from(container.querySelectorAll("[data-group-id]"))
+      .map((el) => el.getAttribute("data-group-id") ?? "")
+      .filter((id) => id.startsWith("lane-") || id.includes(":"));
+    expect(allGroupIds.indexOf("lane-local-mobile")).toBeLessThan(
+      allGroupIds.indexOf("target-studio:lane-studio-mobile"),
+    );
+    expect(allGroupIds.indexOf("target-studio:lane-studio-mobile")).toBeLessThan(
+      allGroupIds.indexOf("lane-unrelated"),
+    );
+  });
+
+  it("does not cluster two Primaries that both track main", () => {
+    const localPrimary = makeLane({
+      id: "lane-primary",
+      name: "Primary",
+      laneType: "primary",
+      branchRef: "main",
+    });
+    const localSession = makeSession({
+      id: "session-primary",
+      laneId: localPrimary.id,
+      laneName: localPrimary.name,
+      title: "Primary chat",
+    });
+    seedStudioLane({
+      lane: makeLane({
+        id: "lane-primary-studio",
+        name: "Primary",
+        laneType: "primary",
+        branchRef: "main",
+      }),
+      session: makeSession({
+        id: "session-primary-studio",
+        laneId: "lane-primary-studio",
+        laneName: "Primary",
+        title: "Primary chat elsewhere",
+      }),
+    });
+
+    const { container } = renderPane({
+      lanes: [localPrimary],
+      workLaneSortMode: "manual",
+      runningFiltered: [localSession],
+      allSessionsUnfiltered: [localSession],
+      sessionsGroupedByLane: new Map([[localPrimary.id, [localSession]]]),
+    });
+
+    expect(container.querySelector('[data-testid="shared-branch-cluster"]')).toBeNull();
+  });
+
+  it("keeps a settled same-branch foreign lane in the inbox next to live work", () => {
+    const localLane = makeLane({
+      id: "lane-local-mobile",
+      name: "ade/mobile-chat-scrolling",
+      branchRef: "ade/mobile-chat-scrolling",
+    });
+    const localSession = makeSession({
+      id: "session-local-mobile",
+      laneId: localLane.id,
+      laneName: localLane.name,
+      title: "iPhone 16 Pro Chat Scroll",
+    });
+    const studioLane = makeLane({
+      id: "lane-studio-mobile",
+      name: "Mobile Chat Scrolling",
+      branchRef: "ade/mobile-chat-scrolling",
+    });
+    seedStudioLane({
+      lane: studioLane,
+      session: makeSession({
+        id: "session-studio-mobile",
+        laneId: studioLane.id,
+        laneName: studioLane.name,
+        title: "Fix Mobile Chat Issues",
+        status: "completed",
+        runtimeState: "idle",
+        settledAt: "2026-07-28T12:00:00.000Z",
+      }),
+    });
+
+    const { container } = renderPane({
+      lanes: [localLane],
+      runningFiltered: [localSession],
+      allSessionsUnfiltered: [localSession],
+      sessionsGroupedByLane: new Map([[localLane.id, [localSession]]]),
+    });
+
+    const cluster = container.querySelector('[data-testid="shared-branch-cluster"]');
+    expect(cluster).toBeTruthy();
+    expect(container.querySelector('[data-section-id="lane-shelf:settled"]')).toBeNull();
+    expect(cluster?.querySelector('[data-group-id="target-studio:lane-studio-mobile"]')).toBeTruthy();
+  });
+
+  it("keeps an entirely quiet same-branch pair together in the settled shelf", () => {
+    const localLane = makeLane({
+      id: "lane-local-mobile",
+      name: "ade/mobile-chat-scrolling",
+      branchRef: "ade/mobile-chat-scrolling",
+    });
+    const localSession = makeSession({
+      id: "session-local-mobile",
+      laneId: localLane.id,
+      laneName: localLane.name,
+      title: "iPhone 16 Pro Chat Scroll",
+      status: "completed",
+      runtimeState: "idle",
+      settledAt: "2026-07-28T12:00:00.000Z",
+    });
+    const studioLane = makeLane({
+      id: "lane-studio-mobile",
+      name: "Mobile Chat Scrolling",
+      branchRef: "ade/mobile-chat-scrolling",
+    });
+    seedStudioLane({
+      lane: studioLane,
+      session: makeSession({
+        id: "session-studio-mobile",
+        laneId: studioLane.id,
+        laneName: studioLane.name,
+        title: "Fix Mobile Chat Issues",
+        status: "completed",
+        runtimeState: "idle",
+        settledAt: "2026-07-28T12:00:00.000Z",
+      }),
+    });
+
+    const { container } = renderPane({
+      lanes: [localLane],
+      runningFiltered: [],
+      settledFiltered: [localSession],
+      allSessionsUnfiltered: [localSession],
+      sessionsGroupedByLane: new Map([[localLane.id, [localSession]]]),
+      workCollapsedSectionIds: OPEN_QUIET_SHELVES,
+    });
+
+    expect(container.querySelector('[data-section-id="lane-shelf:settled"]')).toBeTruthy();
+    const cluster = container.querySelector('[data-testid="shared-branch-cluster"]');
+    expect(cluster).toBeTruthy();
+    expect(container.querySelector('[data-testid="shelf-body-settled"]')?.contains(cluster)).toBe(true);
+    expect(cluster?.querySelector('[data-group-id="lane-local-mobile"]')).toBeTruthy();
+    expect(cluster?.querySelector('[data-group-id="target-studio:lane-studio-mobile"]')).toBeTruthy();
+  });
+});

--- a/apps/desktop/src/renderer/components/terminals/SessionListPane.tsx
+++ b/apps/desktop/src/renderer/components/terminals/SessionListPane.tsx
@@ -35,6 +35,12 @@ import {
   WORK_LANE_SORT_MODES,
   type WorkLaneSortMode,
 } from "./workLaneOrder";
+import {
+  applySharedBranchAdjacency,
+  consecutiveSharedBranchRuns,
+  inboxIdsKeptForSharedBranch,
+  sharedBranchClusterKey,
+} from "./workLaneBranchClusters";
 import { useWorkLaneReorder } from "./useWorkLaneReorder";
 import {
   EMPTY_WORK_SESSION_FILTERS,
@@ -110,6 +116,8 @@ const BULK_DESTRUCTIVE_BUTTON_CLASS =
  */
 const GROUP_STACK_CLASS = "flex flex-col gap-[18px]";
 const ROW_STACK_CLASS = "flex flex-col gap-1";
+/** Hairline around two-or-more worktree lanes that share a feature branch. */
+const SHARED_BRANCH_CLUSTER_CLASS = "rounded-lg border border-dashed border-white/[0.18] py-1";
 /**
  * A card's hover fill bleeds past the pane's gutter so the row reaches the edge;
  * it defaults to 12px, which is the by-lane inset (scroll `px-1` + stack `px-2`).
@@ -259,6 +267,54 @@ type ForeignLaneEntry = {
   quiet: ReturnType<typeof partitionQuietSessions>;
   shelf: "snoozed" | "settled" | null;
 };
+
+type ClusterableLaneItem =
+  | { id: string; kind: "local"; lane: LaneSummary }
+  | { id: string; kind: "foreign"; entry: ForeignLaneEntry };
+
+function clusterKeyForLaneItem(item: ClusterableLaneItem): string | null {
+  switch (item.kind) {
+    case "local":
+      return sharedBranchClusterKey({ branchRef: item.lane.branchRef, laneType: item.lane.laneType });
+    case "foreign":
+      return sharedBranchClusterKey({
+        branchRef: item.entry.row.lane.branchRef,
+        laneType: item.entry.row.lane.laneType,
+      });
+    default: {
+      const _exhaustive: never = item;
+      return _exhaustive;
+    }
+  }
+}
+
+function renderSharedBranchClusters(
+  items: { id: string; clusterKey: string | null; node: React.ReactNode }[],
+  innerStackClass: string,
+): React.ReactNode[] {
+  const nodes: React.ReactNode[] = [];
+  for (const run of consecutiveSharedBranchRuns(items)) {
+    const first = run[0];
+    if (!first) continue;
+    if (run.length === 1 || !first.clusterKey) {
+      nodes.push(<React.Fragment key={first.id}>{first.node}</React.Fragment>);
+      continue;
+    }
+    nodes.push(
+      <div
+        key={`shared-branch:${first.clusterKey}:${run.map((item) => item.id).join("|")}`}
+        className={cn(innerStackClass, SHARED_BRANCH_CLUSTER_CLASS)}
+        data-testid="shared-branch-cluster"
+        data-branch-cluster={first.clusterKey}
+      >
+        {run.map((item) => (
+          <React.Fragment key={item.id}>{item.node}</React.Fragment>
+        ))}
+      </div>,
+    );
+  }
+  return nodes;
+}
 
 function partitionQuietSessions(sessions: readonly TerminalSessionSummary[]): {
   active: TerminalSessionSummary[];
@@ -2238,6 +2294,22 @@ export const SessionListPane = React.memo(function SessionListPane({
   // "No sessions" must not claim an empty machine when another machine is busy.
   const hasForeignSessions = visibleForeignRows.length > 0;
 
+  const sharedBranchInboxKeepIds = inboxIdsKeptForSharedBranch([
+    ...orderedLanes.map((lane) => ({
+      id: lane.id,
+      clusterKey: sharedBranchClusterKey({ branchRef: lane.branchRef, laneType: lane.laneType }),
+      shelf: laneShelfFor(lane.id),
+    })),
+    ...foreignLaneShelving.map((entry) => ({
+      id: entry.compositeLaneId,
+      clusterKey: sharedBranchClusterKey({
+        branchRef: entry.row.lane.branchRef,
+        laneType: entry.row.lane.laneType,
+      }),
+      shelf: entry.shelf,
+    })),
+  ]);
+
   const renderLaneGroup = (lane: LaneSummary) => {
     const list = sessionsGroupedByLane?.get(lane.id) ?? [];
     const laneHandoffJobs = handoffJobsByLaneId.get(lane.id) ?? [];
@@ -2293,7 +2365,7 @@ export const SessionListPane = React.memo(function SessionListPane({
     const suppressMachineChip = Boolean(machineMarker) && !headerless;
     // A lane already filed into a quiet shelf renders its rows flat: the shelf
     // states the tier once, for everything under it.
-    const inQuietShelf = laneShelfFor(lane.id) !== null;
+    const inQuietShelf = laneShelfFor(lane.id) !== null && !sharedBranchInboxKeepIds.has(lane.id);
     return (
       <StickyGroupHeader
         key={lane.id}
@@ -2526,12 +2598,26 @@ export const SessionListPane = React.memo(function SessionListPane({
    * join the same three destinations: the shelf is about how quiet the work is,
    * never about which machine it happens to be sitting on.
    */
-  const snoozedShelfLanes = orderedLanes.filter((lane) => laneShelfFor(lane.id) === "snoozed");
-  const settledShelfLanes = orderedLanes.filter((lane) => laneShelfFor(lane.id) === "settled");
-  const mainLanes = orderedLanes.filter((lane) => laneShelfFor(lane.id) === null);
-  const mainForeignRows = foreignLaneShelving.filter((entry) => entry.shelf === null);
-  const snoozedShelfForeignRows = foreignLaneShelving.filter((entry) => entry.shelf === "snoozed");
-  const settledShelfForeignRows = foreignLaneShelving.filter((entry) => entry.shelf === "settled");
+  const snoozedShelfLanes = orderedLanes.filter((lane) => (
+    laneShelfFor(lane.id) === "snoozed" && !sharedBranchInboxKeepIds.has(lane.id)
+  ));
+  const settledShelfLanes = orderedLanes.filter((lane) => (
+    laneShelfFor(lane.id) === "settled" && !sharedBranchInboxKeepIds.has(lane.id)
+  ));
+  const mainLanes = orderedLanes.filter((lane) => (
+    laneShelfFor(lane.id) === null || sharedBranchInboxKeepIds.has(lane.id)
+  ));
+  const mainForeignRows = foreignLaneShelving
+    .filter((entry) => entry.shelf === null || sharedBranchInboxKeepIds.has(entry.compositeLaneId))
+    .map((entry) => (
+      sharedBranchInboxKeepIds.has(entry.compositeLaneId) ? { ...entry, shelf: null } : entry
+    ));
+  const snoozedShelfForeignRows = foreignLaneShelving.filter((entry) => (
+    entry.shelf === "snoozed" && !sharedBranchInboxKeepIds.has(entry.compositeLaneId)
+  ));
+  const settledShelfForeignRows = foreignLaneShelving.filter((entry) => (
+    entry.shelf === "settled" && !sharedBranchInboxKeepIds.has(entry.compositeLaneId)
+  ));
   // A lane filtered down to nothing renders nothing, so it must not inflate the
   // shelf's count either. Foreign rows need no such guard: `visibleForeignRows`
   // has already dropped any row the filters emptied out.
@@ -2564,12 +2650,58 @@ export const SessionListPane = React.memo(function SessionListPane({
     </div>
   );
 
+  const clusterLaneItems = (
+    localLanes: LaneSummary[],
+    foreignEntries: ForeignLaneEntry[],
+  ) => applySharedBranchAdjacency(
+    [
+      ...localLanes.map((lane): ClusterableLaneItem => ({ id: lane.id, kind: "local", lane })),
+      ...foreignEntries.map((entry): ClusterableLaneItem => ({
+        id: entry.compositeLaneId,
+        kind: "foreign",
+        entry,
+      })),
+    ],
+    clusterKeyForLaneItem,
+  ).map((entry) => {
+    switch (entry.item.kind) {
+      case "local":
+        return {
+          id: entry.item.id,
+          clusterKey: entry.clusterKey,
+          node: renderLaneGroup(entry.item.lane),
+        };
+      case "foreign":
+        return {
+          id: entry.item.id,
+          clusterKey: entry.clusterKey,
+          node: renderForeignLaneGroup(entry.item.entry),
+        };
+      default: {
+        const _exhaustive: never = entry.item;
+        return _exhaustive;
+      }
+    }
+  });
+
+  const clusteredShelfItems = (
+    localLanes: LaneSummary[],
+    foreignEntries: ForeignLaneEntry[],
+  ) => clusterLaneItems(localLanes, foreignEntries).map((item) => ({
+    ...item,
+    node: shelfRow(
+      item.id,
+      isShelfRowExpanded(item.id, headerlessLaneIds.has(item.id)),
+      item.node,
+    ),
+  }));
+
   const byLaneList = (
     // `pb-2` matches the status/time stacks: the quiet zone closes this column,
     // so any extra bottom padding reads as dead space under the last shelf row
     // rather than as the deliberate breathing room above the footer rule.
     <div className={cn(GROUP_STACK_CLASS, SESSION_LIST_BLEED_CLASS, "px-1 pb-2")}>
-      {mainLanes.map(renderLaneGroup)}
+      {renderSharedBranchClusters(clusterLaneItems(mainLanes, mainForeignRows), GROUP_STACK_CLASS)}
       {missingLaneSessionGroups.map(([laneId, list]) => {
         const laneHandoffJobs = handoffJobsByLaneId.get(laneId) ?? [];
         const collapsed = workCollapsedLaneIds.includes(laneId);
@@ -2639,7 +2771,6 @@ export const SessionListPane = React.memo(function SessionListPane({
           </StickyGroupHeader>
         );
       })}
-      {mainForeignRows.map(renderForeignLaneGroup)}
       {/* The two shelves close the column, hidden-for-now above done, inside the
           quiet zone's single heavier rule. A demoted lane keeps its group — a
           quiet header, or none at all for a singleton — so it is filed, not
@@ -2663,23 +2794,13 @@ export const SessionListPane = React.memo(function SessionListPane({
             >
               {/* Row rhythm, not group rhythm — see `SHELF_BODY_STACK_CLASS`;
                   a collapsed shelved lane is a one-line row and only an
-                  expanded one earns the group gap. Local lanes first, then
-                  cross-machine ones — the shelf is one list, but "here" still
-                  reads before "elsewhere". */}
+                  expanded one earns the group gap. Same-branch lanes still
+                  sit together; otherwise local still reads before foreign. */}
               <div className={SHELF_BODY_STACK_CLASS} data-testid="shelf-body-snoozed">
-                {snoozedShelfLanes.map((lane) => shelfRow(
-                  lane.id,
-                  isShelfRowExpanded(lane.id, headerlessLaneIds.has(lane.id)),
-                  renderLaneGroup(lane),
-                ))}
-                {snoozedShelfForeignRows.map((entry) => shelfRow(
-                  entry.compositeLaneId,
-                  isShelfRowExpanded(
-                    entry.compositeLaneId,
-                    headerlessLaneIds.has(entry.compositeLaneId),
-                  ),
-                  renderForeignLaneGroup(entry),
-                ))}
+                {renderSharedBranchClusters(
+                  clusteredShelfItems(snoozedShelfLanes, snoozedShelfForeignRows),
+                  SHELF_BODY_STACK_CLASS,
+                )}
               </div>
             </StickyGroupHeader>
             <StickyGroupHeader
@@ -2694,19 +2815,10 @@ export const SessionListPane = React.memo(function SessionListPane({
               onToggleCollapsed={() => toggleWorkSectionCollapsed(quietShelfOpenMarker("lane-shelf:settled"))}
             >
               <div className={SHELF_BODY_STACK_CLASS} data-testid="shelf-body-settled">
-                {settledShelfLanes.map((lane) => shelfRow(
-                  lane.id,
-                  isShelfRowExpanded(lane.id, headerlessLaneIds.has(lane.id)),
-                  renderLaneGroup(lane),
-                ))}
-                {settledShelfForeignRows.map((entry) => shelfRow(
-                  entry.compositeLaneId,
-                  isShelfRowExpanded(
-                    entry.compositeLaneId,
-                    headerlessLaneIds.has(entry.compositeLaneId),
-                  ),
-                  renderForeignLaneGroup(entry),
-                ))}
+                {renderSharedBranchClusters(
+                  clusteredShelfItems(settledShelfLanes, settledShelfForeignRows),
+                  SHELF_BODY_STACK_CLASS,
+                )}
               </div>
             </StickyGroupHeader>
           </>

--- a/apps/desktop/src/renderer/components/terminals/workLaneBranchClusters.test.ts
+++ b/apps/desktop/src/renderer/components/terminals/workLaneBranchClusters.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from "vitest";
+import {
+  applySharedBranchAdjacency,
+  consecutiveSharedBranchRuns,
+  inboxIdsKeptForSharedBranch,
+  sharedBranchClusterKey,
+} from "./workLaneBranchClusters";
+
+describe("sharedBranchClusterKey", () => {
+  it("normalizes refs and ignores primaries and default trunks", () => {
+    expect(sharedBranchClusterKey({
+      branchRef: "refs/heads/ade/mobile-chat-scrolling",
+      laneType: "worktree",
+    })).toBe("ade/mobile-chat-scrolling");
+    expect(sharedBranchClusterKey({
+      branchRef: "ade/mobile-chat-scrolling",
+      laneType: "worktree",
+    })).toBe("ade/mobile-chat-scrolling");
+    expect(sharedBranchClusterKey({ branchRef: "main", laneType: "worktree" })).toBeNull();
+    expect(sharedBranchClusterKey({ branchRef: "refs/heads/master", laneType: "worktree" })).toBeNull();
+    expect(sharedBranchClusterKey({
+      branchRef: "refs/heads/ade/mobile-chat-scrolling",
+      laneType: "primary",
+    })).toBeNull();
+    expect(sharedBranchClusterKey({ branchRef: "", laneType: "worktree" })).toBeNull();
+  });
+});
+
+describe("applySharedBranchAdjacency", () => {
+  const keyOf = (item: { branch: string | null }) => item.branch;
+
+  it("pulls later same-branch lanes up beside the first one", () => {
+    const ordered = applySharedBranchAdjacency([
+      { id: "local-mobile", branch: "ade/mobile" },
+      { id: "local-other", branch: "ade/other" },
+      { id: "studio-mobile", branch: "ade/mobile" },
+    ], keyOf);
+    expect(ordered.map((entry) => entry.item.id)).toEqual([
+      "local-mobile",
+      "studio-mobile",
+      "local-other",
+    ]);
+    expect(ordered.map((entry) => entry.clusterKey)).toEqual([
+      "ade/mobile",
+      "ade/mobile",
+      null,
+    ]);
+  });
+
+  it("leaves unique branches in place", () => {
+    const ordered = applySharedBranchAdjacency([
+      { id: "a", branch: "feat/a" },
+      { id: "b", branch: "feat/b" },
+    ], keyOf);
+    expect(ordered.map((entry) => entry.item.id)).toEqual(["a", "b"]);
+    expect(ordered.every((entry) => entry.clusterKey === null)).toBe(true);
+  });
+
+  it("does not cluster items whose key is null", () => {
+    const ordered = applySharedBranchAdjacency([
+      { id: "primary-local", branch: null },
+      { id: "work", branch: "feat/x" },
+      { id: "primary-studio", branch: null },
+    ], keyOf);
+    expect(ordered.map((entry) => entry.item.id)).toEqual([
+      "primary-local",
+      "work",
+      "primary-studio",
+    ]);
+  });
+});
+
+describe("inboxIdsKeptForSharedBranch", () => {
+  it("keeps a quiet sibling in the inbox when the other lane is live", () => {
+    const kept = inboxIdsKeptForSharedBranch([
+      { id: "local", clusterKey: "ade/mobile", shelf: null },
+      { id: "studio", clusterKey: "ade/mobile", shelf: "settled" },
+    ]);
+    expect([...kept]).toEqual(["studio"]);
+  });
+
+  it("does not unshelf a cluster that is entirely quiet", () => {
+    const kept = inboxIdsKeptForSharedBranch([
+      { id: "local", clusterKey: "ade/mobile", shelf: "settled" },
+      { id: "studio", clusterKey: "ade/mobile", shelf: "settled" },
+    ]);
+    expect(kept.size).toBe(0);
+  });
+});
+
+describe("consecutiveSharedBranchRuns", () => {
+  it("groups only adjacent clustered items", () => {
+    const runs = consecutiveSharedBranchRuns([
+      { id: "a", clusterKey: "feat" },
+      { id: "b", clusterKey: "feat" },
+      { id: "c", clusterKey: null },
+    ]);
+    expect(runs.map((run) => run.map((item) => item.id))).toEqual([["a", "b"], ["c"]]);
+  });
+});

--- a/apps/desktop/src/renderer/components/terminals/workLaneBranchClusters.ts
+++ b/apps/desktop/src/renderer/components/terminals/workLaneBranchClusters.ts
@@ -1,0 +1,99 @@
+import { branchNameFromLaneRef } from "../../../shared/laneBaseResolution";
+
+/**
+ * Same-branch adjacency for the Work by-lane list.
+ *
+ * The sidebar stays grouped by lane name. The uncommon case — two worktree
+ * lanes on different machines tracking the same feature branch — only tucks
+ * those groups next to each other. Primaries and default trunks are excluded:
+ * every machine has a Primary on `main`, and boxing those would fire constantly.
+ */
+
+const DEFAULT_TRUNK_BRANCHES = new Set(["main", "master"]);
+
+export function sharedBranchClusterKey(args: {
+  branchRef?: string | null;
+  laneType?: string | null;
+}): string | null {
+  if (args.laneType === "primary") return null;
+  const branch = branchNameFromLaneRef(args.branchRef).trim().toLowerCase();
+  if (!branch || DEFAULT_TRUNK_BRANCHES.has(branch)) return null;
+  return branch;
+}
+
+export type SharedBranchShelfItem = {
+  id: string;
+  clusterKey: string | null;
+  shelf: "snoozed" | "settled" | null;
+};
+
+export function inboxIdsKeptForSharedBranch(
+  items: readonly SharedBranchShelfItem[],
+): ReadonlySet<string> {
+  const kept = new Set<string>();
+  const byKey = new Map<string, SharedBranchShelfItem[]>();
+  for (const item of items) {
+    if (!item.clusterKey) continue;
+    const list = byKey.get(item.clusterKey) ?? [];
+    list.push(item);
+    byKey.set(item.clusterKey, list);
+  }
+  for (const group of byKey.values()) {
+    if (group.length < 2) continue;
+    if (!group.some((item) => item.shelf === null)) continue;
+    for (const item of group) {
+      if (item.shelf !== null) kept.add(item.id);
+    }
+  }
+  return kept;
+}
+
+export function applySharedBranchAdjacency<T>(
+  items: readonly T[],
+  getClusterKey: (item: T) => string | null,
+): { item: T; clusterKey: string | null }[] {
+  const counts = new Map<string, number>();
+  for (const item of items) {
+    const key = getClusterKey(item);
+    if (!key) continue;
+    counts.set(key, (counts.get(key) ?? 0) + 1);
+  }
+  const clustered = new Set(
+    [...counts.entries()].filter(([, count]) => count >= 2).map(([key]) => key),
+  );
+  const remaining = [...items];
+  const result: { item: T; clusterKey: string | null }[] = [];
+  while (remaining.length > 0) {
+    const item = remaining.shift();
+    if (item === undefined) break;
+    const key = getClusterKey(item);
+    const clusterKey = key && clustered.has(key) ? key : null;
+    result.push({ item, clusterKey });
+    if (!clusterKey) continue;
+    for (let index = 0; index < remaining.length; ) {
+      const candidate = remaining[index];
+      if (candidate !== undefined && getClusterKey(candidate) === clusterKey) {
+        remaining.splice(index, 1);
+        result.push({ item: candidate, clusterKey });
+      } else {
+        index += 1;
+      }
+    }
+  }
+  return result;
+}
+
+export function consecutiveSharedBranchRuns<T extends { clusterKey: string | null }>(
+  items: readonly T[],
+): T[][] {
+  const runs: T[][] = [];
+  for (const item of items) {
+    const last = runs[runs.length - 1];
+    if (item.clusterKey && last?.[0]?.clusterKey === item.clusterKey) {
+      last.push(item);
+    } else {
+      runs.push([item]);
+    }
+  }
+  return runs;
+}

--- a/docs/features/terminals-and-sessions/README.md
+++ b/docs/features/terminals-and-sessions/README.md
@@ -744,6 +744,12 @@ Renderer surfaces:
   ("Tool context insertion is not available for chats on another machine."),
   because it travels as a DOM window event the chat pane consumes and that
   path carries no machine.
+- `apps/desktop/src/renderer/components/terminals/workLaneBranchClusters.ts` —
+  same-branch adjacency for the Work by-lane list: normalize `branchRef`, skip
+  primaries and `main`/`master`, pull later same-branch lanes (including
+  cross-machine) next to the first, keep a quiet sibling in the inbox when the
+  cluster still has live work, and emit consecutive runs so the pane can wrap
+  two-or-more groups in a dashed hairline.
 - `apps/desktop/src/renderer/components/terminals/SessionListPane.tsx` —
   sidebar list with three organization modes (lane / status / time),
   sticky group headers, search/filter, and two quiet tails: Snoozed and
@@ -794,7 +800,14 @@ Renderer surfaces:
   have sessions, after the same search and lane filter the local list applies, so
   the union stays "work in flight" rather than an inventory of every lane
   everywhere; the empty state accounts for them, so "No sessions" cannot claim an
-  empty machine while another is busy. Foreign lanes use the same active /
+  empty machine while another is busy. The by-lane list still groups by lane
+  name. When two or more non-primary worktree lanes share a feature branch
+  (normalized `branchRef`, excluding `main`/`master`), they are parked next to
+  each other and wrapped in a dashed hairline so the uncommon same-branch /
+  two-machine case is visible without reorganizing the rest of the column. A
+  quiet sibling stays in the inbox when the other lane in that cluster still
+  has live work, instead of filing to Snoozed/Settled alone. Primaries never
+  join a cluster — every machine has one, usually on `main`. Foreign lanes use the same active /
   snoozed / settled partition, collapsed-by-default fully quiet header, quiet
   counts, and nested quiet-tail renderer as local lanes. Their persistence keys
   include the owning machine id (`<machineId>:<laneId>`), and an explicit


### PR DESCRIPTION
## Summary
- In the Work by-lane list, two worktree lanes on the same feature branch (the two-machine case) now sit next to each other inside a dashed cluster.
- Primaries and `main`/`master` stay unclustered. A quiet sibling stays in the inbox when the other lane in that cluster is still live; an entirely quiet pair still shelves together.
- Lane names remain the grouping axis — this is adjacency, not a new organize-by-branch mode.

## Test plan
- [ ] Open Work in by-lane with a local lane and a foreign lane on the same feature branch; confirm they sit together in a dashed box.
- [ ] Confirm two Primaries on `main` are not boxed.
- [ ] Confirm a settled same-branch foreign lane stays next to live local work instead of filing to Settled alone.
- [ ] Confirm two settled same-branch lanes cluster inside the Settled shelf.
- [ ] `cd apps/desktop && npx vitest run src/renderer/components/terminals/workLaneBranchClusters.test.ts src/renderer/components/terminals/SessionListPane.test.tsx`

<!-- ade:link v=1 type=pr repo=arul28/ADE branch=ade%2Fcross-machine-chat-handoff num=1167 -->
<p>
  <img src="https://ade-app.dev/logo.png" height="18" align="left" alt="ADE">
  &nbsp;&nbsp;<strong>Open in ADE</strong>
  &nbsp;·&nbsp; <a href="https://ade-app.dev/open?type=branch&amp;repo=arul28%2FADE&amp;branch=ade%2Fcross-machine-chat-handoff&amp;pr=1167">ade/cross-machine-chat-handoff branch</a>
  &nbsp;·&nbsp; <a href="https://ade-app.dev/open?type=pr&amp;repo=arul28%2FADE&amp;number=1167">PR #1167</a>
</p>
<!-- /ade:link -->
