### PR TITLE
heic-and-chat-drop -> main

### DIFF
--- a/apps/desktop/src/main/services/chat/buildClaudeV2Message.test.ts
+++ b/apps/desktop/src/main/services/chat/buildClaudeV2Message.test.ts
@@ -195,6 +195,20 @@ describe("buildClaudeV2Message", () => {
     });
   });
 
+  it("does not relabel legacy HEIC attachments as PNG", () => {
+    const heicPath = writeFakeImage("legacy-photo.heic");
+    const result = buildClaudeV2Message("Review this photo", [{ path: heicPath, type: "image" }]);
+
+    const msg = result as SDKUserMessagePartial;
+    expect(msg.type).toBe("user");
+    expect(msg.message.content).toHaveLength(2);
+    expect(msg.message.content[1]).toEqual({
+      type: "text",
+      text: `\n[Image attached (image/heic): ${heicPath}]`,
+    });
+    expect((msg.message.content[1] as { text: string }).text).not.toContain("image/png");
+  });
+
   // ─────────────────────────────────────────────────────────────────────────
   // 6. Mixed image and non-image attachments
   // ─────────────────────────────────────────────────────────────────────────
@@ -248,6 +262,8 @@ describe("inferAttachmentMediaType", () => {
     expect(inferAttachmentMediaType({ path: "photo.png", type: "image" })).toBe("image/png");
     expect(inferAttachmentMediaType({ path: "photo.gif", type: "image" })).toBe("image/gif");
     expect(inferAttachmentMediaType({ path: "photo.webp", type: "image" })).toBe("image/webp");
+    expect(inferAttachmentMediaType({ path: "photo.heic", type: "image" })).toBe("image/heic");
+    expect(inferAttachmentMediaType({ path: "photo.heif", type: "image" })).toBe("image/heif");
   });
 
   it("returns correct MIME type for known non-image extensions", () => {
@@ -256,8 +272,9 @@ describe("inferAttachmentMediaType", () => {
     expect(inferAttachmentMediaType({ path: "main.ts", type: "file" })).toBe("text/typescript");
   });
 
-  it("defaults to image/png for unknown extensions on image attachments", () => {
-    expect(inferAttachmentMediaType({ path: "photo.bmp", type: "image" })).toBe("image/png");
+  it("uses the shared image MIME table for otherwise unsupported image extensions", () => {
+    expect(inferAttachmentMediaType({ path: "photo.bmp", type: "image" })).toBe("image/bmp");
+    expect(inferAttachmentMediaType({ path: "photo.tiff", type: "image" })).toBe("image/tiff");
   });
 
   it("defaults to application/octet-stream for unknown extensions on file attachments", () => {
@@ -278,5 +295,7 @@ describe("ANTHROPIC_IMAGE_MEDIA_TYPES", () => {
     expect(ANTHROPIC_IMAGE_MEDIA_TYPES.has("image/svg+xml")).toBe(false);
     expect(ANTHROPIC_IMAGE_MEDIA_TYPES.has("image/bmp")).toBe(false);
     expect(ANTHROPIC_IMAGE_MEDIA_TYPES.has("image/tiff")).toBe(false);
+    expect(ANTHROPIC_IMAGE_MEDIA_TYPES.has("image/heic")).toBe(false);
+    expect(ANTHROPIC_IMAGE_MEDIA_TYPES.has("image/heif")).toBe(false);
   });
 });

--- a/apps/desktop/src/main/services/chat/buildClaudeV2Message.ts
+++ b/apps/desktop/src/main/services/chat/buildClaudeV2Message.ts
@@ -1,6 +1,9 @@
 import fs from "node:fs";
 import path from "node:path";
-import type { AgentChatFileRef } from "../../../shared/types/chat";
+import {
+  getImageAttachmentMediaType,
+  type AgentChatFileRef,
+} from "../../../shared/types/chat";
 import {
   readAgentAccessibleFileBytes,
   readFileWithinRootSecure,
@@ -20,37 +23,30 @@ export const ANTHROPIC_IMAGE_MEDIA_TYPES = new Set([
   "image/webp",
 ]);
 
-/** Extension-to-MIME lookup used by inferAttachmentMediaType. */
+/** Non-image extension-to-MIME lookup used by inferAttachmentMediaType. */
 const ATTACHMENT_MEDIA_TYPES: Record<string, string> = {
   ".c": "text/x-c",
   ".cc": "text/x-c++src",
   ".cpp": "text/x-c++src",
   ".css": "text/css",
   ".csv": "text/csv",
-  ".gif": "image/gif",
   ".go": "text/x-go",
   ".html": "text/html",
-  ".ico": "image/x-icon",
-  ".jpeg": "image/jpeg",
-  ".jpg": "image/jpeg",
   ".js": "text/javascript",
   ".json": "application/json",
   ".jsx": "text/jsx",
   ".md": "text/markdown",
   ".mjs": "text/javascript",
   ".pdf": "application/pdf",
-  ".png": "image/png",
   ".py": "text/x-python",
   ".rb": "text/x-ruby",
   ".rs": "text/x-rustsrc",
   ".sh": "text/x-shellscript",
   ".sql": "application/sql",
-  ".svg": "image/svg+xml",
   ".toml": "application/toml",
   ".ts": "text/typescript",
   ".tsx": "text/tsx",
   ".txt": "text/plain",
-  ".webp": "image/webp",
   ".xml": "application/xml",
   ".yaml": "application/yaml",
   ".yml": "application/yaml",
@@ -59,7 +55,8 @@ const ATTACHMENT_MEDIA_TYPES: Record<string, string> = {
 /** Infer the MIME type of an attachment from its file extension. */
 export function inferAttachmentMediaType(attachment: AgentChatFileRef): string {
   const ext = path.extname(attachment.path).toLowerCase();
-  return ATTACHMENT_MEDIA_TYPES[ext]
+  return getImageAttachmentMediaType(attachment.path)
+    ?? ATTACHMENT_MEDIA_TYPES[ext]
     ?? (attachment.type === "image" ? "image/png" : "application/octet-stream");
 }
 

--- a/apps/desktop/src/main/services/chat/heicAttachmentConverter.test.ts
+++ b/apps/desktop/src/main/services/chat/heicAttachmentConverter.test.ts
@@ -1,0 +1,78 @@
+import fs from "node:fs";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { HeicAttachmentConversionError } from "./heicAttachmentConverter";
+import { convertHeicBufferToJpeg } from "./heicAttachmentConverter";
+
+describe("convertHeicBufferToJpeg", () => {
+  let tempRoot: string;
+
+  beforeEach(async () => {
+    tempRoot = await fs.promises.mkdtemp(path.join(process.cwd(), ".heic-converter-test-"));
+  });
+
+  afterEach(async () => {
+    await fs.promises.rm(tempRoot, { recursive: true, force: true });
+  });
+
+  it("converts HEIC bytes to a JPEG and removes its temporary source files", async () => {
+    const source = Buffer.from("synthetic-heic");
+    const jpeg = Buffer.from([0xFF, 0xD8, 0xFF, 0xD9]);
+    const runSips = vi.fn(async (inputPath: string, outputPath: string) => {
+      await expect(fs.promises.readFile(inputPath)).resolves.toEqual(source);
+      expect(path.basename(inputPath)).toBe("source.heic");
+      expect(path.basename(outputPath)).toBe("converted.jpg");
+      await fs.promises.writeFile(outputPath, jpeg);
+    });
+
+    await expect(convertHeicBufferToJpeg(
+      source,
+      "../IMG_0001.HEIF",
+      "image/heif",
+      { platform: "darwin", tempRoot, runSips },
+    )).resolves.toEqual({
+      data: jpeg,
+      filename: "IMG_0001.jpg",
+      mimeType: "image/jpeg",
+    });
+
+    expect(runSips).toHaveBeenCalledOnce();
+    await expect(fs.promises.readdir(tempRoot)).resolves.toEqual([]);
+  });
+
+  it.each(["win32", "linux"] as const)("fails honestly on %s without the bundled HEIF decoder", async (platform) => {
+    const runSips = vi.fn();
+
+    await expect(convertHeicBufferToJpeg(
+      Buffer.from("synthetic-heic"),
+      "photo.heic",
+      "image/heic",
+      { platform, tempRoot, runSips },
+    )).rejects.toMatchObject({
+      code: "unavailable",
+      name: "HeicAttachmentConversionError",
+    } satisfies Partial<HeicAttachmentConversionError>);
+
+    expect(runSips).not.toHaveBeenCalled();
+    await expect(fs.promises.readdir(tempRoot)).resolves.toEqual([]);
+  });
+
+  it("rejects decoder output that is not a JPEG", async () => {
+    const runSips = vi.fn(async (_inputPath: string, outputPath: string) => {
+      await fs.promises.writeFile(outputPath, "not-an-image");
+    });
+
+    await expect(convertHeicBufferToJpeg(
+      Buffer.from("synthetic-heic"),
+      "photo.heic",
+      undefined,
+      { platform: "darwin", tempRoot, runSips },
+    )).rejects.toMatchObject({
+      code: "failed",
+      name: "HeicAttachmentConversionError",
+    } satisfies Partial<HeicAttachmentConversionError>);
+
+    expect(runSips).toHaveBeenCalledOnce();
+    await expect(fs.promises.readdir(tempRoot)).resolves.toEqual([]);
+  });
+});

--- a/apps/desktop/src/main/services/chat/heicAttachmentConverter.ts
+++ b/apps/desktop/src/main/services/chat/heicAttachmentConverter.ts
@@ -1,0 +1,126 @@
+import { execFile } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { promisify } from "node:util";
+import {
+  isHeicAttachment,
+  type HeicConversionErrorCode,
+} from "../../../shared/types/chat";
+
+const execFileAsync = promisify(execFile);
+const MAX_HEIC_BYTES = 10 * 1024 * 1024;
+const SIPS_TIMEOUT_MS = 30_000;
+
+type RunSips = (inputPath: string, outputPath: string) => Promise<void>;
+
+export type HeicAttachmentConversionResult = {
+  data: Buffer;
+  filename: string;
+  mimeType: "image/jpeg";
+};
+
+export type HeicAttachmentConverterOptions = {
+  platform?: NodeJS.Platform;
+  tempRoot?: string;
+  runSips?: RunSips;
+};
+
+export class HeicAttachmentConversionError extends Error {
+  constructor(readonly code: HeicConversionErrorCode) {
+    super(code);
+    this.name = "HeicAttachmentConversionError";
+  }
+}
+
+async function runSips(inputPath: string, outputPath: string): Promise<void> {
+  await execFileAsync(
+    "/usr/bin/sips",
+    [
+      "-s",
+      "format",
+      "jpeg",
+      "-s",
+      "formatOptions",
+      "90",
+      inputPath,
+      "--out",
+      outputPath,
+    ],
+    {
+      timeout: SIPS_TIMEOUT_MS,
+      maxBuffer: 64 * 1024,
+      windowsHide: true,
+    },
+  );
+}
+
+function safeAttachmentName(filename: string): string {
+  const basename = filename.split(/[\\/]/).pop()?.trim();
+  return basename && basename !== "." && basename !== ".."
+    ? basename.replace(/[\u0000-\u001f\u007f]/g, "_")
+    : "photo.heic";
+}
+
+function jpegFilenameFor(filename: string): string {
+  const basename = safeAttachmentName(filename);
+  const stem = basename.replace(/\.(heic|heif)$/i, "").trim() || "photo";
+  return `${stem}.jpg`;
+}
+
+function looksLikeJpeg(data: Buffer): boolean {
+  return data.length >= 3 && data[0] === 0xFF && data[1] === 0xD8 && data[2] === 0xFF;
+}
+
+/**
+ * Convert a HEIC/HEIF upload into a provider-safe JPEG.
+ *
+ * macOS's bundled `sips` is intentionally the only decoder used here. ADE's
+ * Windows/Linux builds do not ship a HEIF codec, so those platforms fail with
+ * a user-facing conversion instruction instead of pretending the bytes are a
+ * PNG or JPEG. The caller can then keep the existing attachment pipeline for
+ * the returned JPEG, including remote-machine chats.
+ */
+export async function convertHeicBufferToJpeg(
+  content: Buffer,
+  filename: string,
+  mimeType?: string | null,
+  options: HeicAttachmentConverterOptions = {},
+): Promise<HeicAttachmentConversionResult> {
+  if (!isHeicAttachment(filename, mimeType)) {
+    throw new Error("HEIC conversion requires a .heic or .heif image.");
+  }
+  if ((options.platform ?? process.platform) !== "darwin") {
+    throw new HeicAttachmentConversionError("unavailable");
+  }
+  if (content.byteLength > MAX_HEIC_BYTES) {
+    throw new Error("Temporary attachments must be 10 MB or smaller.");
+  }
+
+  const tempDir = await fs.promises.mkdtemp(
+    path.join(options.tempRoot ?? os.tmpdir(), "ade-heic-"),
+  );
+  // Keep the decoder input name fixed so a malicious or unusual renderer
+  // filename can never escape the temporary directory or collide with the
+  // output path. The original name is only used for the returned JPEG name.
+  const inputPath = path.join(tempDir, "source.heic");
+  const outputPath = path.join(tempDir, "converted.jpg");
+
+  try {
+    await fs.promises.writeFile(inputPath, content);
+    await (options.runSips ?? runSips)(inputPath, outputPath);
+    const converted = await fs.promises.readFile(outputPath);
+    if (!converted.byteLength || converted.byteLength > MAX_HEIC_BYTES || !looksLikeJpeg(converted)) {
+      throw new Error("Converted output is not a valid JPEG.");
+    }
+    return {
+      data: converted,
+      filename: jpegFilenameFor(filename),
+      mimeType: "image/jpeg",
+    };
+  } catch {
+    throw new HeicAttachmentConversionError("failed");
+  } finally {
+    await fs.promises.rm(tempDir, { recursive: true, force: true });
+  }
+}

--- a/apps/desktop/src/main/services/ipc/registerIpc.ts
+++ b/apps/desktop/src/main/services/ipc/registerIpc.ts
@@ -54,6 +54,11 @@ import { normalizeAppPackageChannel } from "../../../shared/packageChannel";
 import { findRecentProjectForRepo } from "../projects/repoProjectResolver";
 import { getModelById } from "../../../shared/modelRegistry";
 import { isAgentChatTurnRecoveryAction } from "../../../shared/types/chat";
+import {
+  convertHeicBufferToJpeg,
+  HeicAttachmentConversionError,
+} from "../chat/heicAttachmentConverter";
+import type { ConvertImageToJpegResult } from "../../../shared/types/chat";
 import { appendEvent as perfAppend, isRunActive as isPerfRunActive } from "../perf/perfLog";
 import { buildPrAiResolutionContextKey, isAdeUsageRangePreset, isAdeUsageScope } from "../../../shared/types";
 import { detectCliAuthStatuses } from "../ai/authDetector";
@@ -3878,6 +3883,49 @@ export function registerIpc({
       mimeType: "image/png",
     };
   });
+
+  ipcMain.handle(
+    IPC.appConvertImageToJpeg,
+    async (
+      event,
+      arg: { data?: string; filename?: string; mimeType?: string | null },
+    ): Promise<ConvertImageToJpegResult> => {
+      assertTrustedAppControlSender(event, IPC.appConvertImageToJpeg);
+      if (typeof arg?.data !== "string" || !arg.data.length) {
+        throw new Error("Image data is required.");
+      }
+      const filename = typeof arg.filename === "string" && arg.filename.trim()
+        ? arg.filename
+        : "photo.heic";
+      const maxEncodedLength = Math.ceil(MAX_TEMP_ATTACHMENT_BYTES / 3) * 4;
+      if (arg.data.length > maxEncodedLength) {
+        throw new Error("Temporary attachments must be 10 MB or smaller.");
+      }
+      const content = Buffer.from(arg.data, "base64");
+      if (content.byteLength > MAX_TEMP_ATTACHMENT_BYTES) {
+        throw new Error("Temporary attachments must be 10 MB or smaller.");
+      }
+      try {
+        const converted = await convertHeicBufferToJpeg(
+          content,
+          filename,
+          arg.mimeType,
+          { tempRoot: app.getPath("temp") },
+        );
+        return {
+          ok: true,
+          data: converted.data.toString("base64"),
+          filename: converted.filename,
+          mimeType: converted.mimeType,
+        };
+      } catch (error) {
+        if (error instanceof HeicAttachmentConversionError) {
+          return { ok: false, errorCode: error.code };
+        }
+        throw error;
+      }
+    },
+  );
 
   ipcMain.handle(IPC.appSaveClipboardImageAttachment, async (): Promise<{ path: string; mimeType: string; previewDataUrl: string | null } | null> => {
     const image = clipboard.readImage();

--- a/apps/desktop/src/preload/global.d.ts
+++ b/apps/desktop/src/preload/global.d.ts
@@ -726,6 +726,7 @@ import type {
   SearchRebuildResult,
 } from "../shared/types";
 import type { GitHubIssueLike } from "../shared/laneGitHubIssue";
+import type { ConvertImageToJpegResult } from "../shared/types/chat";
 import type { DiskPressureSnapshot } from "../main/services/storage/diskPressure";
 import type {
   MaintenanceRunReport,
@@ -841,6 +842,12 @@ declare global {
           filename: string;
           mimeType: string;
         } | null>;
+        /** Convert a HEIC/HEIF upload locally before it is sent to any runtime. */
+        convertImageToJpeg?: (args: {
+          data: string;
+          filename: string;
+          mimeType?: string | null;
+        }) => Promise<ConvertImageToJpegResult>;
         saveClipboardImageAttachment: () => Promise<{
           path: string;
           mimeType: string;

--- a/apps/desktop/src/preload/preload.ts
+++ b/apps/desktop/src/preload/preload.ts
@@ -5,6 +5,7 @@ import { projectBindingKey } from "../shared/projectIdentity";
 import { isSyncServiceUnavailableError } from "../shared/runtimeErrors";
 import { resolvePackageChannelFromProcess } from "../shared/packageChannel";
 import { EXTERNAL_FILES_WORKSPACE_ID_PREFIX } from "../shared/types/files";
+import type { ConvertImageToJpegResult } from "../shared/types/chat";
 import {
   type AttentionAcknowledgmentOutcome,
   type AttentionItem,
@@ -3899,6 +3900,12 @@ const adeBridge = {
       filename: string;
       mimeType: string;
     } | null> => ipcRenderer.invoke(IPC.appReadClipboardImage),
+    convertImageToJpeg: async (args: {
+      data: string;
+      filename: string;
+      mimeType?: string | null;
+    }): Promise<ConvertImageToJpegResult> =>
+      ipcRenderer.invoke(IPC.appConvertImageToJpeg, args),
     saveClipboardImageAttachment: async (): Promise<{
       path: string;
       mimeType: string;

--- a/apps/desktop/src/renderer/components/chat/AgentChatComposer.test.tsx
+++ b/apps/desktop/src/renderer/components/chat/AgentChatComposer.test.tsx
@@ -9,7 +9,10 @@ import type {
   OpenProjectBinding,
 } from "../../../shared/types";
 import { THIS_MACHINE_NAME } from "../../../shared/machineIdentity";
-import { AgentChatComposer } from "./AgentChatComposer";
+import {
+  AgentChatComposer,
+  HEIC_CONVERSION_UNAVAILABLE_MESSAGE,
+} from "./AgentChatComposer";
 import { useAppStore } from "../../state/appStore";
 import { formatChatOutputContextBlock } from "../../../shared/chatOutputContext";
 
@@ -2918,6 +2921,97 @@ describe("AgentChatComposer", () => {
 
     await waitFor(() => expect(screen.queryByText("Drop files to attach")).toBeNull());
     expect(dropEvent.defaultPrevented).toBe(true);
+    expect(props.onAddAttachment).not.toHaveBeenCalled();
+  });
+
+  it.each(["heic", "HEIF"])("accepts a .%s image URL drop", (extension) => {
+    const props = renderComposer({
+      turnActive: false,
+      draft: "",
+    });
+    const imageUrl = `https://example.com/photos/IMG_0001.${extension}`;
+    const dataTransfer = {
+      files: [],
+      types: ["text/uri-list"],
+      getData: vi.fn((type: string) => (type === "text/uri-list" ? imageUrl : "")),
+    };
+    fireEvent.drop(screen.getByPlaceholderText("Type to vibecode..."), { dataTransfer });
+
+    expect(props.onAddAttachment).toHaveBeenCalledWith({
+      path: imageUrl,
+      type: "image-url",
+      url: imageUrl,
+    });
+    expect(props.onAddAttachment).toHaveBeenCalledTimes(1);
+    expect(dataTransfer.getData).toHaveBeenCalledWith("text/uri-list");
+  });
+
+  it("converts HEIC uploads to JPEG before saving the attachment", async () => {
+    const convertImageToJpeg = vi.fn().mockResolvedValue({
+      ok: true,
+      data: "/9j/converted",
+      filename: "IMG_0001.jpg",
+      mimeType: "image/jpeg",
+    });
+    const saveTempAttachment = vi.fn().mockResolvedValue({
+      path: "/tmp/ade-IMG_0001.jpg",
+    });
+    (window as any).ade = {
+      app: { convertImageToJpeg },
+      agentChat: { saveTempAttachment },
+    };
+    const props = renderComposer({ turnActive: false, draft: "" });
+    const file = new File([new Uint8Array([1, 2, 3])], "IMG_0001.HEIC", { type: "" });
+    Object.defineProperty(file, "arrayBuffer", {
+      configurable: true,
+      value: vi.fn(async () => new Uint8Array([1, 2, 3]).buffer),
+    });
+    const dataTransfer = {
+      files: [file],
+      types: ["Files"],
+      getData: vi.fn(() => ""),
+    };
+
+    fireEvent.drop(screen.getByPlaceholderText("Type to vibecode..."), { dataTransfer });
+
+    await waitFor(() => expect(convertImageToJpeg).toHaveBeenCalledWith({
+      data: "AQID",
+      filename: "IMG_0001.HEIC",
+      mimeType: null,
+    }));
+    await waitFor(() => expect(saveTempAttachment).toHaveBeenCalledWith({
+      data: "/9j/converted",
+      filename: "IMG_0001.jpg",
+    }, null));
+    expect(props.onAddAttachment).toHaveBeenCalledWith({
+      path: "/tmp/ade-IMG_0001.jpg",
+      type: "image",
+    });
+  });
+
+  it("explains the Windows-style no-codec fallback instead of attaching HEIC bytes as an image", async () => {
+    const convertImageToJpeg = vi.fn().mockResolvedValue({ ok: false, errorCode: "unavailable" });
+    const saveTempAttachment = vi.fn();
+    (window as any).ade = {
+      app: { convertImageToJpeg },
+      agentChat: { saveTempAttachment },
+    };
+    const props = renderComposer({ turnActive: false, draft: "" });
+    const file = new File([new Uint8Array([1, 2, 3])], "IMG_0002.heic", { type: "image/heic" });
+    Object.defineProperty(file, "arrayBuffer", {
+      configurable: true,
+      value: vi.fn(async () => new Uint8Array([1, 2, 3]).buffer),
+    });
+    const dataTransfer = {
+      files: [file],
+      types: ["Files"],
+      getData: vi.fn(() => ""),
+    };
+
+    fireEvent.drop(screen.getByPlaceholderText("Type to vibecode..."), { dataTransfer });
+
+    expect(await screen.findByText(HEIC_CONVERSION_UNAVAILABLE_MESSAGE)).toBeTruthy();
+    expect(saveTempAttachment).not.toHaveBeenCalled();
     expect(props.onAddAttachment).not.toHaveBeenCalled();
   });
 

--- a/apps/desktop/src/renderer/components/chat/AgentChatComposer.test.tsx
+++ b/apps/desktop/src/renderer/components/chat/AgentChatComposer.test.tsx
@@ -2924,6 +2924,28 @@ describe("AgentChatComposer", () => {
     expect(props.onAddAttachment).not.toHaveBeenCalled();
   });
 
+  it("accepts a file dragover before the browser exposes its file list", () => {
+    renderComposer({
+      turnActive: false,
+      draft: "",
+    });
+    const dataTransfer = {
+      files: [],
+      types: ["Files"],
+      getData: vi.fn(() => ""),
+    };
+    const dragOverEvent = new Event("dragover", { bubbles: true, cancelable: true });
+    Object.defineProperty(dragOverEvent, "dataTransfer", {
+      configurable: true,
+      value: dataTransfer,
+    });
+
+    fireEvent(screen.getByPlaceholderText("Type to vibecode..."), dragOverEvent);
+
+    expect(dragOverEvent.defaultPrevented).toBe(true);
+    expect(screen.getByText("Drop files to attach")).toBeTruthy();
+  });
+
   it.each(["heic", "HEIF"])("accepts a .%s image URL drop", (extension) => {
     const props = renderComposer({
       turnActive: false,

--- a/apps/desktop/src/renderer/components/chat/AgentChatComposer.tsx
+++ b/apps/desktop/src/renderer/components/chat/AgentChatComposer.tsx
@@ -4549,7 +4549,8 @@ export function AgentChatComposer({
   const handleDragOver = (event: React.DragEvent<HTMLDivElement>) => {
     event.stopPropagation();
     const hasImageUrl = event.dataTransfer.types.includes("text/uri-list");
-    if (!canAttach || (!event.dataTransfer.files.length && !hasImageUrl)) return;
+    const hasFiles = event.dataTransfer.files.length > 0 || event.dataTransfer.types.includes("Files");
+    if (!canAttach || (!hasFiles && !hasImageUrl)) return;
     event.preventDefault();
     setDragActive(true);
   };

--- a/apps/desktop/src/renderer/components/chat/AgentChatComposer.tsx
+++ b/apps/desktop/src/renderer/components/chat/AgentChatComposer.tsx
@@ -66,6 +66,9 @@ import {
   activeTurnDispatchModes,
   activeTurnInterruptContinues,
   defaultActiveTurnDispatchMode,
+  type HeicConversionErrorCode,
+  isImageAttachmentPath,
+  isHeicAttachment,
   type ActiveTurnSendMode,
 } from "../../../shared/types/chat";
 import { cn } from "../ui/cn";
@@ -126,6 +129,8 @@ import {
 } from "./ComposerPromptStash";
 import { settingsRouteFor } from "../settings/settingsManifest";
 import type { AgentChatPromptHistoryEntry } from "./chatPromptHistory";
+import { ChatAttachmentDropOverlay } from "./ChatAttachmentDropOverlay";
+import type { AgentChatAttachmentDropTarget } from "./chatAttachmentDropTarget";
 
 const MAX_TEMP_ATTACHMENT_BYTES = 10 * 1024 * 1024;
 const CLIPBOARD_IMAGE_PASTE_FALLBACK_DELAY_MS = 80;
@@ -135,7 +140,28 @@ const BASE64_ENCODE_CHUNK_SIZE = 0x8000;
 const ISSUE_CONTEXT_MENU_WIDTH = 180;
 const ISSUE_CONTEXT_MENU_GAP = 8;
 const ISSUE_CONTEXT_MENU_VIEWPORT_GUTTER = 8;
-const IMAGE_URL_EXTENSION_RE = /\.(png|jpe?g|gif|webp|bmp|svg|ico|tiff?)$/i;
+export const HEIC_CONVERSION_UNAVAILABLE_MESSAGE =
+  "HEIC photos can't be converted on this computer. Convert the photo to JPEG before attaching it.";
+export const HEIC_CONVERSION_FAILED_MESSAGE =
+  "This HEIC photo couldn't be converted to JPEG. It may be corrupt or unsupported.";
+const HEIC_CONVERSION_MESSAGES: Record<HeicConversionErrorCode, string> = {
+  unavailable: HEIC_CONVERSION_UNAVAILABLE_MESSAGE,
+  failed: HEIC_CONVERSION_FAILED_MESSAGE,
+};
+
+class AttachmentConversionError extends Error {
+  constructor(readonly code: HeicConversionErrorCode) {
+    super(code);
+    this.name = "AttachmentConversionError";
+  }
+}
+
+function attachmentErrorMessage(error: unknown, filename: string): string {
+  if (error instanceof AttachmentConversionError) {
+    return HEIC_CONVERSION_MESSAGES[error.code];
+  }
+  return `Unable to attach "${filename || "file"}".`;
+}
 
 // Every rich-composer chip carries `data-composer-chip`. Chips are
 // contentEditable="false", so the browser skips them when painting the native
@@ -298,7 +324,7 @@ function normalizeImageAttachmentUrl(value: string | null | undefined): string |
   try {
     const parsed = new URL(raw);
     if (parsed.protocol !== "http:" && parsed.protocol !== "https:") return null;
-    if (!IMAGE_URL_EXTENSION_RE.test(parsed.pathname)) return null;
+    if (!isImageAttachmentPath(parsed.pathname)) return null;
     return parsed.toString();
   } catch {
     return null;
@@ -1606,6 +1632,7 @@ export function AgentChatComposer({
   onInterrupt,
   onApproval,
   onAddAttachment,
+  onRegisterDropTarget,
   onRemoveAttachment,
   onAddContextAttachment,
   onRemoveContextAttachment,
@@ -1769,6 +1796,8 @@ export function AgentChatComposer({
     answers?: Record<string, string | string[]>,
   ) => void;
   onAddAttachment: (attachment: AgentChatFileRef) => void;
+  /** Register this composer's attachment pipeline with its larger chat shell. */
+  onRegisterDropTarget?: (target: AgentChatAttachmentDropTarget | null) => void;
   onRemoveAttachment: (path: string) => void;
   onAddContextAttachment?: (attachment: AgentChatContextAttachment) => void;
   onRemoveContextAttachment?: (key: string) => void;
@@ -2044,6 +2073,7 @@ export function AgentChatComposer({
   const lastSerializedDraftRef = useRef<string>("");
   const lastPlainSelectionRef = useRef<number | null>(null);
   const fileAddInProgressRef = useRef(false);
+  const addFileAttachmentsRef = useRef<(files: FileList | File[] | null | undefined) => void>(() => {});
   const latestComposerMachineBindingRef = useRef(composerMachineBinding);
   latestComposerMachineBindingRef.current = composerMachineBinding;
   // Catalog bucket for every model-derived control in this composer (picker
@@ -2558,6 +2588,10 @@ export function AgentChatComposer({
       setAttachError(attachmentPersistenceUnavailableReason);
       return;
     }
+    if (!canAttach) {
+      setAttachError(attachBlockedReason ?? "Attachments are unavailable right now.");
+      return;
+    }
     if (!files?.length) return;
     if (parallelChatMode && attachmentSlotsUsed >= PARALLEL_CHAT_MAX_ATTACHMENTS) return;
     if (fileAddInProgressRef.current) return;
@@ -2571,8 +2605,9 @@ export function AgentChatComposer({
           setAttachError(`You can attach up to ${PARALLEL_CHAT_MAX_ATTACHMENTS} files for parallel launch.`);
           break;
         }
-        const attachmentName = file.name || "clipboard.png";
-        const isImageAttachment = inferAttachmentType(attachmentName, file.type) === "image";
+        const sourceAttachmentName = file.name || "clipboard.png";
+        const isHeicUpload = isHeicAttachment(sourceAttachmentName, file.type);
+        const isImageAttachment = inferAttachmentType(sourceAttachmentName, file.type) === "image";
 
         if (file.size > MAX_TEMP_ATTACHMENT_BYTES) {
           setAttachError(
@@ -2582,44 +2617,72 @@ export function AgentChatComposer({
         }
 
         const pendingImage = isImageAttachment
-          ? addPendingImageAttachment(attachmentName, createObjectPreviewUrl(file))
+          ? addPendingImageAttachment(sourceAttachmentName, isHeicUpload ? null : createObjectPreviewUrl(file))
           : null;
         const attachmentOwnerBinding = composerMachineBinding;
         try {
           const buf = await file.arrayBuffer();
-          const base64 = arrayBufferToBase64(buf);
+          let attachmentName = sourceAttachmentName;
+          let attachmentData = arrayBufferToBase64(buf);
+          let attachmentMimeType: string | null = file.type || null;
+          let convertedPreviewDataUrl: string | null = null;
+          if (isHeicUpload) {
+            const convertImageToJpeg = window.ade?.app?.convertImageToJpeg;
+            if (typeof convertImageToJpeg !== "function") {
+              throw new AttachmentConversionError("unavailable");
+            }
+            const converted = await convertImageToJpeg({
+              data: attachmentData,
+              filename: sourceAttachmentName,
+              mimeType: file.type || null,
+            });
+            if (converted.ok !== true) {
+              throw new AttachmentConversionError(
+                converted.errorCode === "unavailable" ? "unavailable" : "failed",
+              );
+            }
+            attachmentName = converted.filename;
+            attachmentData = converted.data;
+            attachmentMimeType = converted.mimeType;
+            convertedPreviewDataUrl = `data:${converted.mimeType};base64,${converted.data}`;
+          }
           const { path: tempPath } = await window.ade.agentChat.saveTempAttachment({
-            data: base64,
+            data: attachmentData,
             filename: attachmentName,
           }, attachmentOwnerBinding);
           if (latestComposerMachineBindingRef.current?.key !== attachmentOwnerBinding?.key) {
             if (pendingImage) dropPendingImageAttachment(pendingImage.id);
-            setAttachError(`"${attachmentName}" was not attached because the selected machine changed. Attach it again.`);
+            setAttachError(`"${sourceAttachmentName}" was not attached because the selected machine changed. Attach it again.`);
             continue;
           }
           if (pendingImage && cancelledPendingImageAttachmentsRef.current.has(pendingImage.id)) {
             cancelledPendingImageAttachmentsRef.current.delete(pendingImage.id);
             continue;
           }
-          const attachmentType = inferAttachmentType(tempPath, file.type);
+          const attachmentType = inferAttachmentType(tempPath, attachmentMimeType);
           const pendingPreviewUrl = pendingImage?.previewUrl ?? null;
-          if (attachmentType === "image" && pendingPreviewUrl) {
-            rememberPreviewUrl(tempPath, pendingPreviewUrl);
+          if (attachmentType === "image") {
+            if (convertedPreviewDataUrl) {
+              rememberPreviewUrl(tempPath, convertedPreviewDataUrl);
+            } else if (pendingPreviewUrl) {
+              rememberPreviewUrl(tempPath, pendingPreviewUrl);
+            }
           }
           onAddAttachment({ path: tempPath, type: attachmentType });
           if (pendingImage) {
             dropPendingImageAttachment(pendingImage.id);
           }
           addedInBatch += 1;
-        } catch {
+        } catch (error) {
           if (pendingImage) dropPendingImageAttachment(pendingImage.id);
-          setAttachError(`Unable to attach "${file.name || "clipboard"}".`);
+          setAttachError(attachmentErrorMessage(error, sourceAttachmentName));
         }
       }
     } finally {
       fileAddInProgressRef.current = false;
     }
   };
+  addFileAttachmentsRef.current = addFileAttachments;
 
   const addNativeClipboardImageAttachment = async () => {
     if (attachmentPersistenceUnavailableReason) {
@@ -2687,6 +2750,32 @@ export function AgentChatComposer({
     }
     return attached;
   }, [addImageUrlAttachment]);
+
+  const canAttachRef = useRef(canAttach);
+  canAttachRef.current = canAttach;
+  const addImageUrlFromTransferRef = useRef(addImageUrlFromTransfer);
+  addImageUrlFromTransferRef.current = addImageUrlFromTransfer;
+  const attachmentDropTarget = useMemo<AgentChatAttachmentDropTarget>(() => ({
+    canHandle: (dataTransfer) => canAttachRef.current
+      && (
+        dataTransfer.files.length > 0
+        || dataTransfer.types.includes("Files")
+        || dataTransfer.types.includes("text/uri-list")
+    ),
+    handle: (dataTransfer) => {
+      if (!canAttachRef.current) return;
+      if (dataTransfer.files.length > 0) {
+        void addFileAttachmentsRef.current(dataTransfer.files);
+        return;
+      }
+      addImageUrlFromTransferRef.current(dataTransfer);
+    },
+  }), []);
+
+  useEffect(() => {
+    onRegisterDropTarget?.(attachmentDropTarget);
+    return () => onRegisterDropTarget?.(null);
+  }, [attachmentDropTarget, onRegisterDropTarget]);
 
   const captureRichSelection = useCallback(() => {
     const editor = richEditorRef.current;
@@ -4458,6 +4547,7 @@ export function AgentChatComposer({
   };
 
   const handleDragOver = (event: React.DragEvent<HTMLDivElement>) => {
+    event.stopPropagation();
     const hasImageUrl = event.dataTransfer.types.includes("text/uri-list");
     if (!canAttach || (!event.dataTransfer.files.length && !hasImageUrl)) return;
     event.preventDefault();
@@ -4465,11 +4555,13 @@ export function AgentChatComposer({
   };
 
   const handleDragLeave = (event: React.DragEvent<HTMLDivElement>) => {
+    event.stopPropagation();
     if (event.currentTarget.contains(event.relatedTarget as Node | null)) return;
     setDragActive(false);
   };
 
   const handleDrop = (event: React.DragEvent<HTMLDivElement>) => {
+    event.stopPropagation();
     setDragActive(false);
     const hasFiles = event.dataTransfer.files.length > 0;
     const hasUriList = event.dataTransfer.types.includes("text/uri-list");
@@ -5961,17 +6053,8 @@ export function AgentChatComposer({
         onDrop={handleDrop}
       >
         {dragActive ? (
-          <div className="pointer-events-none absolute inset-0 z-[1] flex items-center justify-center bg-[color:color-mix(in_srgb,var(--chat-accent)_12%,rgba(5,5,8,0.58))] backdrop-blur-sm">
-            <div className="rounded-[var(--chat-radius-card)] border border-[color:color-mix(in_srgb,var(--chat-accent)_32%,transparent)] bg-card/92 px-5 py-4 text-center shadow-[var(--chat-composer-shadow)]">
-              <div className="font-mono text-[length:calc(var(--chat-font-size)*10/14)] uppercase tracking-[0.18em] text-[var(--chat-accent)]">
-                Drop files to attach
-              </div>
-              <div className="mt-1 text-[length:calc(var(--chat-font-size)*12/14)] text-fg/74">
-                {parallelChatMode
-                  ? `Up to ${PARALLEL_CHAT_MAX_ATTACHMENTS} files, sent to every parallel lane.`
-                  : "Images and files will be added to this turn."}
-              </div>
-            </div>
+          <div className="pointer-events-none absolute inset-0 z-[1]">
+            <ChatAttachmentDropOverlay variant="composer" parallelChatMode={parallelChatMode} />
           </div>
         ) : null}
 
@@ -6213,4 +6296,3 @@ export function AgentChatComposer({
     </>
   );
 }
-

--- a/apps/desktop/src/renderer/components/chat/AgentChatPane.test.tsx
+++ b/apps/desktop/src/renderer/components/chat/AgentChatPane.test.tsx
@@ -3355,10 +3355,8 @@ describe("AgentChatPane submit recovery", () => {
 
     renderTabbedPane(session);
 
-    await waitFor(() => {
-      expect(screen.queryByLabelText("Agent working")).toBeNull();
-    });
-    expect(screen.getByLabelText("Ready for next prompt")).toBeTruthy();
+    expect(await screen.findByLabelText("Ready for next prompt")).toBeTruthy();
+    expect(screen.queryByLabelText("Agent working")).toBeNull();
   });
 
   it("keeps the draft cleared after send succeeds even if session refresh fails", async () => {

--- a/apps/desktop/src/renderer/components/chat/AgentChatPane.test.tsx
+++ b/apps/desktop/src/renderer/components/chat/AgentChatPane.test.tsx
@@ -1139,6 +1139,70 @@ function seedRemoteChatStore() {
   return rootPath;
 }
 
+describe("AgentChatPane attachment drop target", () => {
+  it("routes a file dropped on the chat header through the composer pipeline", async () => {
+    const session = buildSession("session-drop");
+    const mocks = installAdeMocks({ sessions: [session] });
+    seedDrawerStore();
+    const { container } = renderPane(session);
+
+    const shellHeader = await waitFor(() => {
+      const header = container.querySelector<HTMLElement>(".ade-chat-shell-header");
+      if (!header) throw new Error("chat header not rendered");
+      return header;
+    });
+    const file = new File([new Uint8Array([1, 2, 3])], "design.png", { type: "image/png" });
+    Object.defineProperty(file, "arrayBuffer", {
+      configurable: true,
+      value: vi.fn(async () => new Uint8Array([1, 2, 3]).buffer),
+    });
+    const dataTransfer = {
+      files: [file],
+      types: ["Files"],
+      getData: vi.fn(() => ""),
+    };
+
+    fireEvent.dragOver(shellHeader, { dataTransfer });
+    expect(screen.getByText("Drop files to attach")).toBeTruthy();
+
+    fireEvent.drop(shellHeader, { dataTransfer });
+
+    await waitFor(() => expect(mocks.saveTempAttachment).toHaveBeenCalledWith({
+      data: "AQID",
+      filename: "design.png",
+    }, LOCAL_PROJECT_BINDING));
+    expect(screen.queryByText("Drop files to attach")).toBeNull();
+  });
+
+  it("does not duplicate a drop already handled by the composer", async () => {
+    const session = buildSession("session-drop-composer");
+    const mocks = installAdeMocks({ sessions: [session] });
+    seedDrawerStore();
+    renderPane(session);
+
+    const composerDropTarget = await waitFor(() => screen.getByPlaceholderText("Type to vibecode..."));
+    const file = new File([new Uint8Array([4, 5, 6])], "composer-drop.txt", { type: "text/plain" });
+    Object.defineProperty(file, "arrayBuffer", {
+      configurable: true,
+      value: vi.fn(async () => new Uint8Array([4, 5, 6]).buffer),
+    });
+    const dataTransfer = {
+      files: [file],
+      types: ["Files"],
+      getData: vi.fn(() => ""),
+    };
+
+    fireEvent.drop(composerDropTarget, { dataTransfer });
+
+    await waitFor(() => expect(mocks.saveTempAttachment).toHaveBeenCalledWith({
+      data: "BAUG",
+      filename: "composer-drop.txt",
+    }, LOCAL_PROJECT_BINDING));
+    expect(mocks.saveTempAttachment).toHaveBeenCalledTimes(1);
+    expect(screen.queryByText("Drop files to attach")).toBeNull();
+  });
+});
+
 function renderDrawerPane() {
   const session = buildSession("session-1", { title: "Drawer audit chat" });
   installAdeMocks({ sessions: [session] });

--- a/apps/desktop/src/renderer/components/chat/AgentChatPane.tsx
+++ b/apps/desktop/src/renderer/components/chat/AgentChatPane.tsx
@@ -111,7 +111,12 @@ import {
 import { filterChatModelIdsForSession } from "../../../shared/chatModelSwitching";
 import { CURSOR_AVAILABLE_MODE_IDS } from "../../../shared/cursorModes";
 import { cn } from "../ui/cn";
-import { AgentChatComposer, type ParallelComposerControlSlot } from "./AgentChatComposer";
+import {
+  AgentChatComposer,
+  type ParallelComposerControlSlot,
+} from "./AgentChatComposer";
+import { ChatAttachmentDropOverlay } from "./ChatAttachmentDropOverlay";
+import type { AgentChatAttachmentDropTarget } from "./chatAttachmentDropTarget";
 import { collectAgentChatPromptHistory, type AgentChatPromptHistoryEntry } from "./chatPromptHistory";
 import { ChatLifecycleBanner } from "./ChatLifecycleBanner";
 import { ChatSubagentTakeoverBanner } from "./ChatSubagentTakeoverBanner";
@@ -3551,6 +3556,33 @@ export function AgentChatPane({
       : null,
   );
   const [attachments, setAttachments] = useState<AgentChatFileRef[]>([]);
+  const chatPaneDropTargetRef = useRef<AgentChatAttachmentDropTarget | null>(null);
+  const [chatPaneDropActive, setChatPaneDropActive] = useState(false);
+  const clearChatPaneDropActive = useCallback(() => setChatPaneDropActive(false), []);
+  const registerChatPaneDropTarget = useCallback((target: AgentChatAttachmentDropTarget | null) => {
+    chatPaneDropTargetRef.current = target;
+  }, []);
+  const handleChatPaneDragOver = useCallback((event: React.DragEvent<HTMLElement>) => {
+    const dropTarget = chatPaneDropTargetRef.current;
+    if (!dropTarget?.canHandle(event.dataTransfer)) {
+      setChatPaneDropActive(false);
+      return;
+    }
+    event.preventDefault();
+    event.dataTransfer.dropEffect = "copy";
+    setChatPaneDropActive(true);
+  }, []);
+  const handleChatPaneDragLeave = useCallback((event: React.DragEvent<HTMLElement>) => {
+    if (event.currentTarget.contains(event.relatedTarget as Node | null)) return;
+    setChatPaneDropActive(false);
+  }, []);
+  const handleChatPaneDrop = useCallback((event: React.DragEvent<HTMLElement>) => {
+    const dropTarget = chatPaneDropTargetRef.current;
+    setChatPaneDropActive(false);
+    if (!dropTarget?.canHandle(event.dataTransfer)) return;
+    event.preventDefault();
+    dropTarget.handle(event.dataTransfer);
+  }, []);
   const draftAttachmentOwnerBindingRef = useRef<OpenProjectBinding | null>(null);
   const [contextAttachments, setContextAttachments] = useState<AgentChatContextAttachment[]>([]);
   const [sdkSlashCommands, setSdkSlashCommands] = useState<import("../../../shared/types").AgentChatSlashCommand[]>([]);
@@ -13117,6 +13149,7 @@ export function AgentChatPane({
               void approve(decision, responseText, answers);
             }}
             onAddAttachment={addAttachment}
+            onRegisterDropTarget={registerChatPaneDropTarget}
             onRemoveAttachment={removeAttachment}
             onAddContextAttachment={addContextAttachment}
             onRemoveContextAttachment={removeContextAttachment}
@@ -13629,6 +13662,12 @@ export function AgentChatPane({
         footer={isEmptyState || appPanelOpen
           ? undefined
           : composerWithTypographyRoot}
+        onDragOver={handleChatPaneDragOver}
+        onDragOverCapture={clearChatPaneDropActive}
+        onDragLeave={handleChatPaneDragLeave}
+        onDrop={handleChatPaneDrop}
+        onDropCapture={clearChatPaneDropActive}
+        dropOverlay={chatPaneDropActive ? <ChatAttachmentDropOverlay variant="pane" /> : undefined}
         footerClassName={compactShell ? "px-0 pb-0 pt-0" : undefined}
         bodyClassName="flex min-h-0 flex-col overflow-hidden"
       >

--- a/apps/desktop/src/renderer/components/chat/ChatAttachmentDropOverlay.tsx
+++ b/apps/desktop/src/renderer/components/chat/ChatAttachmentDropOverlay.tsx
@@ -1,0 +1,42 @@
+import { cn } from "../ui/cn";
+import { PARALLEL_CHAT_MAX_ATTACHMENTS } from "../../../shared/types/chat";
+
+export function ChatAttachmentDropOverlay({
+  variant,
+  parallelChatMode = false,
+}: {
+  variant: "composer" | "pane";
+  parallelChatMode?: boolean;
+}) {
+  const compact = variant === "composer";
+  return (
+    <div className={cn(
+      "flex h-full w-full items-center justify-center bg-[color:color-mix(in_srgb,var(--chat-accent)_10%,rgba(5,5,8,0.58))] backdrop-blur-sm",
+      compact && "bg-[color:color-mix(in_srgb,var(--chat-accent)_12%,rgba(5,5,8,0.58))]",
+    )}>
+      <div className={cn(
+        "rounded-[var(--chat-radius-card)] border border-[color:color-mix(in_srgb,var(--chat-accent)_34%,transparent)] bg-card/92 text-center shadow-[var(--chat-composer-shadow)]",
+        compact ? "px-5 py-4" : "px-6 py-5",
+      )}>
+        <div className={cn(
+          "font-mono uppercase tracking-[0.18em] text-[var(--chat-accent)]",
+          compact
+            ? "text-[length:calc(var(--chat-font-size)*10/14)]"
+            : "text-[length:calc(var(--chat-font-size)*11/14)]",
+        )}>
+          Drop files to attach
+        </div>
+        <div className={cn(
+          "mt-1 text-fg/74",
+          compact
+            ? "text-[length:calc(var(--chat-font-size)*12/14)]"
+            : "font-sans text-[length:calc(var(--chat-font-size)*12/14)]",
+        )}>
+          {compact && parallelChatMode
+            ? `Up to ${PARALLEL_CHAT_MAX_ATTACHMENTS} files, sent to every parallel lane.`
+            : "Images and files will be added to this turn."}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/desktop/src/renderer/components/chat/ChatSurfaceShell.tsx
+++ b/apps/desktop/src/renderer/components/chat/ChatSurfaceShell.tsx
@@ -1,4 +1,4 @@
-import type { CSSProperties, ReactNode, Ref } from "react";
+import type { CSSProperties, DragEventHandler, ReactNode, Ref } from "react";
 import type { ChatChromeTint, ChatShellGeometry } from "../../state/appStore";
 import type { ChatSurfaceMode } from "../../../shared/types";
 import { cn } from "../ui/cn";
@@ -29,6 +29,12 @@ export function ChatSurfaceShell({
   autoHeight = false,
   paneReserveLeft = "0px",
   paneReserveRight = "0px",
+  dropOverlay,
+  onDragOverCapture,
+  onDropCapture,
+  onDragOver,
+  onDragLeave,
+  onDrop,
 }: {
   mode: ChatSurfaceMode;
   accentColor?: string | null;
@@ -47,6 +53,13 @@ export function ChatSurfaceShell({
   /** Horizontal space the chat reserves for open floating side panes (CSS length). */
   paneReserveLeft?: string;
   paneReserveRight?: string;
+  /** Optional whole-surface drag/drop hooks for hosts such as Work Chat. */
+  dropOverlay?: ReactNode;
+  onDragOverCapture?: DragEventHandler<HTMLElement>;
+  onDropCapture?: DragEventHandler<HTMLElement>;
+  onDragOver?: DragEventHandler<HTMLElement>;
+  onDragLeave?: DragEventHandler<HTMLElement>;
+  onDrop?: DragEventHandler<HTMLElement>;
 }) {
   const scale = Number.isFinite(contentScale) && contentScale > 0 ? contentScale : 1;
   const scaled = Math.abs(scale - 1) > 0.001;
@@ -113,6 +126,11 @@ export function ChatSurfaceShell({
           ["--chat-pane-reserve-left" as string]: paneReserveLeft,
           ["--chat-pane-reserve-right" as string]: paneReserveRight,
         } as CSSProperties}
+        onDragOverCapture={onDragOverCapture}
+        onDropCapture={onDropCapture}
+        onDragOver={onDragOver}
+        onDragLeave={onDragLeave}
+        onDrop={onDrop}
       >
         {scaled ? (
           <div className="flex min-h-0 min-w-0 max-w-full flex-1 flex-col overflow-hidden" style={scaleWrapperStyle}>
@@ -121,6 +139,11 @@ export function ChatSurfaceShell({
         ) : (
           inner
         )}
+        {dropOverlay ? (
+          <div className="pointer-events-none absolute inset-0 z-50">
+            {dropOverlay}
+          </div>
+        ) : null}
       </section>
     </ChatChromeTintContext.Provider>
   );

--- a/apps/desktop/src/renderer/components/chat/chatAttachmentDropTarget.ts
+++ b/apps/desktop/src/renderer/components/chat/chatAttachmentDropTarget.ts
@@ -1,0 +1,4 @@
+export type AgentChatAttachmentDropTarget = {
+  canHandle: (dataTransfer: DataTransfer) => boolean;
+  handle: (dataTransfer: DataTransfer) => void;
+};

--- a/apps/desktop/src/shared/ipc.ts
+++ b/apps/desktop/src/shared/ipc.ts
@@ -36,6 +36,7 @@ export const IPC = {
   appReadClipboardText: "ade.app.readClipboardText",
   appHasClipboardImage: "ade.app.hasClipboardImage",
   appReadClipboardImage: "ade.app.readClipboardImage",
+  appConvertImageToJpeg: "ade.app.convertImageToJpeg",
   appSaveClipboardImageAttachment: "ade.app.saveClipboardImageAttachment",
   appGetImageDataUrl: "ade.app.getImageDataUrl",
   appWriteClipboardImage: "ade.app.writeClipboardImage",

--- a/apps/desktop/src/shared/types/chat.test.ts
+++ b/apps/desktop/src/shared/types/chat.test.ts
@@ -4,6 +4,7 @@ import {
   activeTurnInterruptContinues,
   defaultActiveTurnDispatchMode,
   inferAttachmentType,
+  isHeicAttachment,
   mergeAttachments,
   providerSupportsCrossMachineHandoffFork,
   providerSupportsHandoffFork,
@@ -74,6 +75,7 @@ describe("inferAttachmentType", () => {
     expect(inferAttachmentType("file.bin", "image/jpeg")).toBe("image");
     expect(inferAttachmentType("file.bin", "image/webp")).toBe("image");
     expect(inferAttachmentType("file.bin", "image/svg+xml")).toBe("image");
+    expect(inferAttachmentType("file.bin", "IMAGE/HEIC")).toBe("image");
   });
 
   it("returns 'image' for image file extensions when no mimeType is provided", () => {
@@ -88,6 +90,8 @@ describe("inferAttachmentType", () => {
     expect(inferAttachmentType("photo.ico")).toBe("image");
     expect(inferAttachmentType("photo.tiff")).toBe("image");
     expect(inferAttachmentType("photo.tif")).toBe("image");
+    expect(inferAttachmentType("photo.heic")).toBe("image");
+    expect(inferAttachmentType("photo.HEIF")).toBe("image");
   });
 
   it("returns 'file' for non-image extensions and no image mimeType", () => {
@@ -114,6 +118,15 @@ describe("inferAttachmentType", () => {
     expect(inferAttachmentType("file.ts", null)).toBe("file");
     expect(inferAttachmentType("photo.jpg", null)).toBe("image");
     expect(inferAttachmentType("file.ts", undefined)).toBe("file");
+  });
+
+  it("recognizes HEIC/HEIF by either MIME type or extension", () => {
+    expect(isHeicAttachment("photo.heic")).toBe(true);
+    expect(isHeicAttachment("photo.HEIF")).toBe(true);
+    expect(isHeicAttachment("photo.bin", "image/heic")).toBe(true);
+    expect(isHeicAttachment("photo.bin", "image/heic; codecs=hevc")).toBe(true);
+    expect(isHeicAttachment("photo.bin", "image/heif-sequence")).toBe(true);
+    expect(isHeicAttachment("photo.jpg", "image/jpeg")).toBe(false);
   });
 });
 

--- a/apps/desktop/src/shared/types/chat.ts
+++ b/apps/desktop/src/shared/types/chat.ts
@@ -350,6 +350,45 @@ export type AgentChatImageUrlRef = {
 
 export type AgentChatFileRef = AgentChatLocalFileRef | AgentChatImageUrlRef;
 
+/** MIME/extension checks for photos from iPhone and other HEIF-producing cameras. */
+const HEIC_MIME_RE = /^image\/hei[cf](?:[-+;]|$)/i;
+const HEIC_EXTENSION_RE = /\.(heic|heif)$/i;
+
+export type HeicConversionErrorCode = "unavailable" | "failed";
+
+export type ConvertImageToJpegResult =
+  | { ok: true; data: string; filename: string; mimeType: "image/jpeg" }
+  | { ok: false; errorCode: HeicConversionErrorCode };
+
+const IMAGE_ATTACHMENT_MEDIA_TYPES: Readonly<Record<string, string>> = {
+  ".bmp": "image/bmp",
+  ".gif": "image/gif",
+  ".heic": "image/heic",
+  ".heif": "image/heif",
+  ".ico": "image/x-icon",
+  ".jpeg": "image/jpeg",
+  ".jpg": "image/jpeg",
+  ".png": "image/png",
+  ".svg": "image/svg+xml",
+  ".tif": "image/tiff",
+  ".tiff": "image/tiff",
+  ".webp": "image/webp",
+};
+
+/** Return the MIME type for a supported image filename/path, if its suffix is known. */
+export function getImageAttachmentMediaType(filePath: string): string | null {
+  const extension = filePath.match(/\.[^./\\]+$/)?.[0]?.toLowerCase();
+  return extension ? IMAGE_ATTACHMENT_MEDIA_TYPES[extension] ?? null : null;
+}
+
+export function isImageAttachmentPath(filePath: string): boolean {
+  return getImageAttachmentMediaType(filePath) !== null;
+}
+
+export function isHeicAttachment(filePath: string, mimeType?: string | null): boolean {
+  return HEIC_MIME_RE.test(mimeType ?? "") || HEIC_EXTENSION_RE.test(filePath);
+}
+
 export type AgentChatLinearIssueContextAttachment = {
   type: "linear_issue";
   issue: LaneLinearIssue;
@@ -391,8 +430,8 @@ export function inferAttachmentType(
   filePath: string,
   mimeType?: string | null,
 ): AgentChatLocalFileRef["type"] {
-  if (mimeType?.startsWith("image/")) return "image";
-  return /\.(png|jpe?g|gif|webp|bmp|svg|ico|tiff?)$/i.test(filePath) ? "image" : "file";
+  if (mimeType?.toLowerCase().startsWith("image/")) return "image";
+  return isImageAttachmentPath(filePath) ? "image" : "file";
 }
 
 /** Merge two attachment lists, deduplicating by path (last-write wins). */

--- a/docs/features/chat/composer-and-ui.md
+++ b/docs/features/chat/composer-and-ui.md
@@ -293,13 +293,19 @@ that could not work without it.
   enclosing `AgentChatPane` reports `isTileActive: true` (for packed
   grid tiles) or any equivalent active state — typing in the grid
   immediately targets the focused tile's composer.
-- **Attachments** via drag-drop, paste, and an inline picker. Pasted and
-  dropped image files show a pending thumbnail while ADE writes the
-  temp attachment. Electron clipboard images use
+- **Attachments** via drag-drop in the composer or anywhere in the selected
+  chat surface, paste, and an inline picker. Pasted and dropped image files
+  show a pending thumbnail while ADE writes the temp attachment. Electron
+  clipboard images use
   `ade.app.saveClipboardImageAttachment` when available so the main
   process can save the PNG and return a small preview without sending
   the full base64 payload through the renderer; the legacy
   `ade.agentChat.saveTempAttachment` path remains as the fallback.
+  On macOS, `.heic` and `.heif` file drops are converted to JPEG through
+  the main-process image bridge before the temp attachment is saved, so
+  the preview and provider payload use the converted bytes. Windows and
+  Linux do not bundle a HEIF codec; those drops stay out of the attachment
+  list and show a clear instruction to convert the photo to JPEG first.
   Temp images keep the 10 MB cap and provider-specific MIME validation.
 - **Issue context.** The composer attach menu (~180px, opaque, Linear and GitHub rows, no subtitle) opens `LinearIssueSelectModal` or `GitHubIssueSelectModal`. GitHub is offered only when `detectRepo()` returns this project's repository; personal chats hide GitHub and still allow Linear. Each attachment is a `linear_issue` or `github_issue` context item built by `makeLinearIssueContextAttachment` / `makeGitHubIssueContextAttachment` from `chatContextAttachments.ts`. Sending the turn persists the issue on the chat session (`attachLinearIssueToSession` / `attachGitHubIssueToSession`); mixed Linear + GitHub attachments are allowed. GitHub PRs are not attachable. Clicking a chip reopens the same pane in details mode (Open + Remove). On send, the composer chip moves onto that user message. TUI `/issue attach ADE-123|owner/repo#42|#42` (slash-only on Windows) attaches without a picker. iOS **Attach issue** in the chat overflow menu reuses the Linear pane in attach mode when `lane.attachLinearIssueToSession` is advertised. PR bodies get Linear `Refs ADE-123` (`closeOnMerge: false`) and GitHub `Closes owner/repo#42` (`closeOnMerge: true`) — see [features/linear-integration/README.md](../linear-integration/README.md).
 - **Typed triggers anywhere.** `detectComposerTrigger(text, cursorPos)`
@@ -819,7 +825,10 @@ allowing a cross-provider fork.
 
 ### Attachment handling
 
-- Pasted and dropped images are written to a temp location. File-backed
+- Pasted and dropped images are written to a temp location. The selected
+  chat surface (header, transcript, and composer) accepts the same file and
+  image-URL drops as the composer and routes them through one attachment
+  pipeline, while composer-owned drops are handled only once. File-backed
   renderer payloads use `ade.agentChat.saveTempAttachment`; native
   clipboard images prefer `ade.app.saveClipboardImageAttachment`, which
   reads the Electron clipboard, writes the PNG beside other chat
@@ -839,8 +848,10 @@ allowing a cross-provider fork.
 - `inferAttachmentType` and `mergeAttachments` in `shared/types/chat.ts`
   dedupe attachments by path (last-write wins).
 - MIME-type validation happens per provider. Claude enforces
-  `image/jpeg | image/png | image/gif | image/webp`; Codex uses local
-  path references; OpenCode uses runtime content blocks.
+  `image/jpeg | image/png | image/gif | image/webp`; macOS HEIC/HEIF
+  uploads are normalized to JPEG before that boundary, while Windows/Linux
+  report the missing codec instead of relabeling HEIC bytes. Codex uses
+  local path references; OpenCode uses runtime content blocks.
 - Parallel launches reuse this same attachment path after the renderer
   validates the 12-file cap. Every child session receives identical
   attachment refs; provider-specific handling still happens inside


### PR DESCRIPTION


<!-- ade:link v=1 type=pr repo=arul28/ADE branch=ade%2Fheic-and-chat-drop-4a9dfb5e num=1170 -->
<p>
  <img src="https://ade-app.dev/logo.png" height="18" align="left" alt="ADE">
  &nbsp;&nbsp;<strong>Open in ADE</strong>
  &nbsp;·&nbsp; <a href="https://ade-app.dev/open?type=branch&amp;repo=arul28%2FADE&amp;branch=ade%2Fheic-and-chat-drop-4a9dfb5e&amp;pr=1170">ade/heic-and-chat-drop-4a9dfb5e branch</a>
  &nbsp;·&nbsp; <a href="https://ade-app.dev/open?type=pr&amp;repo=arul28%2FADE&amp;number=1170">PR #1170</a>
</p>
<!-- /ade:link -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New main-process subprocess (`sips`), temp-file handling, and IPC for binary image data add platform-specific behavior; attachment MIME inference changes affect how non-Anthropic-supported formats are described to the model.
> 
> **Overview**
> Adds **HEIC/HEIF photo handling** for chat attachments: on macOS, dropped or picked `.heic`/`.heif` files are converted to JPEG in the main process (`sips`) via a new `convertImageToJpeg` IPC bridge before temp save, so previews and provider payloads use real JPEG bytes. On Windows and Linux, conversion is refused with a clear user message instead of attaching mislabeled image data.
> 
> **Shared attachment typing** in `shared/types/chat` centralizes image extension/MIME detection (`getImageAttachmentMediaType`, `isHeicAttachment`, `isImageAttachmentPath`); Claude message building uses that table so legacy HEIC paths are labeled `image/heic` rather than defaulting to PNG.
> 
> **Drag-and-drop** is extended so the whole selected chat surface (header/transcript/composer) can accept the same file and image-URL drops as the composer, routed through one pipeline via `onRegisterDropTarget` and a shared `ChatAttachmentDropOverlay`; composer drops are not duplicated when handled locally.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2fbc1992da4c8ee799ce3e8469b915e9390378db. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->