### PR TITLE
docs(release): v1.2.67 release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,40 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.2.67] - 2026-08-28
+
+### Compact from the meter
+
+- An idle measured context dial is a compact control on Claude, Codex, and Pi: click sends `/compact` without replacing the unsent draft. Cursor, Droid, and OpenCode stay read-only (#1169).
+- iOS has the same action in the usage popover. Compact never steers an active turn. ADE still auto-compacts Claude at 97% at a turn boundary; 80% is a hint (#1169).
+
+### Name and status
+
+- Refresh the chat title, lane name, and/or status line from the session context menu. One model call returns all three; only the selected fields apply, and in-flight edits win (#1172).
+- A menu-driven title counts as manually named so quiet auto-title does not overwrite it. Primary lanes skip lane-name generation (#1172).
+
+### Chat attachments
+
+- HEIC and HEIF photos convert to JPEG on macOS before they hit the transcript or a provider. Windows and Linux refuse conversion instead of attaching mislabeled bytes (#1170).
+- Drop files onto the whole chat surface — header, transcript, and composer — not only the composer (#1170).
+
+### Lanes
+
+- Lane templates can run setup scripts when a lane is created, and tear Docker down when you archive the lane (#1173).
+- Settings for templates is simpler. A cancelled setup is treated as incomplete so the next open re-runs it (#1173).
+
+### Codex approvals
+
+- Stop, abort, teardown, and thread delete settle Codex approval cards, including a plan card that appeared after the turn already finished. Stop-only still leaves the card for you to answer (#1171).
+
+### Linux brains
+
+- Linux `install.sh` runtimes vendor cr-sqlite for x64 and arm64, so a signed-in Linux brain hosts CRR like macOS and Windows (#1168).
+
+### Work search
+
+- The command palette searches Work in any word order, with typed filters, ranked content hits, and lifecycle actions on sessions.
+
 ## [1.2.66] - 2026-08-27
 
 ### Pull requests
@@ -1772,7 +1806,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Initial public release.
 
-[Unreleased]: https://github.com/arul28/ADE/compare/v1.2.66...HEAD
+[Unreleased]: https://github.com/arul28/ADE/compare/v1.2.67...HEAD
+[1.2.67]: https://github.com/arul28/ADE/compare/v1.2.66...v1.2.67
 [1.2.66]: https://github.com/arul28/ADE/compare/v1.2.65...v1.2.66
 [1.2.65]: https://github.com/arul28/ADE/compare/v1.2.64...v1.2.65
 [1.2.64]: https://github.com/arul28/ADE/compare/v1.2.63...v1.2.64

--- a/changelog/index.mdx
+++ b/changelog/index.mdx
@@ -5,6 +5,6 @@ description: "Latest ADE release notes and release history."
 
 ADE release notes live here in newest-first order. Start with the latest release, or browse the release list in the sidebar.
 
-<Card title="Latest release" icon="tag" href="/changelog/v1.2.66">
-  v1.2.66 - React to and edit PR comments from ADE, open any lane in an installed editor including over SSH, agents delegate through their own provider's subagents, and two lanes on the same branch sit together in Work.
+<Card title="Latest release" icon="tag" href="/changelog/v1.2.67">
+  v1.2.67 - Compact from the context meter, regenerate a chat's title and status, drop HEIC onto the chat surface, run lane-template setup scripts, settle leftover Codex approvals, and keep Linux brains in sync.
 </Card>

--- a/changelog/v1.2.67.mdx
+++ b/changelog/v1.2.67.mdx
@@ -1,0 +1,40 @@
+---
+title: "v1.2.67"
+description: "Release notes for ADE v1.2.67 - August 28, 2026"
+---
+
+Click a measured context meter to compact Claude, Codex, or Pi without losing the draft. Rename a chat, its lane, and its status line from the session menu. Drop HEIC photos and files onto the whole chat surface. Lane templates can run setup scripts and tear Docker down when you archive. Linux brains stay in sync with macOS and Windows.
+
+---
+
+## Compact from the meter
+
+- **An idle context dial is a compact control** on Claude, Codex, and Pi. Click it to send `/compact` without replacing the unsent draft. Cursor, Droid, and OpenCode stay read-only.
+- **iOS has the same action** in the usage popover. Compact never steers an active turn. ADE still auto-compacts Claude at 97% at a turn boundary; 80% is a hint.
+
+## Name and status
+
+- **Refresh the chat title, lane name, and/or status line** from the session context menu. One model call returns all three; only the fields you picked are applied, and in-flight edits win.
+- **A menu-driven title counts as manually named**, so quiet auto-title does not overwrite it. Primary lanes skip lane-name generation.
+
+## Chat attachments
+
+- **HEIC and HEIF photos convert to JPEG on macOS** before they hit the transcript or a provider. Windows and Linux refuse conversion instead of attaching mislabeled bytes.
+- **Drop files onto the whole chat surface** — header, transcript, and composer — not only the composer.
+
+## Lanes
+
+- **Lane templates can run setup scripts** when a lane is created, and tear Docker down when you archive the lane.
+- **Settings for templates is simpler.** A cancelled setup is treated as incomplete so the next open re-runs it.
+
+## Codex approvals
+
+- **Stop, abort, teardown, and thread delete settle Codex approval cards.** A plan card that appeared after the turn already finished no longer blocks every later send. Stop-only still leaves the card for you to answer.
+
+## Linux brains
+
+- **Linux `install.sh` runtimes vendor cr-sqlite** for x64 and arm64, so a signed-in Linux brain hosts CRR like macOS and Windows instead of dropping out of the account directory.
+
+## Work search
+
+- **The command palette searches Work in any word order**, with typed filters, ranked content hits, and lifecycle actions on sessions.

--- a/docs.json
+++ b/docs.json
@@ -181,6 +181,7 @@
             "expanded": true,
             "pages": [
               "changelog",
+              "changelog/v1.2.67",
               "changelog/v1.2.66",
               "changelog/v1.2.65",
               "changelog/v1.2.64",


### PR DESCRIPTION
## Summary
- Changelog, docs.json, and CHANGELOG.md for desktop v1.2.67 so the release tag can point at notes for compact-from-meter, session rename, HEIC drop, lane-template setup, Codex approval settle, Linux cr-sqlite, and Work search.

## Test plan
- [x] `node scripts/validate-docs.mjs`
- [ ] Confirm squash-merge CI `ci-pass` is green before tagging `v1.2.67`


Made with [Cursor](https://cursor.com)