### PR TITLE
work-search-and-palette -> main

### DIFF
--- a/apps/ade-cli/src/tuiClient/__tests__/commands.test.ts
+++ b/apps/ade-cli/src/tuiClient/__tests__/commands.test.ts
@@ -20,6 +20,16 @@ describe("commands", () => {
     expect(paletteCommands("/attention")).toEqual([]);
   });
 
+  it("matches all palette words in any order", () => {
+    expect(paletteCommands("chat new")).toContainEqual(expect.objectContaining({
+      name: "/new chat",
+      description: "Create a new chat in the current lane",
+    }));
+    expect(paletteCommands("new chat")).toContainEqual(expect.objectContaining({
+      name: "/new chat",
+    }));
+  });
+
   it("parses multi-word ADE commands before generic slash commands", () => {
     const parsed = parseCommand("/linear pull ADE-123");
     expect(parsed?.name).toBe("/linear pull");

--- a/apps/ade-cli/src/tuiClient/app.tsx
+++ b/apps/ade-cli/src/tuiClient/app.tsx
@@ -161,6 +161,10 @@ import { aggregateChatBlocks, derivePendingSteers, type AggregatedBlock } from "
 import { deriveChatInfoSnapshot, mergeSubagentSnapshots, snapshotFromRuntimeSubagent } from "./chatInfo";
 import { BUILTIN_COMMANDS, paletteCommands, parseCommand } from "./commands";
 import {
+  parseWorkSearchQuery,
+  scoreWorkSearchTerms,
+} from "../../../desktop/src/shared/workSearch";
+import {
   resolveSessionTarget,
   resolveSnoozeChoice,
   resolveSnoozeChoices,
@@ -972,19 +976,8 @@ export function firstUrlInText(value: string): { url: string; index: number; wid
 }
 
 function paletteMatchScore(item: CommandPaletteItem, query: string): number | null {
-  const trimmed = query.trim().toLowerCase();
-  if (!trimmed) return 0;
-  const haystack = `${item.label} ${item.detail}`.toLowerCase();
-  if (haystack.includes(trimmed)) return haystack.indexOf(trimmed);
-  let cursor = 0;
-  let score = 0;
-  for (const char of trimmed) {
-    const found = haystack.indexOf(char, cursor);
-    if (found < 0) return null;
-    score += found - cursor;
-    cursor = found + 1;
-  }
-  return score + haystack.length;
+  const terms = parseWorkSearchQuery(query).terms;
+  return scoreWorkSearchTerms(terms, [item.label, item.detail]);
 }
 
 // Collapse a multi-line search snippet into a single trimmed detail line and cap

--- a/apps/ade-cli/src/tuiClient/commands.ts
+++ b/apps/ade-cli/src/tuiClient/commands.ts
@@ -4,6 +4,11 @@ import {
   type AgentChatProvider,
   type AgentChatSlashCommand,
 } from "../../../desktop/src/shared/types/chat";
+import {
+  matchesWorkSearchTerms,
+  parseWorkSearchQuery,
+  scoreWorkSearchTerms,
+} from "../../../desktop/src/shared/workSearch";
 
 /**
  * Providers whose backend accepts this atomic active-turn dispatch mode, read
@@ -341,17 +346,25 @@ export function paletteCommands(
     byName.set(key, command);
   }
   const merged = [...byName.values()];
-  const filtered = !queryToken
-    ? merged
-    : merged.filter((command) => `${command.name} ${command.description}`.toLowerCase().includes(queryToken));
-  // Rank: name-prefix matches first, then name-substring, then description matches, then alphabetical.
+  const queryTerms = parseWorkSearchQuery(queryToken).terms;
+  const filtered = queryTerms.length === 0
+      ? merged
+      : merged.filter((command) => {
+          return matchesWorkSearchTerms(queryTerms, [command.name, command.description]);
+        });
+  // Rank: for one word retain the familiar name-prefix order; for multiple
+  // words sum each word's position so reversed queries rank just as naturally.
   filtered.sort((a, b) => {
-    if (queryToken) {
+    if (queryTerms.length === 1) {
       const aName = a.name.toLowerCase();
       const bName = b.name.toLowerCase();
       const aPrefix = aName.startsWith(`/${queryToken}`) ? 0 : aName.includes(queryToken) ? 1 : 2;
       const bPrefix = bName.startsWith(`/${queryToken}`) ? 0 : bName.includes(queryToken) ? 1 : 2;
       if (aPrefix !== bPrefix) return aPrefix - bPrefix;
+    } else if (queryTerms.length > 1) {
+      const aScore = scoreWorkSearchTerms(queryTerms, [a.name, a.description]) ?? Number.MAX_SAFE_INTEGER;
+      const bScore = scoreWorkSearchTerms(queryTerms, [b.name, b.description]) ?? Number.MAX_SAFE_INTEGER;
+      if (aScore !== bScore) return aScore - bScore;
     }
     return a.name.localeCompare(b.name);
   });

--- a/apps/desktop/src/renderer/components/app/CommandPalette.test.tsx
+++ b/apps/desktop/src/renderer/components/app/CommandPalette.test.tsx
@@ -845,7 +845,8 @@ describe("CommandPalette", () => {
           matchRanges: [{ start: 4, end: 10 }],
           laneId: "lane-1",
           laneName: "redesign",
-          sessionId: "session-claude",
+          // Missing ownership metadata must not bypass the local provider facet.
+          sessionId: null,
           deepLink: "ade://work/session/session-claude?event=1",
           updatedAt: new Date().toISOString(),
         }],
@@ -950,6 +951,37 @@ describe("CommandPalette", () => {
         });
         expect(onOpenChange).toHaveBeenCalledWith(false);
       });
+    });
+
+    it("does not leave a draft when switching to a new-chat target fails", async () => {
+      const switchRemoteProject = vi.fn(async () => {
+        throw new Error("remote target unavailable");
+      });
+      const onOpenChange = vi.fn();
+      seedStore({
+        switchRemoteProject,
+        sessionsCacheByProject: { [PROJECT_ROOT]: [] },
+        workViewByProject: {},
+        crossMachineLanesByMachineId: {
+          "target-studio": makeForeignMachine(),
+        },
+      });
+
+      render(
+        <MemoryRouter initialEntries={["/lanes"]}>
+          <LocationProbe />
+          <CommandPalette open onOpenChange={onOpenChange} />
+        </MemoryRouter>,
+      );
+
+      fireEvent.click(
+        await screen.findByRole("button", { name: "New chat in release" }),
+      );
+
+      await waitFor(() => expect(switchRemoteProject).toHaveBeenCalled());
+      expect(useAppStore.getState().workViewByProject[REMOTE_BINDING.key]).toBeUndefined();
+      expect(screen.getByTestId("location").textContent).toBe("/lanes");
+      expect(onOpenChange).not.toHaveBeenCalledWith(false);
     });
 
     it("renders the status indicator from the shared tone classes", async () => {

--- a/apps/desktop/src/renderer/components/app/CommandPalette.test.tsx
+++ b/apps/desktop/src/renderer/components/app/CommandPalette.test.tsx
@@ -48,6 +48,7 @@ function seedStore(overrides: Record<string, unknown> = {}) {
     },
     lanes: [],
     selectedLaneId: null,
+    projectBinding: null,
     selectLane: vi.fn(),
     switchProjectToPath: vi.fn(async () => {}),
     // Reset explicitly: `setState` merges, so a thread test's sessions would
@@ -734,6 +735,223 @@ describe("CommandPalette", () => {
       expect(screen.queryByText("Alpha")).toBeNull();
     });
 
+    it("matches title words in any order", async () => {
+      seedThreads([
+        makeSession({ id: "session-auth-migration", title: "auth migration" }),
+        makeSession({ id: "session-migration-only", title: "migration cleanup" }),
+      ]);
+
+      render(
+        <MemoryRouter>
+          <CommandPalette open onOpenChange={vi.fn()} />
+        </MemoryRouter>,
+      );
+
+      fireEvent.change(
+        screen.getByPlaceholderText("Search commands, projects, and threads…"),
+        { target: { value: "migration auth" } },
+      );
+
+      await waitFor(() => {
+        expect(document.querySelector('[data-thread-id="session-auth-migration"]')).toBeTruthy();
+      });
+      expect(document.querySelector('[data-thread-id="session-migration-only"]')).toBeNull();
+      expect(screen.getByText("Match: title")).toBeTruthy();
+    });
+
+    it("promotes a transcript hit into the matching Work row", async () => {
+      const query = vi.fn(async () => ({
+        results: [{
+          kind: "chat" as const,
+          id: "chat:session-1:event-1",
+          title: "Keep this chat",
+          snippet: "The rename request is in the transcript.",
+          matchRanges: [{ start: 4, end: 10 }],
+          laneId: "lane-1",
+          laneName: "redesign",
+          sessionId: "session-1",
+          deepLink: "ade://work/session/session-1?event=1",
+          updatedAt: new Date().toISOString(),
+        }],
+        totalByKind: { chat: 1 },
+        nextCursor: null,
+      }));
+      globalThis.window.ade.search = { query } as any;
+      seedThreads([makeSession({ title: "Keep this chat" })]);
+
+      render(
+        <MemoryRouter>
+          <CommandPalette open onOpenChange={vi.fn()} />
+        </MemoryRouter>,
+      );
+
+      fireEvent.change(
+        screen.getByPlaceholderText("Search commands, projects, and threads…"),
+        { target: { value: "rename" } },
+      );
+
+      expect(await screen.findByText("Keep this chat")).toBeTruthy();
+      expect(document.querySelector('[data-thread-id="session-1"]')?.textContent).toContain("rename request");
+      expect(screen.getByText("Match: chat content")).toBeTruthy();
+      expect(query).toHaveBeenCalledWith({ query: "rename", limit: 60 });
+    });
+
+    it("queries each lane when a Work lane facet has multiple values", async () => {
+      const query = vi.fn(async () => ({
+        results: [],
+        totalByKind: {},
+        nextCursor: null,
+      }));
+      globalThis.window.ade.search = { query } as any;
+      seedThreads(
+        [makeSession({ title: "auth migration" })],
+        {
+          lanes: [
+            makeLane({ name: "auth" }),
+            makeLane({ id: "lane-2", name: "payments" }),
+          ],
+        },
+      );
+
+      render(
+        <MemoryRouter>
+          <CommandPalette open onOpenChange={vi.fn()} />
+        </MemoryRouter>,
+      );
+
+      fireEvent.change(
+        screen.getByPlaceholderText("Search commands, projects, and threads…"),
+        { target: { value: "lane:auth lane:payments auth" } },
+      );
+
+      await waitFor(() => expect(query).toHaveBeenCalledTimes(2));
+      expect(query).toHaveBeenNthCalledWith(1, {
+        query: "auth lane:auth",
+        limit: 60,
+      });
+      expect(query).toHaveBeenNthCalledWith(2, {
+        query: "auth lane:payments",
+        limit: 60,
+      });
+    });
+
+    it("does not let a transcript hit bypass a Work facet", async () => {
+      const query = vi.fn(async () => ({
+        results: [{
+          kind: "chat" as const,
+          id: "chat:session-claude:event-1",
+          title: "Claude chat",
+          snippet: "The rename request is in the transcript.",
+          matchRanges: [{ start: 4, end: 10 }],
+          laneId: "lane-1",
+          laneName: "redesign",
+          sessionId: "session-claude",
+          deepLink: "ade://work/session/session-claude?event=1",
+          updatedAt: new Date().toISOString(),
+        }],
+        totalByKind: { chat: 1 },
+        nextCursor: null,
+      }));
+      globalThis.window.ade.search = { query } as any;
+      seedThreads([
+        makeSession({ id: "session-codex", title: "Codex chat", toolType: "codex-chat" }),
+        makeSession({ id: "session-claude", title: "Claude chat", toolType: "claude-chat" }),
+      ]);
+
+      render(
+        <MemoryRouter>
+          <CommandPalette open onOpenChange={vi.fn()} />
+        </MemoryRouter>,
+      );
+
+      fireEvent.change(
+        screen.getByPlaceholderText("Search commands, projects, and threads…"),
+        { target: { value: "provider:codex rename" } },
+      );
+
+      await waitFor(() => expect(query).toHaveBeenCalled());
+      expect(document.querySelector('[data-thread-id="session-claude"]')).toBeNull();
+      expect(screen.queryByText("Claude chat")).toBeNull();
+      expect(screen.queryByText("The rename request is in the transcript.")).toBeNull();
+    });
+
+    it("filters Work results with provider aliases and exposes the chip", async () => {
+      seedThreads([
+        makeSession({ id: "session-codex", title: "auth migration", toolType: "codex-chat" }),
+        makeSession({ id: "session-claude", title: "auth migration", toolType: "claude-chat" }),
+      ]);
+
+      render(
+        <MemoryRouter>
+          <CommandPalette open onOpenChange={vi.fn()} />
+        </MemoryRouter>,
+      );
+
+      fireEvent.change(
+        screen.getByPlaceholderText("Search commands, projects, and threads…"),
+        { target: { value: "provider:codex auth" } },
+      );
+
+      expect(await screen.findByTestId("thread-status-session-codex")).toBeTruthy();
+      expect(screen.queryByTestId("thread-status-session-claude")).toBeNull();
+      expect(screen.getByRole("button", { name: /Remove provider filter codex/i })).toBeTruthy();
+    });
+
+    it("shows lifecycle actions on the highlighted Work result and targets that session", async () => {
+      const settle = vi.fn(async () => {});
+      globalThis.window.ade.sessions = { settle } as any;
+      const onOpenChange = vi.fn();
+      seedThreads([makeSession({
+        id: "session-to-settle",
+        title: "Settle this chat",
+        status: "completed",
+        runtimeState: "exited",
+        exitCode: 0,
+        endedAt: new Date().toISOString(),
+      })]);
+
+      render(
+        <MemoryRouter>
+          <CommandPalette open onOpenChange={onOpenChange} />
+        </MemoryRouter>,
+      );
+
+      fireEvent.click(await screen.findByRole("button", { name: "Settle session" }));
+
+      await waitFor(() => {
+        expect(settle).toHaveBeenCalledWith("session-to-settle", undefined);
+        expect(onOpenChange).toHaveBeenCalledWith(false);
+      });
+    });
+
+    it("persists a new-chat draft before navigating when Work is not mounted", async () => {
+      const onOpenChange = vi.fn();
+      seedThreads([makeSession({ title: "Start a follow-up chat" })]);
+
+      render(
+        <MemoryRouter initialEntries={["/lanes"]}>
+          <LocationProbe />
+          <CommandPalette open onOpenChange={onOpenChange} />
+        </MemoryRouter>,
+      );
+
+      fireEvent.click(
+        await screen.findByRole("button", { name: "New chat in redesign" }),
+      );
+
+      await waitFor(() => {
+        expect(screen.getByTestId("location").textContent).toBe("/work");
+        expect(useAppStore.getState().workViewByProject[PROJECT_ROOT]).toMatchObject({
+          draftKind: "chat",
+          draftLaneId: "lane-1",
+          draftMachineId: null,
+          activeItemId: null,
+          selectedItemId: null,
+        });
+        expect(onOpenChange).toHaveBeenCalledWith(false);
+      });
+    });
+
     it("renders the status indicator from the shared tone classes", async () => {
       seedThreads([makeSession()]);
 
@@ -1147,6 +1365,51 @@ describe("CommandPalette", () => {
         });
         expect(row.dataset.dimmed).toBe("true");
         expect(row.querySelector("[data-machine-marker-mode]")).toBeTruthy();
+      });
+
+      it("keeps the active remote binding on row actions", async () => {
+        const boundKey = "remote:target-studio:project-a";
+        const settle = vi.fn(async () => {});
+        globalThis.window.ade.sessions = { settle } as any;
+        seedStore({
+          projectBinding: {
+            ...REMOTE_BINDING,
+            key: boundKey,
+            projectId: "project-a",
+            rootPath: PROJECT_ROOT,
+          },
+          lanes: [makeLane()],
+          sessionsCacheByProject: {
+            [boundKey]: [makeSession({
+              id: "remote-session-to-settle",
+              title: "Remote completed chat",
+              status: "completed",
+              runtimeState: "exited",
+              endedAt: new Date().toISOString(),
+            })],
+          },
+          workViewByProject: { [boundKey]: { activeItemId: null } },
+        });
+
+        render(
+          <MemoryRouter>
+            <CommandPalette open onOpenChange={vi.fn()} />
+          </MemoryRouter>,
+        );
+
+        fireEvent.click(await screen.findByRole("button", { name: "Settle session" }));
+
+        await waitFor(() => {
+          expect(settle).toHaveBeenCalledWith(
+            "remote-session-to-settle",
+            undefined,
+            expect.objectContaining({
+              kind: "remote",
+              targetId: "target-studio",
+              projectId: "project-a",
+            }),
+          );
+        });
       });
     });
   });

--- a/apps/desktop/src/renderer/components/app/CommandPalette.tsx
+++ b/apps/desktop/src/renderer/components/app/CommandPalette.tsx
@@ -1329,11 +1329,14 @@ export function CommandPalette({
 
   const clearWorkFilters = useCallback(() => {
     setQ((current) => {
-      const parsed = parseWorkSearchQuery(current);
-      return parsed.filterTokens.reduce(
-        (next, token) => removeWorkSearchFilterToken(next, token),
-        current,
-      );
+      let next = current;
+      while (true) {
+        const token = parseWorkSearchQuery(next).filterTokens[0];
+        if (!token) return next;
+        const updated = removeWorkSearchFilterToken(next, token);
+        if (updated === next) return next;
+        next = updated;
+      }
     });
     setSelectedIdx(0);
   }, []);

--- a/apps/desktop/src/renderer/components/app/CommandPalette.tsx
+++ b/apps/desktop/src/renderer/components/app/CommandPalette.tsx
@@ -37,6 +37,15 @@ import type { SearchResultItem } from "../../../shared/types/search";
 import { parseDeeplink } from "../../../shared/deeplinks";
 import { extractError } from "../../lib/format";
 import { requestLinearIssueQuickView } from "../../lib/linearIssueQuickViewNavigation";
+import { isChatToolType } from "../../lib/sessions";
+import {
+  appendWorkSearchFilter,
+  parseWorkSearchQuery,
+  removeWorkSearchFilterToken,
+  WORK_SEARCH_FILTER_KEYS,
+  type WorkSearchFilterKey,
+} from "../../../shared/workSearch";
+import { sessionFilingBucket } from "../../lib/terminalAttention";
 import {
   ENTITY_SECTION_PREVIEW,
   SearchResultRow,
@@ -52,6 +61,12 @@ import {
   useThreadIndex,
   type ThreadIndexEntry,
 } from "./commandPaletteThreads";
+import {
+  buildWorkResults,
+  WorkFilterBar,
+  useWorkSessionActions,
+  type WorkFilterMenuKey,
+} from "./commandPaletteWork";
 import { fadeScale } from "../../lib/motion";
 import { isMacPlatform, modifierKeyLabel } from "../../lib/platform";
 import { PROJECT_BROWSER_CLOSE_EVENT } from "../../lib/projectBrowserEvents";
@@ -223,7 +238,9 @@ function readLastBrowsePathMap(): Record<string, string> {
     const parsed = JSON.parse(raw) as unknown;
     if (!parsed || typeof parsed !== "object") return {};
     const out: Record<string, string> = {};
-    for (const [key, value] of Object.entries(parsed as Record<string, unknown>)) {
+    for (const [key, value] of Object.entries(
+      parsed as Record<string, unknown>,
+    )) {
       if (typeof value === "string") out[key] = value;
     }
     return out;
@@ -292,6 +309,7 @@ export function CommandPalette({
   const project = useAppStore((s) => s.project);
   const projectBinding = useAppStore((s) => s.projectBinding);
   const selectLane = useAppStore((s) => s.selectLane);
+  const setWorkViewState = useAppStore((s) => s.setWorkViewState);
   const switchProjectToPath = useAppStore((s) => s.switchProjectToPath);
   const switchRemoteProject = useAppStore((s) => s.switchRemoteProject);
   // The palette lists settings, so it has to agree with the settings page about
@@ -336,23 +354,29 @@ export function CommandPalette({
   // also *starts* the cross-machine sync and fires a `project.listRecent` on
   // mount, and the palette is mounted for the whole session. Whatever the Work
   // tab's sync has populated is what we search.
-  const foreignMachines = useRootAppStore((s) => s.crossMachineLanesByMachineId);
+  const foreignMachines = useRootAppStore(
+    (s) => s.crossMachineLanesByMachineId,
+  );
   /**
    * Which machine owns the tab's own sessions and lanes. Remote-bound tabs make
    * that another Mac, and without saying so those threads look local: unmarked
    * in the results, and unfindable by their machine's name.
    *
-   * Memoized on the two primitives rather than on `projectBinding`, which is a
-   * fresh object across store writes and would rebuild the whole lowercased
-   * thread index on every one.
+   * The binding is carried into active rows as well: remote row actions must
+   * address the owning machine, not the renderer's local default.
    */
-  const boundTargetId = projectBinding?.kind === "remote" ? projectBinding.targetId : null;
-  const boundRuntimeName = projectBinding?.kind === "remote" ? projectBinding.runtimeName : null;
+  const boundTargetId =
+    projectBinding?.kind === "remote" ? projectBinding.targetId : null;
+  const boundRuntimeName =
+    projectBinding?.kind === "remote" ? projectBinding.runtimeName : null;
 
   const [mode, setMode] = useState<CommandPaletteMode>("default");
   const [actionOutcome, setActionOutcome] =
     useState<ProjectActionOutcome | null>(null);
   const [q, setQ] = useState("");
+  const [filterMenuKey, setFilterMenuKey] = useState<WorkFilterMenuKey | null>(
+    null,
+  );
   const [selectedIdx, setSelectedIdx] = useState(0);
   const [browseInput, setBrowseInput] = useState(
     defaultBrowseInput(project?.rootPath),
@@ -382,22 +406,20 @@ export function CommandPalette({
     },
     [],
   );
-  const activeMachine = useMemo(
-    () => {
-      if (!boundTargetId || !boundRuntimeName) return null;
-      const connection = remoteSnapshot?.connections.find(
-        (candidate) => candidate.target.id === boundTargetId,
-      );
-      return {
-        machineId: boundTargetId,
-        machineName: boundRuntimeName,
-        // A remote-bound tab has no local fallback: before its Work slice
-        // arrives, the target connection is the only honest liveness source.
-        online: connection?.state === "connected",
-      };
-    },
-    [boundRuntimeName, boundTargetId, remoteSnapshot],
-  );
+  const activeMachine = useMemo(() => {
+    if (!boundTargetId || !boundRuntimeName) return null;
+    const connection = remoteSnapshot?.connections.find(
+      (candidate) => candidate.target.id === boundTargetId,
+    );
+    return {
+      machineId: boundTargetId,
+      machineName: boundRuntimeName,
+      // A remote-bound tab has no local fallback: before its Work slice
+      // arrives, the target connection is the only honest liveness source.
+      online: connection?.state === "connected",
+      binding: projectBinding?.kind === "remote" ? projectBinding : null,
+    };
+  }, [boundRuntimeName, boundTargetId, projectBinding, remoteSnapshot]);
   const listRef = useRef<HTMLUListElement>(null);
   const browseRequestRef = useRef(0);
   const detailRequestRef = useRef(0);
@@ -549,6 +571,7 @@ export function CommandPalette({
     if (!open) {
       setMode("default");
       setQ("");
+      setFilterMenuKey(null);
       setSelectedIdx(0);
       setBrowseError(null);
       setBrowseLoading(false);
@@ -586,6 +609,7 @@ export function CommandPalette({
 
     setMode("default");
     setQ("");
+    setFilterMenuKey(null);
     setSelectedIdx(0);
     setBrowseError(null);
   }, [
@@ -698,13 +722,15 @@ export function CommandPalette({
       // disagreeing with the nav.
       ...(isWebClientMode()
         ? []
-        : [{
-          id: "go-automations",
-          title: "Go to Automations",
-          hint: "Automation rules and agent workflows",
-          group: "Navigation",
-          run: () => navigate("/automations"),
-        }]),
+        : [
+            {
+              id: "go-automations",
+              title: "Go to Automations",
+              hint: "Automation rules and agent workflows",
+              group: "Navigation",
+              run: () => navigate("/automations"),
+            },
+          ]),
       {
         id: "go-settings",
         title: "Go to Settings",
@@ -851,16 +877,21 @@ export function CommandPalette({
     startProjectRemote,
   ]);
 
+  const parsedWorkQuery = useMemo(() => parseWorkSearchQuery(q), [q]);
+
   const filtered = useMemo(() => {
-    const needle = q.trim().toLowerCase();
-    if (!needle) return commands;
-    return commands.filter(
-      (command) =>
-        command.title.toLowerCase().includes(needle) ||
-        (command.hint ?? "").toLowerCase().includes(needle) ||
-        (command.keywords ?? []).some((keyword) => keyword.toLowerCase().includes(needle)),
-    );
-  }, [commands, q]);
+    if (parsedWorkQuery.terms.length === 0) return commands;
+    return commands.filter((command) => {
+      const searchable = [
+        command.title,
+        command.hint ?? "",
+        ...(command.keywords ?? []),
+      ]
+        .join(" ")
+        .toLowerCase();
+      return parsedWorkQuery.terms.every((term) => searchable.includes(term));
+    });
+  }, [commands, parsedWorkQuery.terms]);
 
   const grouped = useMemo(() => {
     const groups: { label: string; items: Command[] }[] = [];
@@ -878,43 +909,91 @@ export function CommandPalette({
   }, [filtered]);
 
   const trimmedQuery = q.trim();
+  const entityQuery = parsedWorkQuery.backendQuery.trim();
   const canEntitySearch =
-    open && mode === "default" && hasActiveProject && trimmedQuery.length > 0;
+    open &&
+    mode === "default" &&
+    hasActiveProject &&
+    parsedWorkQuery.backendQueries.some((candidate) => candidate.length > 0);
 
   // Built once per session/lane list, not per keystroke — the palette can be
   // opened against hundreds of sessions and the lowercasing is the expensive
   // half of the match.
-  const threadIndex = useThreadIndex(threadSessions, lanes, foreignMachines, activeMachine);
+  const threadIndex = useThreadIndex(
+    threadSessions,
+    lanes,
+    foreignMachines,
+    activeMachine,
+  );
   const threadMatches = useMemo(
     () =>
       open && mode === "default" ? rankThreads(threadIndex, trimmedQuery) : [],
     [mode, open, threadIndex, trimmedQuery],
   );
-  const visibleThreads = useMemo(
-    () => threadMatches.slice(0, THREAD_RESULT_LIMIT),
-    [threadMatches],
-  );
-  const visibleThreadIds = useMemo(
-    () => new Set(visibleThreads.map((match) => match.entry.session.id)),
-    [visibleThreads],
-  );
+
+  const workFacetOptions = useMemo<
+    Record<WorkSearchFilterKey, string[]>
+  >(() => {
+    const values: Record<WorkSearchFilterKey, Set<string>> = {
+      lane: new Set(),
+      provider: new Set(),
+      status: new Set(),
+      type: new Set(),
+      machine: new Set(),
+    };
+    for (const entry of threadIndex) {
+      if (entry.laneName) values.lane.add(entry.laneName);
+      if (entry.provider) values.provider.add(entry.provider);
+      values.status.add(sessionFilingBucket(entry.session));
+      values.type.add(
+        isChatToolType(entry.session.toolType) ? "chat" : "terminal",
+      );
+      if (entry.machineName) values.machine.add(entry.machineName);
+    }
+    const options: Record<WorkSearchFilterKey, string[]> = {
+      lane: [],
+      provider: [],
+      status: [],
+      type: [],
+      machine: [],
+    };
+    for (const key of WORK_SEARCH_FILTER_KEYS) {
+      options[key] = [...values[key]].sort((a, b) => a.localeCompare(b));
+    }
+    return options;
+  }, [threadIndex]);
 
   const {
     loading: searchLoading,
+    sessionResults,
     sections: entitySections,
     flatEntities,
     expandedKinds,
     toggleExpandKind,
-  } = useUniversalSearch(trimmedQuery, canEntitySearch, {
-    excludeSessionIds: visibleThreadIds,
-  });
+  } = useUniversalSearch(q, canEntitySearch);
+
+  const workResults = useMemo(
+    () =>
+      buildWorkResults({
+        parsedWorkQuery,
+        sessionResults,
+        threadIndex,
+        threadMatches,
+      }),
+    [parsedWorkQuery, sessionResults, threadIndex, threadMatches],
+  );
+
+  const visibleWorkResults = useMemo(
+    () => workResults.slice(0, THREAD_RESULT_LIMIT),
+    [workResults],
+  );
 
   // Flat keyboard index layout: threads, then commands, then entity results.
   // Threads lead because the palette is the Work sidebar's search now — with an
   // empty query the thing you most likely came here for is a chat you were just
   // in, not a command. When a query matches no thread the section disappears
   // and commands lead on their own, so the first row is always a live target.
-  const threadCount = visibleThreads.length;
+  const threadCount = visibleWorkResults.length;
   const commandCount = filtered.length;
   const totalFlat = threadCount + commandCount + flatEntities.length;
 
@@ -1219,6 +1298,46 @@ export function CommandPalette({
     [onOpenChange],
   );
 
+  const handleThreadAction = useWorkSessionActions({
+    navigate,
+    onOpenChange,
+    projectRoot: project?.rootPath ?? null,
+    projectBinding,
+    setWorkViewState,
+    switchProjectToPath,
+    switchRemoteProject,
+  });
+
+  const removeWorkFilter = useCallback(
+    (
+      token: ReturnType<typeof parseWorkSearchQuery>["filterTokens"][number],
+    ) => {
+      setQ((current) => removeWorkSearchFilterToken(current, token));
+      setSelectedIdx(0);
+    },
+    [],
+  );
+
+  const addWorkFilter = useCallback(
+    (key: WorkSearchFilterKey, value: string) => {
+      setQ((current) => appendWorkSearchFilter(current, key, value));
+      setFilterMenuKey(null);
+      setSelectedIdx(0);
+    },
+    [],
+  );
+
+  const clearWorkFilters = useCallback(() => {
+    setQ((current) => {
+      const parsed = parseWorkSearchQuery(current);
+      return parsed.filterTokens.reduce(
+        (next, token) => removeWorkSearchFilterToken(next, token),
+        current,
+      );
+    });
+    setSelectedIdx(0);
+  }, []);
+
   /**
    * Open a thread. Same two-step as the `chat`/`terminal` search results below:
    * the Work tab is keep-alive mounted, so the event focuses the session and
@@ -1313,7 +1432,10 @@ export function CommandPalette({
         }
         case "commit": {
           const parsed = item.deepLink ? parseDeeplink(item.deepLink) : null;
-          const target = parsed?.ok && parsed.target.kind === "commit" ? parsed.target : null;
+          const target =
+            parsed?.ok && parsed.target.kind === "commit"
+              ? parsed.target
+              : null;
           const laneId = target?.laneId ?? item.laneId ?? null;
           if (laneId && target?.sha) {
             navigate(
@@ -1345,7 +1467,8 @@ export function CommandPalette({
           // root. Content hits carry a line anchor the editor reveals on open.
           const relative = relativeFilePathForResult(item);
           const laneWorktree = item.laneId
-            ? lanes.find((lane) => lane.id === item.laneId)?.worktreePath ?? null
+            ? (lanes.find((lane) => lane.id === item.laneId)?.worktreePath ??
+              null)
             : null;
           const root = laneWorktree ?? project?.rootPath ?? null;
           if (relative && root) {
@@ -1353,7 +1476,10 @@ export function CommandPalette({
             const absolute = `${root}${
               root.endsWith(separator) ? "" : separator
             }${relative.path}`;
-            const line = relative.line && relative.line > 0 ? `&line=${relative.line}` : "";
+            const line =
+              relative.line && relative.line > 0
+                ? `&line=${relative.line}`
+                : "";
             navigate(
               `/files?externalPath=${encodeURIComponent(
                 absolute,
@@ -1393,8 +1519,10 @@ export function CommandPalette({
   const activateFlat = useCallback(
     (index: number) => {
       if (index < threadCount) {
-        const match = visibleThreads[index];
-        if (match) activateThread(match.entry);
+        const result = visibleWorkResults[index];
+        if (!result) return;
+        if (result.type === "thread") activateThread(result.match.entry);
+        else activateResult(result.item);
         return;
       }
       if (index < threadCount + commandCount) {
@@ -1416,7 +1544,7 @@ export function CommandPalette({
       runCommand,
       threadCount,
       toggleExpandKind,
-      visibleThreads,
+      visibleWorkResults,
     ],
   );
 
@@ -1685,7 +1813,9 @@ export function CommandPalette({
         navigate("/work");
         onOpenChange(false);
       } catch (error) {
-        throw new Error(extractError(error) || "Failed to open the new project");
+        throw new Error(
+          extractError(error) || "Failed to open the new project",
+        );
       }
     },
     [navigate, onOpenChange, switchProjectToPath, switchRemoteProject],
@@ -1946,6 +2076,20 @@ export function CommandPalette({
                     </span>
                   </div>
                 )}
+
+                {!isAddFlow && !isBrowsing ? (
+                  <WorkFilterBar
+                    query={q}
+                    parsed={parsedWorkQuery}
+                    options={workFacetOptions}
+                    filterMenuKey={filterMenuKey}
+                    matchCount={workResults.length}
+                    onMenuKeyChange={setFilterMenuKey}
+                    onAdd={addWorkFilter}
+                    onRemove={removeWorkFilter}
+                    onClear={clearWorkFilters}
+                  />
+                ) : null}
 
                 {isAddFlow ? (
                   <div className="flex-1 overflow-auto p-6">
@@ -2350,8 +2494,8 @@ export function CommandPalette({
                           </div>
                         ) : trimmedQuery.length > 0 ? (
                           <div className="px-4 py-6 text-sm text-[var(--color-muted-fg)]">
-                            No matches — try kind:chat, lane:&lt;name&gt;, since:7d,
-                            or &quot;exact phrase&quot;
+                            No matches — try kind:chat, lane:&lt;name&gt;,
+                            since:7d, or &quot;exact phrase&quot;
                           </div>
                         ) : (
                           <div className="px-4 py-6 text-sm text-[var(--color-muted-fg)]">
@@ -2363,37 +2507,61 @@ export function CommandPalette({
                           {(() => {
                             let flatIndex = 0;
                             const threadNodes =
-                              visibleThreads.length > 0
+                              visibleWorkResults.length > 0
                                 ? [
                                     <li key="threads">
                                       <div className="px-4 py-1.5 text-[10px] font-mono font-semibold uppercase tracking-[0.16em] text-[var(--color-muted-fg)]">
-                                        Recent threads
+                                        {trimmedQuery
+                                          ? "Work results"
+                                          : "Recent threads"}
                                       </div>
                                       <ul>
-                                        {visibleThreads.map((match) => {
+                                        {visibleWorkResults.map((result) => {
                                           const index = flatIndex++;
+                                          if (result.type === "content") {
+                                            return (
+                                              <SearchResultRow
+                                                key={result.item.id}
+                                                item={result.item}
+                                                query={entityQuery}
+                                                index={index}
+                                                isSelected={
+                                                  index === selectedIdx
+                                                }
+                                                onHover={setSelectedIdx}
+                                                onActivate={activateResult}
+                                              />
+                                            );
+                                          }
                                           return (
                                             <ThreadResultRow
-                                              key={match.entry.session.id}
-                                              entry={match.entry}
+                                              key={
+                                                result.match.entry.session.id
+                                              }
+                                              entry={result.match.entry}
                                               query={trimmedQuery}
+                                              contentHit={result.contentHit}
                                               index={index}
                                               isSelected={index === selectedIdx}
                                               isCurrent={
-                                                match.entry.session.id ===
-                                                activeSessionId
+                                                result.match.entry.session
+                                                  .id === activeSessionId
                                               }
                                               projectName={
                                                 project?.displayName ?? null
                                               }
+                                              matchFields={
+                                                result.match.matchFields
+                                              }
                                               onHover={setSelectedIdx}
                                               onActivate={activateThread}
+                                              onAction={handleThreadAction}
                                             />
                                           );
                                         })}
                                         <ThreadOverflowNote
-                                          shown={visibleThreads.length}
-                                          total={threadMatches.length}
+                                          shown={visibleWorkResults.length}
+                                          total={workResults.length}
                                         />
                                       </ul>
                                     </li>,
@@ -2454,56 +2622,65 @@ export function CommandPalette({
                               </li>
                             ));
 
-                            const entityNodes = entitySections.map((section) => {
-                              const expanded = expandedKinds.has(section.kind);
-                              const visible = expanded
-                                ? section.rows
-                                : section.rows.slice(0, ENTITY_SECTION_PREVIEW);
-                              const showMore =
-                                !expanded &&
-                                section.rows.length > ENTITY_SECTION_PREVIEW;
-                              const hiddenCount =
-                                section.total - ENTITY_SECTION_PREVIEW;
-                              return (
-                                <li key={`entity:${section.kind}`}>
-                                  <div className="px-4 py-1.5 text-[10px] font-mono font-semibold uppercase tracking-[0.16em] text-[var(--color-muted-fg)]">
-                                    {section.label}
-                                  </div>
-                                  <ul>
-                                    {visible.map((item) => {
-                                      const index = flatIndex++;
-                                      return (
-                                        <SearchResultRow
-                                          key={item.id}
-                                          item={item}
-                                          query={trimmedQuery}
-                                          index={index}
-                                          isSelected={index === selectedIdx}
-                                          onHover={setSelectedIdx}
-                                          onActivate={activateResult}
-                                        />
-                                      );
-                                    })}
-                                    {showMore
-                                      ? (() => {
-                                          const index = flatIndex++;
-                                          return (
-                                            <ShowMoreRow
-                                              key={`more:${section.kind}`}
-                                              kind={section.kind}
-                                              hiddenCount={hiddenCount}
-                                              index={index}
-                                              isSelected={index === selectedIdx}
-                                              onHover={setSelectedIdx}
-                                              onToggle={toggleExpandKind}
-                                            />
-                                          );
-                                        })()
-                                      : null}
-                                  </ul>
-                                </li>
-                              );
-                            });
+                            const entityNodes = entitySections.map(
+                              (section) => {
+                                const expanded = expandedKinds.has(
+                                  section.kind,
+                                );
+                                const visible = expanded
+                                  ? section.rows
+                                  : section.rows.slice(
+                                      0,
+                                      ENTITY_SECTION_PREVIEW,
+                                    );
+                                const showMore =
+                                  !expanded &&
+                                  section.rows.length > ENTITY_SECTION_PREVIEW;
+                                const hiddenCount =
+                                  section.total - ENTITY_SECTION_PREVIEW;
+                                return (
+                                  <li key={`entity:${section.kind}`}>
+                                    <div className="px-4 py-1.5 text-[10px] font-mono font-semibold uppercase tracking-[0.16em] text-[var(--color-muted-fg)]">
+                                      {section.label}
+                                    </div>
+                                    <ul>
+                                      {visible.map((item) => {
+                                        const index = flatIndex++;
+                                        return (
+                                          <SearchResultRow
+                                            key={item.id}
+                                            item={item}
+                                            query={entityQuery}
+                                            index={index}
+                                            isSelected={index === selectedIdx}
+                                            onHover={setSelectedIdx}
+                                            onActivate={activateResult}
+                                          />
+                                        );
+                                      })}
+                                      {showMore
+                                        ? (() => {
+                                            const index = flatIndex++;
+                                            return (
+                                              <ShowMoreRow
+                                                key={`more:${section.kind}`}
+                                                kind={section.kind}
+                                                hiddenCount={hiddenCount}
+                                                index={index}
+                                                isSelected={
+                                                  index === selectedIdx
+                                                }
+                                                onHover={setSelectedIdx}
+                                                onToggle={toggleExpandKind}
+                                              />
+                                            );
+                                          })()
+                                        : null}
+                                    </ul>
+                                  </li>
+                                );
+                              },
+                            );
 
                             return [
                               ...threadNodes,
@@ -2777,7 +2954,10 @@ function RepoDetailBlocks({ detail }: { detail: ProjectDetail }) {
     <>
       <div className="flex flex-wrap items-center gap-2">
         {detail.worktreeOf && (
-          <StatusChip icon={<TreeStructure size={11} weight="bold" />} tone="accent">
+          <StatusChip
+            icon={<TreeStructure size={11} weight="bold" />}
+            tone="accent"
+          >
             worktree of {detail.worktreeOf.displayName}
           </StatusChip>
         )}

--- a/apps/desktop/src/renderer/components/app/commandPaletteSearch.tsx
+++ b/apps/desktop/src/renderer/components/app/commandPaletteSearch.tsx
@@ -28,6 +28,7 @@ import type {
 } from "../../../shared/types/search";
 import { parseDeeplink } from "../../../shared/deeplinks";
 import { relativeTimeCompact } from "../../lib/format";
+import { parseWorkSearchQuery } from "../../../shared/workSearch";
 import { cn } from "../ui/cn";
 
 // Debounce before hitting the universal search backend as the user types.
@@ -88,24 +89,41 @@ function KindIcon({ kind }: { kind: SearchDocKind }) {
   }
 }
 
-// Bold the first case-insensitive substring hit of the query inside a title.
+// Bold every bare word/phrase hit in a title. A full multi-word query is not a
+// contiguous substring when the user types the words in a different order.
 export function highlightTitle(
   title: string,
   query: string,
 ): React.ReactNode {
-  const needle = query.trim();
-  if (!needle) return title;
-  const idx = title.toLowerCase().indexOf(needle.toLowerCase());
-  if (idx < 0) return title;
-  return (
-    <>
-      {title.slice(0, idx)}
-      <span className="font-semibold text-[var(--color-fg)]">
-        {title.slice(idx, idx + needle.length)}
-      </span>
-      {title.slice(idx + needle.length)}
-    </>
-  );
+  const terms = parseWorkSearchQuery(query).terms;
+  if (terms.length === 0) return title;
+  const lowerTitle = title.toLowerCase();
+  const ranges: Array<{ start: number; end: number }> = [];
+  for (const term of terms) {
+    const index = lowerTitle.indexOf(term);
+    if (index < 0) continue;
+    ranges.push({ start: index, end: index + term.length });
+  }
+  if (ranges.length === 0) return title;
+  ranges.sort((a, b) => a.start - b.start || b.end - a.end);
+  const nodes: React.ReactNode[] = [];
+  let cursor = 0;
+  ranges.forEach((range, index) => {
+    const start = Math.max(cursor, range.start);
+    if (range.end <= cursor) return;
+    if (start > cursor) nodes.push(title.slice(cursor, start));
+    nodes.push(
+      <span
+        key={`${range.start}:${index}`}
+        className="font-semibold text-[var(--color-fg)]"
+      >
+        {title.slice(start, range.end)}
+      </span>,
+    );
+    cursor = range.end;
+  });
+  if (cursor < title.length) nodes.push(title.slice(cursor));
+  return nodes;
 }
 
 // Accent the backend-provided match offsets inside a snippet (no heavy box).
@@ -265,22 +283,12 @@ export function ShowMoreRow({
 
 export type UseUniversalSearchResult = {
   loading: boolean;
+  /** Chat/terminal content hits are promoted into the Work-first result group. */
+  sessionResults: SearchResultItem[];
   sections: EntitySection[];
   flatEntities: FlatEntity[];
   expandedKinds: Set<SearchDocKind>;
   toggleExpandKind: (kind: SearchDocKind) => void;
-};
-
-export type UseUniversalSearchOptions = {
-  /**
-   * Session ids already rendered by the palette's local "Recent threads" group.
-   * A thread that matches on its title almost always matches on its content
-   * too, so without this the same chat appears twice — once instantly from the
-   * local index, once again a beat later under "Chats". Excluding them here
-   * (rather than at the render site) keeps `flatEntities` the single source of
-   * truth for the keyboard index.
-   */
-  excludeSessionIds?: ReadonlySet<string>;
 };
 
 /**
@@ -292,9 +300,7 @@ export type UseUniversalSearchOptions = {
 export function useUniversalSearch(
   query: string,
   enabled: boolean,
-  options: UseUniversalSearchOptions = {},
 ): UseUniversalSearchResult {
-  const excludeSessionIds = options.excludeSessionIds;
   const [results, setResults] = useState<SearchResultItem[] | null>(null);
   const [totalByKind, setTotalByKind] = useState<
     Partial<Record<SearchDocKind, number>>
@@ -326,15 +332,40 @@ export function useUniversalSearch(
     }
     const queryApi = window.ade.search?.query;
     if (!queryApi) return;
+    const parsedQuery = parseWorkSearchQuery(query);
+    const backendQueries = parsedQuery.backendQueries.length > 0
+      ? parsedQuery.backendQueries
+      : [parsedQuery.backendQuery];
     const requestId = ++requestRef.current;
     setLoading(true);
     const timeout = globalThis.setTimeout(() => {
       void Promise.resolve()
-        .then(() => queryApi({ query, limit: SEARCH_QUERY_LIMIT }))
-        .then((result) => {
+        .then(() => Promise.all(
+          backendQueries.map((backendQuery) => queryApi({
+            query: backendQuery,
+            limit: SEARCH_QUERY_LIMIT,
+          })),
+        ))
+        .then((queryResults) => {
           if (requestRef.current !== requestId) return;
-          setResults(result.results);
-          setTotalByKind(result.totalByKind);
+          const seen = new Set<string>();
+          const mergedResults: SearchResultItem[] = [];
+          const mergedTotals: Partial<Record<SearchDocKind, number>> = {};
+          for (const result of queryResults) {
+            for (const item of result.results) {
+              const key = `${item.kind}:${item.id}`;
+              if (seen.has(key)) continue;
+              seen.add(key);
+              mergedResults.push(item);
+            }
+            for (const [kind, total] of Object.entries(result.totalByKind)) {
+              if (typeof total !== "number") continue;
+              const searchKind = kind as SearchDocKind;
+              mergedTotals[searchKind] = (mergedTotals[searchKind] ?? 0) + total;
+            }
+          }
+          setResults(mergedResults);
+          setTotalByKind(mergedTotals);
           setLoading(false);
         })
         .catch(() => {
@@ -353,18 +384,11 @@ export function useUniversalSearch(
   const sections = useMemo<EntitySection[]>(() => {
     if (!results || results.length === 0) return [];
     const byKind = new Map<SearchDocKind, SearchResultItem[]>();
-    // Count what the exclusion removed per kind so each section's "show N more"
-    // total stays honest against the rows actually rendered.
-    const excludedByKind = new Map<SearchDocKind, number>();
     for (const item of results) {
-      if (
-        excludeSessionIds &&
-        item.sessionId &&
-        excludeSessionIds.has(item.sessionId)
-      ) {
-        excludedByKind.set(item.kind, (excludedByKind.get(item.kind) ?? 0) + 1);
-        continue;
-      }
+      // Work owns chat/terminal result presentation. Keeping these rows in the
+      // generic entity sections made content hits appear below commands and
+      // created a second copy of a cached Work row.
+      if (item.kind === "chat" || item.kind === "terminal") continue;
       const bucket = byKind.get(item.kind);
       if (bucket) bucket.push(item);
       else byKind.set(item.kind, [item]);
@@ -378,11 +402,11 @@ export function useUniversalSearch(
         kind,
         label: ENTITY_KIND_LABEL[kind],
         rows,
-        total: Math.max(rows.length, reportedTotal - (excludedByKind.get(kind) ?? 0)),
+        total: Math.max(rows.length, reportedTotal),
       });
     }
     return next;
-  }, [excludeSessionIds, results, totalByKind]);
+  }, [results, totalByKind]);
 
   // Flattened, keyboard-navigable sequence of entity rows + show-more rows,
   // continuing after the command items in the shared flat index.
@@ -419,5 +443,17 @@ export function useUniversalSearch(
     });
   }, []);
 
-  return { loading, sections, flatEntities, expandedKinds, toggleExpandKind };
+  const sessionResults = useMemo(
+    () => (results ?? []).filter((item) => item.kind === "chat" || item.kind === "terminal"),
+    [results],
+  );
+
+  return {
+    loading,
+    sessionResults,
+    sections,
+    flatEntities,
+    expandedKinds,
+    toggleExpandKind,
+  };
 }

--- a/apps/desktop/src/renderer/components/app/commandPaletteThreads.tsx
+++ b/apps/desktop/src/renderer/components/app/commandPaletteThreads.tsx
@@ -13,12 +13,22 @@
  * `shared/sessionStatusPresentation.ts` for why exactly one hue table exists.
  */
 import React, { useMemo } from "react";
-import { ChatCircle, Terminal } from "@phosphor-icons/react";
+import {
+  ArrowUUpLeft,
+  ChatCircle,
+  Check,
+  Moon,
+  PencilSimple,
+  Plus,
+  Sun,
+  Terminal,
+} from "@phosphor-icons/react";
 import type {
   LaneSummary,
   OpenProjectBinding,
   TerminalSessionSummary,
 } from "../../../shared/types";
+import type { SearchResultItem } from "../../../shared/types/search";
 import type { CrossMachineMachineLanes } from "../../state/appStore";
 import type { CrossMachineLaneMarker } from "../../state/crossMachineLanes";
 import { THIS_MACHINE_ID, THIS_MACHINE_NAME } from "../../../shared/machineIdentity";
@@ -29,7 +39,14 @@ import {
   type SessionStatusPresentation,
 } from "../../../shared/sessionStatusPresentation";
 import { relativeTimeCompact } from "../../lib/format";
-import { isChatToolType } from "../../lib/sessions";
+import { isChatToolType, shortToolTypeLabel } from "../../lib/sessions";
+import { providerChatAccent } from "../chat/chatSurfaceTheme";
+import { workToolFamily } from "../terminals/workSessionFilters";
+import {
+  matchesWorkSearchFilters,
+  parseWorkSearchQuery,
+  type ParsedWorkSearch,
+} from "../../../shared/workSearch";
 import {
   isSessionSnoozed,
   sessionWokeMarker,
@@ -37,10 +54,13 @@ import {
 } from "../../lib/sessionSnooze";
 import {
   canonicalInputFromSummary,
+  sessionFilingBucket,
+  sessionIsMidFlight,
+  sessionCanonicalUiState,
   sessionStatusDisplay,
 } from "../../lib/terminalAttention";
 import { cn } from "../ui/cn";
-import { highlightTitle } from "./commandPaletteSearch";
+import { highlightRanges, highlightTitle } from "./commandPaletteSearch";
 
 /**
  * Rows rendered in the Recent threads group. The palette can be opened against
@@ -54,6 +74,8 @@ export type ThreadIndexEntry = {
   session: TerminalSessionSummary;
   /** Lane/worktree label — the "project · branch" line's first half. */
   laneName: string;
+  /** Lane accent copied into the index so row rendering stays per-keystroke cheap. */
+  laneColor: string | null;
   /** Lane branch ref, when the lane is known. Shown with a leading `#`. */
   branch: string | null;
   /**
@@ -71,6 +93,14 @@ export type ThreadIndexEntry = {
   laneNameLower: string;
   branchLower: string;
   machineNameLower: string;
+  goalLower: string;
+  summaryLower: string;
+  previewLower: string;
+  tagLower: string;
+  toolTypeLower: string;
+  /** Stable provider family used by the provider facet and row identity accent. */
+  provider: string;
+  providerLower: string;
   /** Recency rank (ms). Ties in relevance fall back to "most recently touched". */
   recencyMs: number;
 };
@@ -105,9 +135,11 @@ function makeEntry(args: {
 }): ThreadIndexEntry {
   const laneName = args.lane?.name ?? args.session.laneName ?? "";
   const branch = args.lane?.branchRef?.trim() || null;
+  const provider = workToolFamily(args.session.toolType);
   return {
     session: args.session,
     laneName,
+    laneColor: args.lane?.color ?? null,
     branch,
     machineId: args.machineId,
     machineName: args.machineName,
@@ -117,6 +149,13 @@ function makeEntry(args: {
     laneNameLower: laneName.toLowerCase(),
     branchLower: (branch ?? "").toLowerCase(),
     machineNameLower: args.machineName.toLowerCase(),
+    goalLower: (args.session.goal ?? "").toLowerCase(),
+    summaryLower: (args.session.summary ?? "").toLowerCase(),
+    previewLower: (args.session.lastOutputPreview ?? "").toLowerCase(),
+    tagLower: (args.session.claudeTag ?? "").toLowerCase(),
+    toolTypeLower: (args.session.toolType ?? "").toLowerCase(),
+    provider,
+    providerLower: provider.toLowerCase(),
     recencyMs: recencyRank(args.session),
   };
 }
@@ -152,6 +191,8 @@ export function buildThreadIndex(
     machineName: string;
     /** Live target status from the remote-runtime connection snapshot. */
     online: boolean;
+    /** Binding for the active remote tab, so actions route to its owner. */
+    binding?: OpenProjectBinding | null;
   } | null = null,
 ): ThreadIndexEntry[] {
   const laneById = new Map(lanes.map((lane) => [lane.id, lane] as const));
@@ -173,7 +214,7 @@ export function buildThreadIndex(
         machineId: activeMachine?.machineId ?? THIS_MACHINE_ID,
         machineName: activeMachine?.machineName ?? THIS_MACHINE_NAME,
         machineOnline: activeMachineOnline,
-        binding: null,
+        binding: activeMachine?.binding ?? null,
       }),
     );
   }
@@ -205,6 +246,38 @@ export function buildThreadIndex(
   return entries;
 }
 
+/** Apply the local metadata part of a Work query to a cached row. */
+export function matchesThreadWorkFacets(
+  entry: ThreadIndexEntry,
+  parsed: ParsedWorkSearch,
+): boolean {
+  const filingBucket = sessionFilingBucket(entry.session);
+  if (!matchesWorkSearchFilters(parsed.filters, {
+    lane: [entry.laneName],
+    provider: [entry.provider, entry.toolTypeLower],
+    status: [
+      filingBucket,
+      filingBucket === "awaiting-input" ? "your move" : filingBucket,
+    ],
+    type: [
+      entry.toolTypeLower,
+      isChatToolType(entry.session.toolType) ? "chat" : "terminal",
+    ],
+    machine: [entry.machineName, entry.machineId],
+  })) return false;
+  if (!matchesTrackedFilter(entry.session.tracked, parsed.tracked)) return false;
+  return true;
+}
+
+function matchesTrackedFilter(
+  tracked: boolean | undefined,
+  wanted: string | null,
+): boolean {
+  if (wanted === "yes" || wanted === "true") return Boolean(tracked);
+  if (wanted === "no" || wanted === "false") return !tracked;
+  return true;
+}
+
 /**
  * Per-term score for one entry. Returns 0 when the term matches nothing, which
  * makes the caller's AND semantics fall out naturally: every typed word has to
@@ -216,32 +289,79 @@ export function buildThreadIndex(
  * hit within each field so typing "red" surfaces "Redesign…" above
  * "…considered".
  */
-function scoreTerm(entry: ThreadIndexEntry, term: string): number {
-  const titleIdx = entry.titleLower.indexOf(term);
-  if (titleIdx === 0) return 100;
-  if (titleIdx > 0) {
-    // Word-boundary hits read as deliberate; mid-word hits are usually noise.
-    const preceding = entry.titleLower[titleIdx - 1] ?? "";
-    return /[\s\-_/.]/.test(preceding) ? 80 : 60;
+export type ThreadMatchField =
+  | "title"
+  | "goal"
+  | "summary"
+  | "preview"
+  | "tag"
+  | "lane"
+  | "provider"
+  | "type"
+  | "branch"
+  | "machine"
+  | "content";
+
+const MATCH_FIELD_LABELS: Record<ThreadMatchField, string> = {
+  title: "title",
+  goal: "goal",
+  summary: "summary",
+  preview: "recent output",
+  tag: "tag",
+  lane: "lane",
+  provider: "provider",
+  type: "type",
+  branch: "branch",
+  machine: "machine",
+  content: "chat content",
+};
+
+export function threadMatchFieldLabel(field: ThreadMatchField): string {
+  return MATCH_FIELD_LABELS[field];
+}
+
+type ScoredField = { field: ThreadMatchField; value: string; base: number };
+
+function scoreField(value: string, term: string, base: number): number {
+  const index = value.indexOf(term);
+  if (index < 0) return 0;
+  if (index === 0) return base;
+  const preceding = value[index - 1] ?? "";
+  return /[\s\-_/.]/.test(preceding) ? base - 10 : base - 20;
+}
+
+function scoreTerm(
+  entry: ThreadIndexEntry,
+  term: string,
+): { score: number; field: ThreadMatchField } | null {
+  const fields: ScoredField[] = [
+    { field: "title", value: entry.titleLower, base: 110 },
+    { field: "goal", value: entry.goalLower, base: 96 },
+    { field: "summary", value: entry.summaryLower, base: 88 },
+    { field: "preview", value: entry.previewLower, base: 80 },
+    { field: "tag", value: entry.tagLower, base: 74 },
+    { field: "lane", value: entry.laneNameLower, base: 62 },
+    { field: "provider", value: entry.providerLower, base: 54 },
+    { field: "type", value: entry.toolTypeLower, base: 48 },
+    { field: "branch", value: entry.branchLower, base: 42 },
+    // Machine name ranks last: it narrows a set, but rarely identifies the
+    // thread by itself.
+    { field: "machine", value: entry.machineNameLower, base: 24 },
+  ];
+  for (const candidate of fields) {
+    const score = scoreField(candidate.value, term, candidate.base);
+    if (score > 0) return { score, field: candidate.field };
   }
-  const laneIdx = entry.laneNameLower.indexOf(term);
-  if (laneIdx === 0) return 50;
-  if (laneIdx > 0) return 40;
-  const branchIdx = entry.branchLower.indexOf(term);
-  if (branchIdx === 0) return 30;
-  if (branchIdx > 0) return 25;
-  // Machine name ranks last: "Mac Studio" narrows a set, it rarely identifies
-  // the one thread you want, so it must never outrank a title hit.
-  const machineIdx = entry.machineNameLower.indexOf(term);
-  if (machineIdx === 0) return 20;
-  if (machineIdx > 0) return 15;
-  return 0;
+  return null;
 }
 
 export type ThreadMatch = {
   entry: ThreadIndexEntry;
   score: number;
+  matchFields: ThreadMatchField[];
 };
+
+export type ThreadRowAction = "new-chat" | "rename" | "settle" | "snooze";
 
 /**
  * Rank the index against a query. An empty query returns the index as-is (it is
@@ -253,22 +373,30 @@ export function rankThreads(
   index: readonly ThreadIndexEntry[],
   query: string,
 ): ThreadMatch[] {
-  const needle = query.trim().toLowerCase();
-  if (!needle) return index.map((entry) => ({ entry, score: 0 }));
-  const terms = needle.split(/\s+/).filter(Boolean);
+  const parsed = parseWorkSearchQuery(query);
+  if (
+    parsed.terms.length === 0 &&
+    parsed.filterTokens.length === 0 &&
+    parsed.tracked === null
+  ) {
+    return index.map((entry) => ({ entry, score: 0, matchFields: [] }));
+  }
   const matches: ThreadMatch[] = [];
   for (const entry of index) {
+    if (!matchesThreadWorkFacets(entry, parsed)) continue;
     let total = 0;
     let matchedEveryTerm = true;
-    for (const term of terms) {
-      const score = scoreTerm(entry, term);
-      if (score === 0) {
+    const matchFields: ThreadMatchField[] = [];
+    for (const term of parsed.terms) {
+      const scored = scoreTerm(entry, term);
+      if (!scored) {
         matchedEveryTerm = false;
         break;
       }
-      total += score;
+      total += scored.score;
+      if (!matchFields.includes(scored.field)) matchFields.push(scored.field);
     }
-    if (matchedEveryTerm) matches.push({ entry, score: total });
+    if (matchedEveryTerm) matches.push({ entry, score: total, matchFields });
   }
   // Stable-by-recency: the index is already recency-ordered, and Array#sort is
   // stable in every engine we ship on, so equal scores keep that order.
@@ -285,6 +413,7 @@ export function useThreadIndex(
     machineId: string;
     machineName: string;
     online: boolean;
+    binding?: OpenProjectBinding | null;
   } | null = null,
 ): ThreadIndexEntry[] {
   return useMemo(
@@ -323,15 +452,20 @@ function ThreadGlyph({ session }: { session: TerminalSessionSummary }) {
 export const ThreadResultRow = React.memo(function ThreadResultRow({
   entry,
   query,
+  contentHit,
   index,
   isSelected,
   isCurrent,
   projectName,
   onHover,
   onActivate,
+  matchFields = [],
+  onAction,
 }: {
   entry: ThreadIndexEntry;
   query: string;
+  /** A backend transcript hit that promoted this cached Work row. */
+  contentHit?: SearchResultItem | null;
   index: number;
   isSelected: boolean;
   /** The session currently open in the Work tab — annotated, never hidden. */
@@ -340,9 +474,18 @@ export const ThreadResultRow = React.memo(function ThreadResultRow({
   onHover: (index: number) => void;
   /** Takes the whole entry — foreign rows need the machine binding to route. */
   onActivate: (entry: ThreadIndexEntry) => void;
+  matchFields?: ThreadMatchField[];
+  onAction?: (entry: ThreadIndexEntry, action: ThreadRowAction) => void;
 }) {
   const { session } = entry;
   const status = threadStatusPresentation(session);
+  const canonical = canonicalInputFromSummary(session);
+  const canonicalState = sessionCanonicalUiState(canonical);
+  const isSettled = canonicalState.phase === "settled";
+  const canSettle = isSettled || !sessionIsMidFlight(canonical);
+  const snoozed = isSessionSnoozed(session);
+  const providerLabel = shortToolTypeLabel(session.toolType);
+  const providerAccent = providerChatAccent(entry.provider) ?? "var(--color-muted-fg)";
   const time = relativeTimeCompact(
     session.lastActivityAt ?? session.settledAt ?? session.startedAt,
   );
@@ -384,22 +527,18 @@ export const ThreadResultRow = React.memo(function ThreadResultRow({
   if (entry.branch) contextParts.push(`#${entry.branch}`);
   else if (rowProjectName && entry.laneName) contextParts.push(entry.laneName);
 
+  const actionButtonClass = "inline-flex h-6 items-center gap-1 rounded-md border border-[var(--color-border)] bg-[var(--color-surface)] px-2 text-[10px] text-[var(--color-muted-fg)] transition-colors hover:border-[var(--color-accent)] hover:text-[var(--color-fg)]";
+
   return (
     <li>
-      <button
-        type="button"
-        data-cmd-item
-        data-thread-id={session.id}
+      <div
         className={cn(
-          // Same geometry and selection treatment as the command rows so a
-          // selected thread and a selected command are visually identical.
-          "mx-2 flex w-[calc(100%-1rem)] items-center gap-2.5 rounded-lg border px-3 py-2 text-left transition-colors",
+          "mx-2 overflow-hidden rounded-lg border transition-colors",
           isSelected
             ? "border-[var(--color-accent)] bg-[var(--color-accent-muted)]"
             : "border-transparent hover:border-[var(--color-border)] hover:bg-[var(--color-muted)]",
         )}
-        onMouseEnter={() => onHover(index)}
-        onClick={() => onActivate(entry)}
+        data-thread-id={session.id}
         data-machine-id={entry.machineId}
         data-machine-online={
           machineMarker ? (entry.machineOnline ? "true" : "false") : undefined
@@ -409,64 +548,162 @@ export const ThreadResultRow = React.memo(function ThreadResultRow({
         // queryable fact rather than a per-surface opacity class.
         data-dimmed={offline ? "true" : undefined}
       >
-        <span
-          className={cn(
-            "flex h-4 w-4 shrink-0 items-center justify-center",
-            offline && "opacity-55",
-          )}
+        <button
+          type="button"
+          data-cmd-item
+          className="flex w-full items-center gap-2.5 px-3 py-2 text-left"
+          onMouseEnter={() => onHover(index)}
+          onClick={() => onActivate(entry)}
         >
-          <ThreadGlyph session={session} />
-        </span>
-        <div className={cn("min-w-0 flex-1", offline && "opacity-55")}>
-          <div className="flex min-w-0 items-center gap-1.5">
-            {status ? (
-              <span
-                data-testid={`thread-status-${session.id}`}
-                className={cn(
-                  "inline-flex shrink-0 items-center gap-1 text-[10px]",
-                  SESSION_TONE_TEXT_CLASS[status.tone],
-                )}
-              >
-                <span
-                  aria-hidden
-                  className={cn(
-                    "h-1.5 w-1.5 rounded-full",
-                    SESSION_TONE_DOT_CLASS[status.tone],
-                  )}
-                />
-                {status.label}
-              </span>
-            ) : null}
-            {/* `min-w-0` is what actually lets `truncate` win inside a flex
-                row — without it the item's automatic min-width keeps a long
-                title from shrinking and the row grows a second line. */}
-            <span className="min-w-0 truncate text-sm text-[var(--color-fg)]">
-              {highlightTitle(session.title || "Untitled thread", query)}
-            </span>
-          </div>
-          <div className="mt-0.5 flex min-w-0 items-center gap-1.5 text-xs text-[var(--color-muted-fg)]">
-            {machineMarker ? <LaneMachineMarker marker={machineMarker} /> : null}
-            <span className="min-w-0 truncate">
-              {contextParts.join(" · ")}
-              {isCurrent ? (
-                <span className="text-[var(--color-accent)]">
-                  {contextParts.length > 0 ? " · " : ""}Current thread
-                </span>
-              ) : null}
-            </span>
-          </div>
-        </div>
-        {time ? (
           <span
             className={cn(
-              "shrink-0 text-[10px] tabular-nums text-[var(--color-muted-fg)]",
+              "flex h-5 w-5 shrink-0 items-center justify-center rounded-md",
               offline && "opacity-55",
             )}
+            style={{
+              color: providerAccent,
+              backgroundColor: `color-mix(in srgb, ${providerAccent} 14%, transparent)`,
+            }}
+            title={`${providerLabel} provider`}
           >
-            {time}
+            <ThreadGlyph session={session} />
           </span>
+          <div className={cn("min-w-0 flex-1", offline && "opacity-55")}>
+            <div className="flex min-w-0 items-center gap-1.5">
+              {status ? (
+                <span
+                  data-testid={`thread-status-${session.id}`}
+                  className={cn(
+                    "inline-flex shrink-0 items-center gap-1 text-[10px]",
+                    SESSION_TONE_TEXT_CLASS[status.tone],
+                  )}
+                >
+                  <span
+                    data-status-dot
+                    aria-hidden
+                    className={cn(
+                      "h-1.5 w-1.5 rounded-full",
+                      SESSION_TONE_DOT_CLASS[status.tone],
+                    )}
+                  />
+                  {status.label}
+                </span>
+              ) : null}
+              <span className="min-w-0 truncate text-sm text-[var(--color-fg)]">
+                {highlightTitle(session.title || "Untitled thread", query)}
+              </span>
+            </div>
+            <div className="mt-0.5 flex min-w-0 items-center gap-1.5 text-xs text-[var(--color-muted-fg)]">
+              {machineMarker ? <LaneMachineMarker marker={machineMarker} /> : null}
+              <span className="min-w-0 truncate">
+                {contextParts.join(" · ")}
+                {isCurrent ? (
+                  <span className="text-[var(--color-accent)]">
+                    {contextParts.length > 0 ? " · " : ""}Current thread
+                  </span>
+                ) : null}
+              </span>
+            </div>
+            <div className="mt-1 flex min-w-0 items-center gap-1.5 text-[10px] text-[var(--color-muted-fg)]">
+              <span
+                className="inline-flex shrink-0 items-center gap-1 rounded-md border px-1.5 py-0.5"
+                style={{
+                  borderColor: `color-mix(in srgb, ${providerAccent} 35%, var(--color-border))`,
+                  color: providerAccent,
+                }}
+              >
+                <span className="h-1.5 w-1.5 rounded-full" style={{ backgroundColor: providerAccent }} aria-hidden />
+                {providerLabel}
+              </span>
+              <span className="truncate" title={session.toolType ? `${session.toolType} session` : "Terminal session"}>
+                {isChatToolType(session.toolType) ? "Chat" : "Terminal"}
+              </span>
+              {entry.laneName ? (
+                <span
+                  className="max-w-[150px] truncate rounded-md border px-1.5 py-0.5"
+                  style={entry.laneColor ? {
+                    borderColor: `color-mix(in srgb, ${entry.laneColor} 35%, var(--color-border))`,
+                    color: entry.laneColor,
+                  } : undefined}
+                >
+                  {entry.laneName}
+                </span>
+              ) : null}
+            </div>
+            {contentHit?.snippet ? (
+              <div className="mt-1 truncate text-[11px] text-[var(--color-muted-fg)]">
+                {highlightRanges(contentHit.snippet, contentHit.matchRanges)}
+              </div>
+            ) : null}
+            {matchFields.length > 0 ? (
+              <div className="mt-1 truncate text-[10px] text-[var(--color-muted-fg)]">
+                Match: {matchFields.map(threadMatchFieldLabel).join(", ")}
+              </div>
+            ) : null}
+          </div>
+          {time ? (
+            <span className={cn(
+              "shrink-0 text-[10px] tabular-nums text-[var(--color-muted-fg)]",
+              offline && "opacity-55",
+            )}>
+              {time}
+            </span>
+          ) : null}
+        </button>
+        {isSelected && onAction ? (
+          <div className="flex flex-wrap items-center gap-1.5 border-t border-[var(--color-border)] px-3 py-1.5">
+            <span className="mr-1 text-[10px] text-[var(--color-muted-fg)]">Actions</span>
+            <button
+              type="button"
+              className={actionButtonClass}
+              aria-label={`New chat in ${entry.laneName || "this lane"}`}
+              onClick={(event) => {
+                event.stopPropagation();
+                onAction(entry, "new-chat");
+              }}
+            >
+              <Plus size={12} aria-hidden /> New chat
+            </button>
+            <button
+              type="button"
+              className={actionButtonClass}
+              aria-label={`Rename ${session.title || "session"}`}
+              onClick={(event) => {
+                event.stopPropagation();
+                onAction(entry, "rename");
+              }}
+            >
+              <PencilSimple size={12} aria-hidden /> Rename
+            </button>
+            {canSettle ? (
+              <button
+                type="button"
+                className={actionButtonClass}
+                aria-label={isSettled ? "Unsettle session" : "Settle session"}
+                onClick={(event) => {
+                  event.stopPropagation();
+                  onAction(entry, "settle");
+                }}
+              >
+                {isSettled ? <ArrowUUpLeft size={12} aria-hidden /> : <Check size={12} aria-hidden />}
+                {isSettled ? "Unsettle" : "Settle"}
+              </button>
+            ) : null}
+            <button
+              type="button"
+              className={actionButtonClass}
+              aria-label={snoozed ? "Wake session" : "Snooze session"}
+              onClick={(event) => {
+                event.stopPropagation();
+                onAction(entry, "snooze");
+              }}
+            >
+              {snoozed ? <Sun size={12} aria-hidden /> : <Moon size={12} aria-hidden />}
+              {snoozed ? "Wake" : "Snooze 1h"}
+            </button>
+          </div>
         ) : null}
-      </button>
+      </div>
     </li>
   );
 });

--- a/apps/desktop/src/renderer/components/app/commandPaletteWork.tsx
+++ b/apps/desktop/src/renderer/components/app/commandPaletteWork.tsx
@@ -1,0 +1,457 @@
+import React, { useCallback } from "react";
+import { Funnel, X } from "@phosphor-icons/react";
+import type { OpenProjectBinding } from "../../../shared/types";
+import type { SearchResultItem } from "../../../shared/types/search";
+import {
+  WORK_SEARCH_FILTER_KEYS,
+  type ParsedWorkSearch,
+  type WorkSearchFilterKey,
+} from "../../../shared/workSearch";
+import {
+  matchesThreadWorkFacets,
+  type ThreadIndexEntry,
+  type ThreadMatch,
+  type ThreadRowAction,
+} from "./commandPaletteThreads";
+import {
+  projectStateKeyForBinding,
+  type WorkProjectViewState,
+} from "../../state/appStore";
+import { invalidateSessionListCache } from "../../lib/sessionListCache";
+import { isSessionSnoozed } from "../../lib/sessionSnooze";
+import {
+  canonicalInputFromSummary,
+  sessionCanonicalUiState,
+} from "../../lib/terminalAttention";
+import {
+  renameSession,
+  settleSession,
+  snoozeSessionForDuration,
+  unsettleSession,
+  wakeSessionNow,
+} from "../terminals/sessionLifecycleActions";
+
+export type PaletteWorkResult =
+  | {
+      type: "thread";
+      match: ThreadMatch;
+      contentHit: SearchResultItem | null;
+    }
+  | {
+      type: "content";
+      item: SearchResultItem;
+      score: number;
+    };
+
+export type WorkFilterMenuKey = WorkSearchFilterKey | "choose";
+
+export const WORK_FILTER_LABELS: Record<WorkSearchFilterKey, string> = {
+  lane: "Lane",
+  provider: "Provider",
+  status: "Status",
+  type: "Type",
+  machine: "Machine",
+};
+
+function workFilterValueLabel(key: WorkSearchFilterKey, value: string): string {
+  if (key === "status") {
+    const labels: Record<string, string> = {
+      "awaiting-input": "Your move",
+      running: "Running",
+      ended: "Ended",
+      settled: "Settled",
+      snoozed: "Snoozed",
+    };
+    return labels[value] ?? value;
+  }
+  if (key === "type") return value === "chat" ? "Chat" : "Terminal";
+  if (key === "provider") {
+    return value.length > 0
+      ? value.charAt(0).toUpperCase() + value.slice(1)
+      : value;
+  }
+  return value;
+}
+
+export function contentResultScore(
+  item: SearchResultItem,
+  terms: readonly string[],
+): number {
+  const title = item.title.toLowerCase();
+  const titleHit = terms.some((term) => title.includes(term));
+  return 40 + Math.min(item.matchRanges.length * 6, 24) + (titleHit ? 18 : 0);
+}
+
+export function WorkFilterBar({
+  query,
+  parsed,
+  options,
+  filterMenuKey,
+  matchCount,
+  onMenuKeyChange,
+  onAdd,
+  onRemove,
+  onClear,
+}: {
+  query: string;
+  parsed: ParsedWorkSearch;
+  options: Record<WorkSearchFilterKey, string[]>;
+  filterMenuKey: WorkFilterMenuKey | null;
+  matchCount: number;
+  onMenuKeyChange: (key: WorkFilterMenuKey | null) => void;
+  onAdd: (key: WorkSearchFilterKey, value: string) => void;
+  onRemove: (token: ParsedWorkSearch["filterTokens"][number]) => void;
+  onClear: () => void;
+}) {
+  const activeTokens = parsed.filterTokens.filter(
+    (token, index, all) =>
+      all.findIndex(
+        (candidate) =>
+          candidate.key === token.key && candidate.value === token.value,
+      ) === index,
+  );
+  const hasFilters = activeTokens.length > 0;
+
+  return (
+    <div
+      className="relative flex min-h-10 shrink-0 items-center gap-2 border-b px-4 py-1.5 text-[11px]"
+      style={{ borderColor: "var(--color-border)" }}
+    >
+      <span className="shrink-0 font-medium text-[var(--color-muted-fg)]">
+        Work
+      </span>
+      <div className="flex min-w-0 flex-1 flex-wrap items-center gap-1.5">
+        {activeTokens.map((token) => (
+          <button
+            key={`${token.key}:${token.value}`}
+            type="button"
+            className="inline-flex max-w-[170px] items-center gap-1 rounded-full border border-[var(--color-accent)]/35 bg-[var(--color-accent-muted)] px-2 py-0.5 text-[var(--color-fg)] hover:border-[var(--color-accent)]"
+            aria-label={`Remove ${token.key} filter ${token.value}`}
+            onClick={() => onRemove(token)}
+          >
+            <span className="text-[var(--color-muted-fg)]">
+              {WORK_FILTER_LABELS[token.key]}:
+            </span>
+            <span className="truncate">
+              {workFilterValueLabel(token.key, token.value)}
+            </span>
+            <X size={10} weight="bold" aria-hidden />
+          </button>
+        ))}
+        {hasFilters ? (
+          <button
+            type="button"
+            className="shrink-0 px-1 text-[var(--color-muted-fg)] underline decoration-[var(--color-border)] underline-offset-2 hover:text-[var(--color-fg)]"
+            onClick={onClear}
+          >
+            Clear
+          </button>
+        ) : (
+          <span className="truncate text-[var(--color-muted-fg)]">
+            Any lane, provider, status, type, or machine
+          </span>
+        )}
+      </div>
+      <span className="shrink-0 tabular-nums text-[var(--color-muted-fg)]">
+        {matchCount} {matchCount === 1 ? "match" : "matches"}
+      </span>
+      <button
+        type="button"
+        className={
+          filterMenuKey
+            ? "inline-flex h-7 shrink-0 items-center gap-1 rounded-md border border-[var(--color-accent)] bg-[var(--color-accent-muted)] px-2 text-[11px] text-[var(--color-fg)] transition-colors"
+            : "inline-flex h-7 shrink-0 items-center gap-1 rounded-md border border-[var(--color-border)] px-2 text-[11px] text-[var(--color-muted-fg)] transition-colors hover:bg-[var(--color-muted)] hover:text-[var(--color-fg)]"
+        }
+        aria-label="Add Work filter"
+        aria-expanded={filterMenuKey !== null}
+        onClick={() => onMenuKeyChange(filterMenuKey ? null : "choose")}
+      >
+        <Funnel size={12} aria-hidden />
+        Filter
+      </button>
+      {filterMenuKey ? (
+        <div
+          role="menu"
+          aria-label={
+            filterMenuKey === "choose"
+              ? "Work filter facets"
+              : `${WORK_FILTER_LABELS[filterMenuKey]} filter values`
+          }
+          className="absolute right-4 top-full z-20 mt-1 max-h-64 min-w-44 overflow-auto rounded-lg border border-[var(--color-border)] bg-[var(--color-popup-bg)] p-1 shadow-xl"
+        >
+          {filterMenuKey === "choose" ? (
+            <>
+              <div className="flex items-center justify-between px-2 py-1 text-[10px] uppercase tracking-wide text-[var(--color-muted-fg)]">
+                <span>Add Work filter</span>
+                <button
+                  type="button"
+                  className="text-[var(--color-muted-fg)] hover:text-[var(--color-fg)]"
+                  onClick={() => onMenuKeyChange(null)}
+                >
+                  Done
+                </button>
+              </div>
+              {WORK_SEARCH_FILTER_KEYS.map((key) => (
+                <button
+                  key={key}
+                  type="button"
+                  role="menuitem"
+                  className="flex w-full items-center justify-between rounded px-2 py-1.5 text-left text-xs text-[var(--color-fg)] hover:bg-[var(--color-muted)]"
+                  onClick={() => onMenuKeyChange(key)}
+                >
+                  <span>{WORK_FILTER_LABELS[key]}</span>
+                  <span className="ml-2 text-[10px] text-[var(--color-muted-fg)]">
+                    {options[key].length}
+                  </span>
+                </button>
+              ))}
+            </>
+          ) : (
+            <>
+              <div className="flex items-center justify-between px-2 py-1 text-[10px] uppercase tracking-wide text-[var(--color-muted-fg)]">
+                <button
+                  type="button"
+                  className="text-[var(--color-muted-fg)] hover:text-[var(--color-fg)]"
+                  onClick={() => onMenuKeyChange("choose")}
+                >
+                  All filters
+                </button>
+                <button
+                  type="button"
+                  className="text-[var(--color-muted-fg)] hover:text-[var(--color-fg)]"
+                  onClick={() => onMenuKeyChange(null)}
+                >
+                  Done
+                </button>
+              </div>
+              {options[filterMenuKey].length > 0 ? (
+                options[filterMenuKey].map((value) => (
+                  <button
+                    key={value}
+                    type="button"
+                    role="menuitem"
+                    className="flex w-full items-center justify-between rounded px-2 py-1.5 text-left text-xs text-[var(--color-fg)] hover:bg-[var(--color-muted)]"
+                    onClick={() => onAdd(filterMenuKey, value)}
+                  >
+                    <span className="truncate">
+                      {workFilterValueLabel(filterMenuKey, value)}
+                    </span>
+                    {parsed.filters[filterMenuKey].includes(value) ? (
+                      <span className="ml-2 text-[var(--color-accent)]">✓</span>
+                    ) : null}
+                  </button>
+                ))
+              ) : (
+                <div className="px-2 py-2 text-xs text-[var(--color-muted-fg)]">
+                  No values yet.
+                </div>
+              )}
+              <div className="mt-1 border-t border-[var(--color-border)] px-2 py-1 text-[10px] text-[var(--color-muted-fg)]">
+                Choose more than one value to match either.
+              </div>
+            </>
+          )}
+        </div>
+      ) : null}
+      <span className="sr-only">Search: {query}</span>
+    </div>
+  );
+}
+
+export function buildWorkResults({
+  parsedWorkQuery,
+  sessionResults,
+  threadIndex,
+  threadMatches,
+}: {
+  parsedWorkQuery: ParsedWorkSearch;
+  sessionResults: readonly SearchResultItem[];
+  threadIndex: readonly ThreadIndexEntry[];
+  threadMatches: readonly ThreadMatch[];
+}): PaletteWorkResult[] {
+  const contentBySessionId = new Map<string, SearchResultItem>();
+  for (const item of sessionResults) {
+    if (item.sessionId && !contentBySessionId.has(item.sessionId)) {
+      contentBySessionId.set(item.sessionId, item);
+    }
+  }
+
+  const localEntriesById = new Map(
+    threadIndex.map((entry) => [entry.session.id, entry] as const),
+  );
+  const matchedSessionIds = new Set<string>();
+  const merged: PaletteWorkResult[] = threadMatches.map((match) => {
+    const sessionId = match.entry.session.id;
+    matchedSessionIds.add(sessionId);
+    const contentHit = contentBySessionId.get(sessionId) ?? null;
+    if (contentHit && !match.matchFields.includes("content")) {
+      match = {
+        ...match,
+        score: match.score + 8,
+        matchFields: [...match.matchFields, "content"],
+      };
+    }
+    return { type: "thread", match, contentHit };
+  });
+
+  const contentIds = new Set<string>();
+  for (const item of sessionResults) {
+    if (item.sessionId && matchedSessionIds.has(item.sessionId)) continue;
+    if (item.sessionId) {
+      const localEntry = localEntriesById.get(item.sessionId);
+      if (localEntry) {
+        if (!matchesThreadWorkFacets(localEntry, parsedWorkQuery)) continue;
+        matchedSessionIds.add(item.sessionId);
+        merged.push({
+          type: "thread",
+          match: {
+            entry: localEntry,
+            score: contentResultScore(item, parsedWorkQuery.terms),
+            matchFields: ["content"],
+          },
+          contentHit: item,
+        });
+        continue;
+      }
+      // Local-only facets cannot be evaluated safely for an unindexed session.
+      if (
+        parsedWorkQuery.filterTokens.length > 0 ||
+        parsedWorkQuery.tracked !== null
+      ) continue;
+    }
+    if (contentIds.has(item.id)) continue;
+    contentIds.add(item.id);
+    merged.push({
+      type: "content",
+      item,
+      score: contentResultScore(item, parsedWorkQuery.terms),
+    });
+  }
+
+  merged.sort((left, right) => {
+    const scoreLeft = left.type === "thread" ? left.match.score : left.score;
+    const scoreRight = right.type === "thread" ? right.match.score : right.score;
+    if (scoreLeft !== scoreRight) return scoreRight - scoreLeft;
+    const timeLeft = left.type === "thread"
+      ? left.match.entry.recencyMs
+      : new Date(left.item.updatedAt).getTime();
+    const timeRight = right.type === "thread"
+      ? right.match.entry.recencyMs
+      : new Date(right.item.updatedAt).getTime();
+    return timeRight - timeLeft;
+  });
+  return merged;
+}
+
+export function useWorkSessionActions({
+  navigate,
+  onOpenChange,
+  projectRoot,
+  projectBinding,
+  setWorkViewState,
+  switchProjectToPath,
+  switchRemoteProject,
+}: {
+  navigate: (path: string) => void;
+  onOpenChange: (open: boolean) => void;
+  projectRoot: string | null;
+  projectBinding: OpenProjectBinding | null;
+  setWorkViewState: (
+    projectRoot: string | null | undefined,
+    next:
+      | Partial<WorkProjectViewState>
+      | ((prev: WorkProjectViewState) => WorkProjectViewState),
+  ) => void;
+  switchProjectToPath: (rootPath: string) => Promise<void>;
+  switchRemoteProject: (
+    targetId: string,
+    projectId: string,
+  ) => Promise<OpenProjectBinding>;
+}) {
+  return useCallback(
+    async (entry: ThreadIndexEntry, action: ThreadRowAction) => {
+      const { session, binding } = entry;
+      if (action === "new-chat") {
+        // Persist the draft before navigation. Work can be unmounted while the
+        // palette is open, so an ephemeral window event would be lost before
+        // the destination page gets a chance to consume it.
+        const destinationProjectKey = projectStateKeyForBinding(
+          binding,
+          projectRoot,
+        );
+        setWorkViewState(destinationProjectKey, (previous) => ({
+          ...previous,
+          draftKind: "chat",
+          draftLaneId: session.laneId || null,
+          draftMachineId: binding?.kind === "remote" ? binding.targetId : null,
+          orchestratorEnabled: false,
+          activeItemId: null,
+          selectedItemId: null,
+        }));
+        const currentProjectKey = projectStateKeyForBinding(
+          projectBinding,
+          projectRoot,
+        );
+        const switching =
+          !binding || destinationProjectKey === currentProjectKey
+            ? Promise.resolve()
+            : binding.kind === "remote"
+              ? switchRemoteProject(binding.targetId, binding.projectId)
+              : switchProjectToPath(binding.rootPath);
+        try {
+          await switching;
+          navigate("/work");
+          onOpenChange(false);
+        } catch (error) {
+          console.error("[CommandPalette] new chat target switch failed", {
+            error,
+            sessionId: session.id,
+          });
+        }
+        return;
+      }
+
+      if (action === "rename") {
+        const nextTitle = window.prompt("Rename session", session.title ?? "")?.trim();
+        if (!nextTitle) return;
+        try {
+          await renameSession(session, nextTitle, binding);
+          invalidateSessionListCache();
+        } catch (error) {
+          console.error("[CommandPalette] rename session failed", {
+            sessionId: session.id,
+            error,
+          });
+        }
+        onOpenChange(false);
+        return;
+      }
+
+      if (action === "settle") {
+        const isSettled =
+          sessionCanonicalUiState(canonicalInputFromSummary(session)).phase ===
+          "settled";
+        if (isSettled) await unsettleSession(session, binding);
+        else await settleSession(session, binding);
+        onOpenChange(false);
+        return;
+      }
+
+      if (isSessionSnoozed(session)) {
+        await wakeSessionNow(session, binding);
+      } else {
+        await snoozeSessionForDuration(session, "hour", Date.now(), binding);
+      }
+      onOpenChange(false);
+    },
+    [
+      navigate,
+      onOpenChange,
+      projectBinding,
+      projectRoot,
+      setWorkViewState,
+      switchProjectToPath,
+      switchRemoteProject,
+    ],
+  );
+}

--- a/apps/desktop/src/renderer/components/app/commandPaletteWork.tsx
+++ b/apps/desktop/src/renderer/components/app/commandPaletteWork.tsx
@@ -319,6 +319,14 @@ export function buildWorkResults({
         parsedWorkQuery.tracked !== null
       ) continue;
     }
+    // A content result without an owning session cannot prove provider,
+    // status, type, or machine facets. Do not let it bypass a local facet just
+    // because the backend omitted sessionId.
+    if (
+      !item.sessionId &&
+      (parsedWorkQuery.filterTokens.length > 0 ||
+        parsedWorkQuery.tracked !== null)
+    ) continue;
     if (contentIds.has(item.id)) continue;
     contentIds.add(item.id);
     merged.push({
@@ -379,15 +387,6 @@ export function useWorkSessionActions({
           binding,
           projectRoot,
         );
-        setWorkViewState(destinationProjectKey, (previous) => ({
-          ...previous,
-          draftKind: "chat",
-          draftLaneId: session.laneId || null,
-          draftMachineId: binding?.kind === "remote" ? binding.targetId : null,
-          orchestratorEnabled: false,
-          activeItemId: null,
-          selectedItemId: null,
-        }));
         const currentProjectKey = projectStateKeyForBinding(
           projectBinding,
           projectRoot,
@@ -400,6 +399,15 @@ export function useWorkSessionActions({
               : switchProjectToPath(binding.rootPath);
         try {
           await switching;
+          setWorkViewState(destinationProjectKey, (previous) => ({
+            ...previous,
+            draftKind: "chat",
+            draftLaneId: session.laneId || null,
+            draftMachineId: binding?.kind === "remote" ? binding.targetId : null,
+            orchestratorEnabled: false,
+            activeItemId: null,
+            selectedItemId: null,
+          }));
           navigate("/work");
           onOpenChange(false);
         } catch (error) {

--- a/apps/desktop/src/renderer/components/terminals/TerminalsPage.tsx
+++ b/apps/desktop/src/renderer/components/terminals/TerminalsPage.tsx
@@ -57,7 +57,7 @@ import {
   type HandoffLaunchJob,
 } from "../../lib/handoffLaunchJobs";
 import { getLaneDeleteStatusLabel } from "../../lib/laneDeleteProgress";
-import { clearSessionWokeMarker } from "./sessionLifecycleActions";
+import { clearSessionWokeMarker, renameSession } from "./sessionLifecycleActions";
 import { useWorkLaneDeleteProgress } from "./useWorkLaneDeleteProgress";
 import { useRetainedCrossMachineSlices } from "./useWorkMachineRouter";
 import { buildPtyContinuationLaunchFields } from "./cliLaunch";
@@ -1659,27 +1659,7 @@ export function TerminalsPage({ active = true }: { active?: boolean }) {
           });
         }}
         onRename={(session, newTitle, runtimePin) => {
-          let renamePromise: Promise<unknown>;
-          if (isChatToolType(session.toolType)) {
-            renamePromise = runtimePin
-              ? window.ade.agentChat.updateSession(
-                { sessionId: session.id, title: newTitle, manuallyNamed: true },
-                runtimePin,
-              )
-              : window.ade.agentChat.updateSession(
-                { sessionId: session.id, title: newTitle, manuallyNamed: true },
-              );
-          } else {
-            renamePromise = runtimePin
-              ? window.ade.sessions.updateMeta(
-                { sessionId: session.id, title: newTitle, manuallyNamed: true },
-                runtimePin,
-              )
-              : window.ade.sessions.updateMeta(
-                { sessionId: session.id, title: newTitle, manuallyNamed: true },
-              );
-          }
-          runSessionMutation(session.id, renamePromise, {
+          runSessionMutation(session.id, renameSession(session, newTitle, runtimePin), {
             actionName: "rename session",
             errorLabel: "Rename",
             refreshLabel: "rename",

--- a/apps/desktop/src/renderer/components/terminals/sessionLifecycleActions.ts
+++ b/apps/desktop/src/renderer/components/terminals/sessionLifecycleActions.ts
@@ -8,6 +8,7 @@ import {
   canonicalInputFromSummary,
   sessionNeedsYou,
 } from "../../lib/terminalAttention";
+import { isChatToolType } from "../../lib/sessions";
 import {
   snoozeConfirmationLabel,
   snoozeDeadlineIso,
@@ -21,6 +22,24 @@ import {
  */
 
 const UNDO_TOAST_MS = 5_000;
+
+/** Rename either a chat or a terminal through its owning runtime binding. */
+export async function renameSession(
+  session: Pick<TerminalSessionSummary, "id" | "toolType">,
+  title: string,
+  pin?: OpenProjectBinding | null,
+): Promise<void> {
+  const input = { sessionId: session.id, title, manuallyNamed: true };
+  if (isChatToolType(session.toolType)) {
+    await (pin
+      ? window.ade.agentChat.updateSession(input, pin)
+      : window.ade.agentChat.updateSession(input));
+    return;
+  }
+  await (pin
+    ? window.ade.sessions.updateMeta(input, pin)
+    : window.ade.sessions.updateMeta(input));
+}
 
 function reportFailure(action: string, sessionId: string, error: unknown): void {
   console.error(`[sessionLifecycle] ${action} failed`, { sessionId, error });

--- a/apps/desktop/src/renderer/components/terminals/useWorkSessions.ts
+++ b/apps/desktop/src/renderer/components/terminals/useWorkSessions.ts
@@ -35,7 +35,12 @@ import {
   matchesWorkSessionFilters,
   type WorkSessionFilters,
 } from "./workSessionFilters";
-import { buildOptimisticChatSessionSummary } from "../../lib/sessions";
+import { buildOptimisticChatSessionSummary, isChatToolType } from "../../lib/sessions";
+import {
+  matchesWorkSearchFilters,
+  matchesWorkSearchTerms,
+  parseWorkSearchQuery,
+} from "../../../shared/workSearch";
 import {
   shouldRefreshSessionListForChatEvent,
   subscribeWorkChatSessionCreated,
@@ -1511,35 +1516,38 @@ export function useWorkSessions({ active = true }: UseWorkSessionsOptions = {}) 
   const filtered = useMemo(() => {
     // Filtering here is active-binding-only: SessionListPane applies the same
     // controls to its separately rendered cross-machine rows.
-    const needle = q.trim().toLowerCase();
+    const parsedQuery = parseWorkSearchQuery(q);
+    const nowMs = Date.now();
     return sessions.filter((session) => {
       if (filterLaneId !== "all" && session.laneId !== filterLaneId) return false;
-      if (!needle) return true;
+      if (parsedQuery.tracked === "yes" || parsedQuery.tracked === "true") {
+        if (!session.tracked) return false;
+      } else if (parsedQuery.tracked === "no" || parsedQuery.tracked === "false") {
+        if (session.tracked) return false;
+      }
+      if (!matchesWorkSearchTerms(parsedQuery.terms, [
+        session.goal,
+        session.title,
+        session.laneName,
+        session.toolType,
+        session.lastOutputPreview,
+        session.summary,
+        session.claudeTag,
+        session.resumeCommand,
+      ])) return false;
 
-      if (needle.startsWith("lane:")) {
-        const value = needle.slice(5).trim();
-        return session.laneName.toLowerCase().includes(value);
-      }
-      if (needle.startsWith("type:")) {
-        const value = needle.slice(5).trim();
-        return (session.toolType ?? "").toLowerCase().includes(value);
-      }
-      if (needle.startsWith("tracked:")) {
-        const value = needle.slice(8).trim();
-        if (value === "yes" || value === "true") return session.tracked;
-        if (value === "no" || value === "false") return !session.tracked;
-        return true;
-      }
-
-      return (
-        (session.goal ?? session.title).toLowerCase().includes(needle) ||
-        session.laneName.toLowerCase().includes(needle) ||
-        (session.toolType ?? "").toLowerCase().includes(needle) ||
-        (session.lastOutputPreview ?? "").toLowerCase().includes(needle) ||
-        (session.summary ?? "").toLowerCase().includes(needle) ||
-        (session.claudeTag ?? "").toLowerCase().includes(needle) ||
-        (session.resumeCommand ?? "").toLowerCase().includes(needle)
-      );
+      // Keep the inline Work search and Cmd-K's typed facets on the same
+      // vocabulary. The machine facet is resolved by the palette's cross-
+      // machine index; this active-binding list has no machine dimension.
+      return matchesWorkSearchFilters(parsedQuery.filters, {
+        lane: [session.laneName],
+        provider: [session.toolType ?? ""],
+        status: [sessionFilingBucket(session, nowMs)],
+        type: [
+          session.toolType ?? "",
+          isChatToolType(session.toolType) ? "chat" : "terminal",
+        ],
+      });
     });
   }, [sessions, filterLaneId, q]);
 

--- a/apps/desktop/src/renderer/components/terminals/workSessionFilters.test.ts
+++ b/apps/desktop/src/renderer/components/terminals/workSessionFilters.test.ts
@@ -9,6 +9,14 @@ import {
   workToolFamily,
   type WorkSessionFilters,
 } from "./workSessionFilters";
+import {
+  appendWorkSearchFilter,
+  matchesWorkSearchFilters,
+  matchesWorkSearchTerms,
+  parseWorkSearchQuery,
+  removeWorkSearchFilterToken,
+  scoreWorkSearchTerms,
+} from "../../../shared/workSearch";
 
 function makeSession(overrides: Partial<TerminalSessionSummary> = {}): TerminalSessionSummary {
   return {
@@ -147,5 +155,56 @@ describe("activeWorkSessionFilterLabels", () => {
     expect(activeWorkSessionFilterLabels(filters({
       status: ["awaiting-input"], tool: ["claude"], hasPr: true,
     }))).toEqual(["Your move", "Claude", "Has PR"]);
+  });
+});
+
+describe("shared Work search vocabulary", () => {
+  it("matches every word in any order and keeps quoted phrases together", () => {
+    const parsed = parseWorkSearchQuery('migration auth "login flow"');
+
+    expect(parsed.terms).toEqual(["migration", "auth", "login flow"]);
+    expect(matchesWorkSearchTerms(parsed.terms, ["auth migration", "fix login flow"])).toBe(true);
+    expect(matchesWorkSearchTerms(parsed.terms, ["migration only", "auth"])).toBe(false);
+  });
+
+  it("ANDs facets across keys and ORs values within one key", () => {
+    const parsed = parseWorkSearchQuery("provider:codex provider:claude status:running");
+
+    expect(matchesWorkSearchFilters(parsed.filters, {
+      provider: ["codex-chat"],
+      status: ["running"],
+    })).toBe(true);
+    expect(matchesWorkSearchFilters(parsed.filters, {
+      provider: ["cursor"],
+      status: ["running"],
+    })).toBe(false);
+    expect(matchesWorkSearchFilters(parsed.filters, {
+      provider: ["codex"],
+      status: ["ended"],
+    })).toBe(false);
+  });
+
+  it("adds and removes a typed facet without disturbing free text", () => {
+    const query = appendWorkSearchFilter("migration", "lane", "auth flow");
+    const parsed = parseWorkSearchQuery(query);
+
+    expect(query).toBe('migration lane:"auth flow"');
+    expect(removeWorkSearchFilterToken(query, parsed.filterTokens[0]!)).toBe("migration");
+  });
+
+  it("keeps kind aliases local and fans repeated lanes out for backend search", () => {
+    const parsed = parseWorkSearchQuery("kind:chat lane:auth lane:payments");
+
+    expect(parsed.terms).toEqual([]);
+    expect(parsed.filters.type).toEqual(["chat"]);
+    expect(parsed.backendQueries).toEqual([
+      "kind:chat lane:auth",
+      "kind:chat lane:payments",
+    ]);
+  });
+
+  it("keeps the TUI subsequence fallback for compact command queries", () => {
+    expect(scoreWorkSearchTerms(["nch"], ["/new chat"])).not.toBeNull();
+    expect(scoreWorkSearchTerms(["nch"], ["/rename"])).toBeNull();
   });
 });

--- a/apps/desktop/src/renderer/components/terminals/workSessionFilters.test.ts
+++ b/apps/desktop/src/renderer/components/terminals/workSessionFilters.test.ts
@@ -192,6 +192,26 @@ describe("shared Work search vocabulary", () => {
     expect(removeWorkSearchFilterToken(query, parsed.filterTokens[0]!)).toBe("migration");
   });
 
+  it("removes one value from a comma-separated facet chip", () => {
+    const query = "provider:codex,claude auth";
+    const parsed = parseWorkSearchQuery(query);
+
+    expect(removeWorkSearchFilterToken(query, parsed.filterTokens[0]!)).toBe(
+      "provider:claude auth",
+    );
+    const remaining = parseWorkSearchQuery("provider:claude auth");
+    expect(removeWorkSearchFilterToken("provider:claude auth", remaining.filterTokens[0]!)).toBe(
+      "auth",
+    );
+  });
+
+  it("keeps universal backend aliases out of local required terms", () => {
+    const parsed = parseWorkSearchQuery("since:7d session:session-1 auth");
+
+    expect(parsed.terms).toEqual(["auth"]);
+    expect(parsed.backendQuery).toBe("since:7d session:session-1 auth");
+  });
+
   it("keeps kind aliases local and fans repeated lanes out for backend search", () => {
     const parsed = parseWorkSearchQuery("kind:chat lane:auth lane:payments");
 

--- a/apps/desktop/src/shared/workSearch.ts
+++ b/apps/desktop/src/shared/workSearch.ts
@@ -1,0 +1,255 @@
+/**
+ * Search vocabulary shared by Work's cached session list, the desktop command
+ * palette, and the ADE TUI. Keep the parser deliberately small: users get
+ * quoted phrases, whitespace-separated any-order terms, and the facets Work
+ * can actually explain in a result row.
+ */
+
+export const WORK_SEARCH_FILTER_KEYS = [
+  "lane",
+  "provider",
+  "status",
+  "type",
+  "machine",
+] as const;
+
+export type WorkSearchFilterKey = (typeof WORK_SEARCH_FILTER_KEYS)[number];
+
+export type WorkSearchFilterToken = {
+  key: WorkSearchFilterKey;
+  value: string;
+  raw: string;
+};
+
+export type ParsedWorkSearch = {
+  /** Bare words and quoted phrases, already lowercased. */
+  terms: string[];
+  /** Facets are OR-ed within a key and AND-ed across keys. */
+  filters: Record<WorkSearchFilterKey, string[]>;
+  filterTokens: WorkSearchFilterToken[];
+  /** Existing universal-search aliases plus free text, minus local-only facets. */
+  backendQuery: string;
+  /** One backend query per lane so repeated lane: values retain OR semantics. */
+  backendQueries: string[];
+  /** Legacy Work-only alias retained for the inline list. */
+  tracked: string | null;
+};
+
+type ParsedToken = {
+  raw: string;
+  key: string | null;
+  value: string;
+};
+
+const TOKEN_RE =
+  /(?:(lane|provider|status|type|machine|kind|since|session|tracked):)?(?:"([^"]+)"|(\S+))/gi;
+const WORK_FACET_KEY_SET = new Set<string>(WORK_SEARCH_FILTER_KEYS);
+
+function emptyFilters(): Record<WorkSearchFilterKey, string[]> {
+  return {
+    lane: [],
+    provider: [],
+    status: [],
+    type: [],
+    machine: [],
+  };
+}
+
+function normalize(value: string): string {
+  return value.trim().toLowerCase();
+}
+
+function tokenValue(value: string): string {
+  return normalize(value).replace(/\s+/g, " ");
+}
+
+function isWorkSearchFilterKey(key: string): key is WorkSearchFilterKey {
+  return WORK_FACET_KEY_SET.has(key);
+}
+
+function renderBackendFacetValue(value: string): string {
+  return /[\s,]/.test(value)
+    ? `"${value.replace(/"/g, "")}"`
+    : value;
+}
+
+function parseTokens(query: string): ParsedToken[] {
+  const tokens: ParsedToken[] = [];
+  for (const match of query.matchAll(TOKEN_RE)) {
+    const raw = match[0] ?? "";
+    const key = match[1]?.toLowerCase() ?? null;
+    const value = match[2] ?? match[3] ?? "";
+    if (raw && value) tokens.push({ raw, key, value });
+  }
+  return tokens;
+}
+
+/** Parse the user-facing Work query without losing phrase boundaries. */
+export function parseWorkSearchQuery(query: string): ParsedWorkSearch {
+  const filters = emptyFilters();
+  const terms: string[] = [];
+  const filterTokens: WorkSearchFilterToken[] = [];
+  const backendTokens: string[] = [];
+  const laneValues: string[] = [];
+  let tracked: string | null = null;
+
+  for (const token of parseTokens(query.trim())) {
+    const value = tokenValue(token.value);
+    if (!value) continue;
+
+    if (token.key && isWorkSearchFilterKey(token.key)) {
+      const key = token.key;
+      const values = value.split(",").map(tokenValue).filter(Boolean);
+      for (const filterValue of values) {
+        filters[key].push(filterValue);
+        filterTokens.push({ key, value: filterValue, raw: token.raw });
+      }
+      // `lane:` is understood by the universal index too. Keep each value so
+      // the backend can be queried once per lane; its parser stores one lane
+      // value, while Work's user-facing contract is OR within a facet.
+      if (key === "lane") laneValues.push(...values);
+      continue;
+    }
+
+    // `kind:` is an existing universal-search alias. Work treats it as its
+    // type facet as well, so cached rows obey the same restriction as content
+    // hits instead of treating "chat" as ordinary free text.
+    if (token.key === "kind") {
+      const values = value.split(",").map(tokenValue).filter(Boolean);
+      for (const filterValue of values) {
+        filters.type.push(filterValue);
+        filterTokens.push({ key: "type", value: filterValue, raw: token.raw });
+      }
+      backendTokens.push(token.raw);
+      continue;
+    }
+
+    if (token.key === "tracked") {
+      tracked = value;
+      continue;
+    }
+
+    terms.push(value);
+    backendTokens.push(token.raw);
+  }
+
+  const backendBase = backendTokens.join(" ");
+  const backendQueries = laneValues.length > 0
+    ? [...new Set(laneValues)].map((lane) => `${backendBase} lane:${renderBackendFacetValue(lane)}`.trim())
+    : [backendBase];
+
+  return {
+    terms,
+    filters,
+    filterTokens,
+    backendQuery: backendQueries[0] ?? "",
+    backendQueries,
+    tracked,
+  };
+}
+
+/** Every bare word/phrase must be present somewhere in the indexed fields. */
+export function matchesWorkSearchTerms(
+  terms: readonly string[],
+  fields: readonly (string | null | undefined)[],
+): boolean {
+  if (terms.length === 0) return true;
+  const haystack = fields
+    .filter(
+      (field): field is string => typeof field === "string" && field.length > 0,
+    )
+    .join(" ")
+    .toLowerCase();
+  return terms.every((term) => haystack.includes(term));
+}
+
+/**
+ * Score TUI-style labels while retaining its established subsequence fallback.
+ * Desktop Work rows use the stricter matcher above; the TUI command palette has
+ * historically let short queries such as "nch" find "/new chat".
+ */
+export function scoreWorkSearchTerms(
+  terms: readonly string[],
+  fields: readonly (string | null | undefined)[],
+): number | null {
+  if (terms.length === 0) return 0;
+  const haystack = fields
+    .filter(
+      (field): field is string => typeof field === "string" && field.length > 0,
+    )
+    .join(" ")
+    .toLowerCase();
+  let total = 0;
+  for (const term of terms) {
+    const exactIndex = haystack.indexOf(term);
+    if (exactIndex >= 0) {
+      total += exactIndex;
+      continue;
+    }
+    let cursor = 0;
+    let fuzzyScore = 0;
+    for (const char of term) {
+      const found = haystack.indexOf(char, cursor);
+      if (found < 0) return null;
+      fuzzyScore += found - cursor;
+      cursor = found + 1;
+    }
+    total += fuzzyScore + haystack.length;
+  }
+  return total;
+}
+
+function valueMatchesFacet(value: string, wanted: string): boolean {
+  const normalizedValue = normalize(value);
+  const normalizedWanted = normalize(wanted);
+  return (
+    normalizedValue === normalizedWanted ||
+    normalizedValue.includes(normalizedWanted)
+  );
+}
+
+/** Apply the facet contract: OR within one facet, AND across facets. */
+export function matchesWorkSearchFilters(
+  filters: ParsedWorkSearch["filters"],
+  facets: Partial<Record<WorkSearchFilterKey, readonly string[]>>,
+): boolean {
+  for (const key of WORK_SEARCH_FILTER_KEYS) {
+    const wanted = filters[key];
+    if (wanted.length === 0) continue;
+    const available = facets[key] ?? [];
+    if (
+      !wanted.some((candidate) =>
+        available.some((value) => valueMatchesFacet(value, candidate)),
+      )
+    ) {
+      return false;
+    }
+  }
+  return true;
+}
+
+/** Remove one typed facet occurrence when its inline chip is dismissed. */
+export function removeWorkSearchFilterToken(
+  query: string,
+  token: WorkSearchFilterToken,
+): string {
+  const index = query.toLowerCase().indexOf(token.raw.toLowerCase());
+  if (index < 0) return query;
+  return `${query.slice(0, index)} ${query.slice(index + token.raw.length)}`
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+/** Add a facet from the palette picker while keeping free text intact. */
+export function appendWorkSearchFilter(
+  query: string,
+  key: WorkSearchFilterKey,
+  value: string,
+): string {
+  const normalizedValue = value.trim();
+  if (!normalizedValue) return query;
+  const renderedValue = /[\s,]/.test(normalizedValue)
+    ? `"${normalizedValue.replace(/"/g, "")}"`
+    : normalizedValue;
+  return `${query.trim()}${query.trim() ? " " : ""}${key}:${renderedValue}`;
+}

--- a/apps/desktop/src/shared/workSearch.ts
+++ b/apps/desktop/src/shared/workSearch.ts
@@ -19,6 +19,8 @@ export type WorkSearchFilterToken = {
   key: WorkSearchFilterKey;
   value: string;
   raw: string;
+  /** Position within a comma-separated filter token. */
+  valueIndex: number;
 };
 
 export type ParsedWorkSearch = {
@@ -100,9 +102,14 @@ export function parseWorkSearchQuery(query: string): ParsedWorkSearch {
     if (token.key && isWorkSearchFilterKey(token.key)) {
       const key = token.key;
       const values = value.split(",").map(tokenValue).filter(Boolean);
-      for (const filterValue of values) {
+      for (const [valueIndex, filterValue] of values.entries()) {
         filters[key].push(filterValue);
-        filterTokens.push({ key, value: filterValue, raw: token.raw });
+        filterTokens.push({
+          key,
+          value: filterValue,
+          raw: token.raw,
+          valueIndex,
+        });
       }
       // `lane:` is understood by the universal index too. Keep each value so
       // the backend can be queried once per lane; its parser stores one lane
@@ -116,9 +123,14 @@ export function parseWorkSearchQuery(query: string): ParsedWorkSearch {
     // hits instead of treating "chat" as ordinary free text.
     if (token.key === "kind") {
       const values = value.split(",").map(tokenValue).filter(Boolean);
-      for (const filterValue of values) {
+      for (const [valueIndex, filterValue] of values.entries()) {
         filters.type.push(filterValue);
-        filterTokens.push({ key: "type", value: filterValue, raw: token.raw });
+        filterTokens.push({
+          key: "type",
+          value: filterValue,
+          raw: token.raw,
+          valueIndex,
+        });
       }
       backendTokens.push(token.raw);
       continue;
@@ -126,6 +138,15 @@ export function parseWorkSearchQuery(query: string): ParsedWorkSearch {
 
     if (token.key === "tracked") {
       tracked = value;
+      continue;
+    }
+
+    // These are valid universal-search filters, but Work does not have a
+    // local representation for their semantics. Preserve them for the
+    // backend without making values such as "7d" or a session id required
+    // words in cached Work rows.
+    if (token.key === "since" || token.key === "session") {
+      backendTokens.push(token.raw);
       continue;
     }
 
@@ -235,6 +256,28 @@ export function removeWorkSearchFilterToken(
 ): string {
   const index = query.toLowerCase().indexOf(token.raw.toLowerCase());
   if (index < 0) return query;
+
+  const colon = token.raw.indexOf(":");
+  const rawValues = colon >= 0 ? token.raw.slice(colon + 1).split(",") : [];
+  if (rawValues.length > 1) {
+    const valueIndex = Math.min(token.valueIndex, rawValues.length - 1);
+    const valueStart = index + colon + 1;
+    const partStart = valueStart
+      + rawValues
+        .slice(0, valueIndex)
+        .reduce((offset, part) => offset + part.length + 1, 0);
+    const partEnd = partStart + rawValues[valueIndex]!.length;
+    const removeStart = valueIndex === rawValues.length - 1
+      ? partStart - 1
+      : partStart;
+    const removeEnd = valueIndex === rawValues.length - 1
+      ? partEnd
+      : partEnd + 1;
+    return `${query.slice(0, removeStart)}${query.slice(removeEnd)}`
+      .replace(/\s+/g, " ")
+      .trim();
+  }
+
   return `${query.slice(0, index)} ${query.slice(index + token.raw.length)}`
     .replace(/\s+/g, " ")
     .trim();


### PR DESCRIPTION


<!-- ade:link v=1 type=pr repo=arul28/ADE branch=ade%2Fwork-search-and-palette-89513ac2 num=1174 -->
<p>
  <img src="https://ade-app.dev/logo.png" height="18" align="left" alt="ADE">
  &nbsp;&nbsp;<strong>Open in ADE</strong>
  &nbsp;·&nbsp; <a href="https://ade-app.dev/open?type=branch&amp;repo=arul28%2FADE&amp;branch=ade%2Fwork-search-and-palette-89513ac2&amp;pr=1174">ade/work-search-and-palette-89513ac2 branch</a>
  &nbsp;·&nbsp; <a href="https://ade-app.dev/open?type=pr&amp;repo=arul28%2FADE&amp;number=1174">PR #1174</a>
</p>
<!-- /ade:link -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches high-traffic search/navigation and session lifecycle actions across local and remote bindings; behavior changes are broad but covered by new tests.
> 
> **Overview**
> Introduces **`workSearch`** as shared query parsing and matching for the Work sidebar, desktop **Command Palette**, and **ADE TUI**—any-order words, quoted phrases, and typed facets (`lane`, `provider`, `status`, `type`, `machine`, plus `kind`/`tracked` aliases). Inline Work filtering and palette command/thread ranking now use the same rules; the TUI keeps its subsequence fallback for short command queries.
> 
> The palette becomes **Work-first**: a filter bar with removable chips, merged local thread hits with universal **chat/terminal content** search (no duplicate rows), facet-aware backend queries (including one query per `lane:` when several lanes are OR’d), and transcript snippets promoted onto matching sessions. Work rows gain **lifecycle actions** (new chat with draft persisted in store when Work isn’t mounted, rename, settle/unsettle, snooze) with **remote project binding** passed through for API calls.
> 
> Thread indexing/search expands to goal, summary, provider, and filing status; **`renameSession`** is centralized for Terminals and the palette.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4e399cef2b19350102333f58eeb656ce8ef9e6f1. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->