### PR TITLE
Fix hosted-web zoom clipping and menu placement

### DIFF
--- a/apps/desktop/src/renderer/browserMock.ts
+++ b/apps/desktop/src/renderer/browserMock.ts
@@ -76,6 +76,8 @@ import {
 } from "../shared/types/keepAwake";
 import { attachBrowserRuntimeBridge } from "./browserRuntimeBridge";
 import { rendererPlatformAttribute } from "./lib/platform";
+import { applyHostedWebZoom } from "./lib/webZoom";
+import { getStoredZoomLevel, zoomFactorForDisplay, zoomFactorForLevel } from "./lib/zoom";
 
 // The browser preview holds no power locks, so it reports the honest default.
 const MOCK_KEEP_AWAKE_SNAPSHOT = INERT_KEEP_AWAKE_SNAPSHOT;
@@ -2528,6 +2530,11 @@ if (typeof window !== "undefined" && shouldInstallBrowserMock(window)) {
     );
   }
   w.__adeBrowserMock = true;
+  let mockZoomLevel = 0;
+  const vitestRuntime = typeof process !== "undefined" && Boolean(process.env.VITEST);
+  if (!vitestRuntime) {
+    applyHostedWebZoom(zoomFactorForDisplay(getStoredZoomLevel()));
+  }
   const BROWSER_MOCK_LOCAL_DEVICE: any = {
     deviceId: "browser-mock-device",
     siteId: "browser-mock-site",
@@ -6506,9 +6513,12 @@ if (typeof window !== "undefined" && shouldInstallBrowserMock(window)) {
       assetDataUrl: resolvedArg({ dataUrl: "data:text/html;base64,PGgxPkRhc2hib2FyZCBXaXJlZnJhbWU8L2gxPg==", mimeType: "text/html", text: "<h1>Dashboard Wireframe</h1><p>Mock wireframe preview</p>" }),
     },
     zoom: {
-      getLevel: () => 0,
-      setLevel: (_level: number) => {},
-      getFactor: () => 1,
+      getLevel: () => mockZoomLevel,
+      setLevel: (level: number) => {
+        mockZoomLevel = level;
+        if (!vitestRuntime) applyHostedWebZoom(zoomFactorForLevel(level));
+      },
+      getFactor: () => zoomFactorForLevel(mockZoomLevel),
       setTitleBarOverlay: async () => ({ applied: false }),
       onCommand: () => () => {},
     },

--- a/apps/desktop/src/renderer/components/app/AppShell.tsx
+++ b/apps/desktop/src/renderer/components/app/AppShell.tsx
@@ -15,7 +15,7 @@ import { useLocation, useNavigate } from "react-router-dom";
 import { CommandPalette } from "./CommandPalette";
 import { IntegrationBannerHost } from "./IntegrationBannerHost";
 import { TabNav } from "./TabNav";
-import { isWebClientMode } from "../../lib/webClientMode";
+import { isCssZoomedBrowserSurface } from "../../lib/webClientMode";
 import { TopBar } from "./TopBar";
 import { ProjectTransitionErrorAlert } from "./ProjectTransitionErrorAlert";
 import {
@@ -1172,10 +1172,11 @@ export function AppShell({ children }: { children: React.ReactNode }) {
     <div
       className={cn(
         "text-fg overflow-hidden flex flex-col bg-bg",
-        // In the browser web client the App is nested under the shell's top
-        // strip, so fill that container (h-full) instead of the whole viewport
-        // (h-screen), which would overflow beneath the strip.
-        isWebClientMode() ? "h-full w-full" : "h-screen w-screen",
+        // Hosted web and the Vite mock zoom <body> and inverse-size it.
+        // `h-screen` is 100vh in unzoomed viewport pixels, so CSS zoom would
+        // paint the shell larger than the window and clip the launch shelf
+        // and chat column. Electron keeps h-screen: webFrame shrinks 100vh.
+        isCssZoomedBrowserSurface() ? "h-full w-full" : "h-screen w-screen",
       )}
     >
       <div className="shrink-0 relative z-20">

--- a/apps/desktop/src/renderer/components/chat/AgentChatComposer.tsx
+++ b/apps/desktop/src/renderer/components/chat/AgentChatComposer.tsx
@@ -108,6 +108,7 @@ import { ChatCommandMenu, type ChatCommandMenuItem, type ChatCommandMenuHandle }
 import { isMacPlatform, modifierKeyLabel } from "../../lib/platform";
 import { canOpenInAdeBrowser, openUrlInAdeBrowser } from "../../lib/openExternal";
 import { isWebClientMode } from "../../lib/webClientMode";
+import { fixedMenuAboveAnchorStyle } from "../../lib/fixedMenuPlacement";
 import {
   deriveSmartLinkPreview,
   findSmartLinks,
@@ -340,24 +341,6 @@ function arrayBufferToBase64(buffer: ArrayBuffer): string {
     parts.push(String.fromCharCode(...chunk));
   }
   return btoa(parts.join(""));
-}
-
-function getIssueContextMenuStyle(trigger: HTMLButtonElement): React.CSSProperties {
-  const rect = trigger.getBoundingClientRect();
-  const maxLeft = Math.max(
-    ISSUE_CONTEXT_MENU_VIEWPORT_GUTTER,
-    window.innerWidth - ISSUE_CONTEXT_MENU_WIDTH - ISSUE_CONTEXT_MENU_VIEWPORT_GUTTER,
-  );
-  const left = Math.min(
-    Math.max(ISSUE_CONTEXT_MENU_VIEWPORT_GUTTER, rect.right - ISSUE_CONTEXT_MENU_WIDTH),
-    maxLeft,
-  );
-
-  return {
-    left,
-    bottom: Math.max(ISSUE_CONTEXT_MENU_VIEWPORT_GUTTER, window.innerHeight - rect.top + ISSUE_CONTEXT_MENU_GAP),
-    width: ISSUE_CONTEXT_MENU_WIDTH,
-  };
 }
 
 type ExecutionModeOption = {
@@ -1295,13 +1278,10 @@ function useComposerSplitMenu(menuSelector: string) {
 }
 
 function composerSplitMenuPosition(anchor: HTMLButtonElement): React.CSSProperties {
-  const rect = anchor.getBoundingClientRect();
-  const width = COMPOSER_COMPACT_MENU_WIDTH;
-  return {
-    left: Math.min(Math.max(8, rect.right - width), Math.max(8, window.innerWidth - width - 8)),
-    bottom: Math.max(8, window.innerHeight - rect.top + 8),
-    width,
-  };
+  return fixedMenuAboveAnchorStyle(anchor.getBoundingClientRect(), {
+    width: COMPOSER_COMPACT_MENU_WIDTH,
+    align: "end",
+  });
 }
 
 function ActiveTurnSendButton({
@@ -4907,7 +4887,12 @@ export function AgentChatComposer({
       data-issue-context-menu="true"
       role="menu"
       aria-label="Attach issue context"
-      style={getIssueContextMenuStyle(issueContextButtonRef.current)}
+      style={fixedMenuAboveAnchorStyle(issueContextButtonRef.current.getBoundingClientRect(), {
+        width: ISSUE_CONTEXT_MENU_WIDTH,
+        gap: ISSUE_CONTEXT_MENU_GAP,
+        gutter: ISSUE_CONTEXT_MENU_VIEWPORT_GUTTER,
+        align: "end",
+      })}
     >
       <div className="border-b border-white/[0.04] px-3 py-2">
         <div className="font-sans text-[length:calc(var(--chat-font-size)*11/14)] font-semibold text-fg/80">Attach issue context</div>

--- a/apps/desktop/src/renderer/components/chat/CursorCloudAdvancedMenu.tsx
+++ b/apps/desktop/src/renderer/components/chat/CursorCloudAdvancedMenu.tsx
@@ -140,9 +140,8 @@ export function CursorCloudAdvancedMenu({
               width: placement?.width ?? MENU_WIDTH,
               left: placement?.left ?? 0,
               maxHeight: placement?.maxHeight,
-              ...(placement?.bottom !== undefined
-                ? { bottom: placement.bottom }
-                : { top: placement?.top ?? 0 }),
+              top: placement?.top ?? 0,
+              transform: placement?.transform,
             }}
           >
             {attachPr ? (

--- a/apps/desktop/src/renderer/components/chat/DraftMachinePicker.tsx
+++ b/apps/desktop/src/renderer/components/chat/DraftMachinePicker.tsx
@@ -231,9 +231,8 @@ export function DraftMachinePicker({
                     width: placement?.width ?? MENU_WIDTH,
                     left: placement?.left ?? 0,
                     maxHeight: placement?.maxHeight,
-                    ...(placement?.bottom !== undefined
-                      ? { bottom: placement.bottom }
-                      : { top: placement?.top ?? 0 }),
+                    top: placement?.top ?? 0,
+                    transform: placement?.transform,
                   }}
                 >
                   {machines.map((machine) => {

--- a/apps/desktop/src/renderer/components/shared/PermissionModePicker.test.tsx
+++ b/apps/desktop/src/renderer/components/shared/PermissionModePicker.test.tsx
@@ -1,0 +1,50 @@
+/* @vitest-environment jsdom */
+
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { PermissionModePicker, type PermissionModePickerOption } from "./PermissionModePicker";
+
+const OPTIONS: Array<PermissionModePickerOption<"edit" | "plan" | "full">> = [
+  { value: "edit", label: "Edit mode", detail: "Edit", tone: "green", icon: "edit" },
+  { value: "plan", label: "Plan mode", detail: "Plan", tone: "blue", icon: "plan" },
+  { value: "full", label: "Full access", detail: "Full", tone: "red", icon: "full" },
+];
+
+describe("PermissionModePicker", () => {
+  afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+  });
+
+  it("places the menu with top + translateY instead of innerHeight-based bottom", () => {
+    render(
+      <PermissionModePicker
+        ariaLabel="Permission mode"
+        selectedValue="edit"
+        options={OPTIONS}
+        onSelect={() => {}}
+      />,
+    );
+
+    const trigger = screen.getByRole("button", { name: "Permission mode" });
+    vi.spyOn(HTMLElement.prototype, "getBoundingClientRect").mockReturnValue({
+      x: 180,
+      y: 420,
+      top: 420,
+      left: 180,
+      bottom: 444,
+      right: 260,
+      width: 80,
+      height: 24,
+      toJSON: () => ({}),
+    });
+
+    fireEvent.click(trigger);
+    const menu = screen.getByRole("listbox", { name: "Permission mode" });
+    expect(menu.style.top).toBe("420px");
+    expect(menu.style.left).toBe("180px");
+    expect(menu.style.width).toBe("240px");
+    expect(menu.style.transform).toBe("translateY(calc(-100% - 8px))");
+    expect(menu.style.bottom).toBe("");
+  });
+});

--- a/apps/desktop/src/renderer/components/shared/PermissionModePicker.tsx
+++ b/apps/desktop/src/renderer/components/shared/PermissionModePicker.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useState } from "react";
 import { createPortal } from "react-dom";
+import { fixedMenuAboveAnchorStyle } from "../../lib/fixedMenuPlacement";
 import {
   CaretDown,
   Check,
@@ -240,9 +241,9 @@ export function PermissionModePicker<Value extends string>({
       </button>
       {open && ref.current ? createPortal(
         (() => {
-          const rect = ref.current.getBoundingClientRect();
-          const width = PERMISSION_MODE_MENU_WIDTH;
-          const left = Math.min(Math.max(8, rect.left), Math.max(8, window.innerWidth - width - 8));
+          const anchor = ref.current;
+          if (!anchor) return null;
+          const rect = anchor.getBoundingClientRect();
           return (
             <div
               role="listbox"
@@ -252,11 +253,7 @@ export function PermissionModePicker<Value extends string>({
                 "fixed overflow-hidden rounded-xl border border-white/[0.08] bg-[#13111A]/95 shadow-[0_18px_48px_rgba(0,0,0,0.55)] backdrop-blur-md",
                 menuLayerClassName,
               )}
-              style={{
-                left,
-                bottom: Math.max(8, window.innerHeight - rect.top + 8),
-                width,
-              }}
+              style={fixedMenuAboveAnchorStyle(rect, { width: PERMISSION_MODE_MENU_WIDTH })}
             >
               <ul className="py-0.5">
                 {options.map((option) => {

--- a/apps/desktop/src/renderer/components/terminals/LaneCombobox.test.tsx
+++ b/apps/desktop/src/renderer/components/terminals/LaneCombobox.test.tsx
@@ -56,15 +56,15 @@ describe("computeLanePopoverPlacement", () => {
     expect(placement.left).toBeGreaterThanOrEqual(10);
   });
 
-  it("opens upward and stays off the top edge when the trigger sits low", () => {
+  it("opens upward from the trigger top so a short list stays flush, not floated by maxHeight", () => {
     const placement = computeLanePopoverPlacement({
       trigger: { top: 672, bottom: 700, left: 20, width: 200 },
       viewport: { width: 900, height: 745 },
     });
     expect(placement.openAbove).toBe(true);
-    expect(placement.bottom).toBeDefined();
-    const top = 745 - (placement.bottom ?? 0) - placement.maxHeight;
-    expect(top).toBeGreaterThanOrEqual(10);
+    expect(placement.top).toBe(672);
+    expect(placement.transform).toBe("translateY(calc(-100% - 4px))");
+    expect(placement.maxHeight).toBeGreaterThan(0);
   });
 
   it("detaches from the anchor rather than overflowing when neither side fits", () => {

--- a/apps/desktop/src/renderer/components/terminals/LaneCombobox.tsx
+++ b/apps/desktop/src/renderer/components/terminals/LaneCombobox.tsx
@@ -209,9 +209,18 @@ export type LanePopoverPlacement = {
   left: number;
   width: number;
   maxHeight: number;
-  /** Exactly one of these is set; `bottom` anchors an upward-opening popover. */
-  top?: number;
-  bottom?: number;
+  /**
+   * Always a `top` offset from the same rect space as `left`. Do not mix
+   * `window.innerHeight` into a `bottom` value: hosted-web CSS zoom multiplies
+   * `bottom` while leaving innerHeight in viewport pixels, which parks the
+   * menu at the top of the window (the permission-picker failure mode).
+   *
+   * When `openAbove` is true, `top` is the trigger's top edge and `transform`
+   * shifts the box by its own height so a short list stays flush above the
+   * trigger (the old `bottom` behavior) without measuring first.
+   */
+  top: number;
+  transform?: string;
   openAbove: boolean;
 };
 
@@ -259,9 +268,17 @@ export function computeLanePopoverPlacement(input: {
     return { left, width, maxHeight, top, openAbove: false };
   }
 
-  return openAbove
-    ? { left, width, maxHeight: fitted, bottom: viewport.height - trigger.top + POPOVER_GAP, openAbove }
-    : { left, width, maxHeight: fitted, top: trigger.bottom + POPOVER_GAP, openAbove };
+  if (openAbove) {
+    return {
+      left,
+      width,
+      maxHeight: fitted,
+      top: trigger.top,
+      transform: `translateY(calc(-100% - ${POPOVER_GAP}px))`,
+      openAbove,
+    };
+  }
+  return { left, width, maxHeight: fitted, top: trigger.bottom + POPOVER_GAP, openAbove };
 }
 
 type LaneComboboxProps = {
@@ -458,13 +475,19 @@ export function LaneCombobox({
       ? null
       : (customLaneColor ?? COLORS.accent);
 
-  const popoverStyle: React.CSSProperties = {
+  const popoverAnchorStyle: React.CSSProperties = {
+    // Owns `position: fixed` and the upward `translateY`. `.ade-lane-popover`
+    // is `position: relative` so framer-motion's `y` cannot overwrite it.
+    position: "fixed",
+    zIndex: 9999,
     left: placement?.left ?? 0,
     width: placement?.width ?? POPOVER_MIN_WIDTH,
+    top: placement?.top ?? 0,
+    transform: placement?.transform,
+  };
+  const popoverStyle: React.CSSProperties = {
+    width: "100%",
     maxHeight: placement?.maxHeight ?? POPOVER_PREFERRED_MAX_HEIGHT,
-    ...(placement?.bottom !== undefined
-      ? { bottom: placement.bottom }
-      : { top: placement?.top ?? 0 }),
     // The stylesheet ships a CSS keyframe entrance for this class; framer owns
     // the entrance now, and running both double-animates the open.
     animation: "none",
@@ -523,6 +546,7 @@ export function LaneCombobox({
       */}
       {open
         ? createPortal(
+          <div style={popoverAnchorStyle}>
             <motion.div
               ref={popoverRef}
               tabIndex={-1}
@@ -637,7 +661,8 @@ export function LaneCombobox({
                   })
                 )}
               </div>
-            </motion.div>,
+            </motion.div>
+          </div>,
             document.body,
           )
         : null}

--- a/apps/desktop/src/renderer/components/terminals/TerminalView.tsx
+++ b/apps/desktop/src/renderer/components/terminals/TerminalView.tsx
@@ -1638,8 +1638,10 @@ function ensureOpen(runtime: CachedRuntime): boolean {
 /**
  * The compounded CSS `zoom` the terminal would otherwise inherit.
  *
- * The hosted client scales its whole UI with `body { zoom: <factor> }`
- * (webclient/adapter/misc.ts), which defaults to 1.1 at the "100%" setting.
+ * The hosted client scales its whole UI with CSS zoom on <body>
+ * (webclient/adapter/misc.ts via applyHostedWebZoom), which defaults to 1.1
+ * at the "100%" setting. The body's layout box is inverse-sized so the zoomed
+ * used size still fills one viewport.
  */
 function webZoomFactor(): number {
   if (typeof document === "undefined") return 1;

--- a/apps/desktop/src/renderer/components/terminals/importSessions/ImportSessionBrowser.test.tsx
+++ b/apps/desktop/src/renderer/components/terminals/importSessions/ImportSessionBrowser.test.tsx
@@ -26,7 +26,7 @@ vi.mock("../../shared/ModelPicker/ModelPicker", () => ({
 }));
 vi.mock("../LaneCombobox", () => ({
   LaneCombobox: () => <div data-testid="lane-combobox" />,
-  computeLanePopoverPlacement: () => ({ width: 220, left: 0, top: 0, maxHeight: 320 }),
+  computeLanePopoverPlacement: () => ({ width: 220, left: 0, top: 0, maxHeight: 320, openAbove: false }),
 }));
 
 function summary(overrides: Partial<ExternalSessionSummary> = {}): ExternalSessionSummary {

--- a/apps/desktop/src/renderer/index.css
+++ b/apps/desktop/src/renderer/index.css
@@ -1059,22 +1059,30 @@ h6 {
   display: none;
 }
 
-/* Work split gutter: 1px divider at rest; wider only while hovering/dragging */
+/* Work split gutter: keep the generic 8px hit target; paint a 1px
+   full-height line so the divider stays grabbable under hosted-web CSS
+   zoom (a 1px layout box misses pointer hit-testing once zoom desyncs
+   layout pixels from the painted line). */
 .ade-work-surface .ade-pane-gutter.vertical {
-  width: 1px !important;
-  min-width: 1px !important;
-  background: var(--work-pane-border) !important;
+  background: transparent !important;
   border: none !important;
   box-shadow: none !important;
 }
 
 .ade-work-surface .ade-pane-gutter.vertical::before {
-  opacity: 0;
+  opacity: 1;
+  top: 0;
+  left: 50%;
+  width: 1px;
+  height: 100%;
+  transform: translateX(-50%);
+  border-radius: 0;
+  background: var(--work-pane-border);
+  box-shadow: none;
 }
 
 .ade-work-surface .ade-pane-gutter.vertical:hover,
 .ade-work-surface .ade-pane-gutter.vertical[data-resize-handle-active] {
-  width: 4px !important;
   background: color-mix(in srgb, var(--color-accent) 14%, transparent) !important;
   border-radius: 2px;
 }
@@ -1082,6 +1090,8 @@ h6 {
 .ade-work-surface .ade-pane-gutter.vertical:hover::before,
 .ade-work-surface .ade-pane-gutter.vertical[data-resize-handle-active]::before {
   opacity: 1;
+  width: 2px;
+  height: 100%;
   background: var(--color-accent);
   box-shadow: 0 0 6px 1px color-mix(in srgb, var(--color-accent) 35%, transparent);
 }
@@ -1094,7 +1104,7 @@ h6 {
 /* Lane Combobox Popover */
 
 .ade-lane-popover {
-  position: fixed;
+  position: relative;
   z-index: 9999;
   min-width: 200px;
   max-width: 280px;

--- a/apps/desktop/src/renderer/lib/fixedMenuPlacement.test.ts
+++ b/apps/desktop/src/renderer/lib/fixedMenuPlacement.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+import { fixedMenuAboveAnchorStyle } from "./fixedMenuPlacement";
+
+describe("fixedMenuAboveAnchorStyle", () => {
+  const rect = { left: 120, top: 400, right: 200 };
+
+  it("anchors with top + translateY so vertical math never mixes innerHeight", () => {
+    const style = fixedMenuAboveAnchorStyle(rect, { width: 240, viewportWidth: 800 });
+    expect(style.top).toBe(400);
+    expect(style.left).toBe(120);
+    expect(style.width).toBe(240);
+    expect(style.transform).toBe("translateY(calc(-100% - 8px))");
+  });
+
+  it("right-aligns when asked and clamps to the viewport", () => {
+    const aligned = fixedMenuAboveAnchorStyle(
+      { left: 700, top: 400, right: 790 },
+      { width: 240, align: "end", gutter: 8, viewportWidth: 800 },
+    );
+    expect(aligned.left).toBe(790 - 240);
+
+    const clamped = fixedMenuAboveAnchorStyle(
+      { left: 760, top: 400, right: 800 },
+      { width: 240, align: "end", gutter: 8, viewportWidth: 800 },
+    );
+    expect(clamped.left).toBe(800 - 240 - 8);
+  });
+
+  it("honors a custom gap in the translate", () => {
+    const style = fixedMenuAboveAnchorStyle(rect, { width: 240, gap: 4, viewportWidth: 800 });
+    expect(style.transform).toBe("translateY(calc(-100% - 4px))");
+  });
+});

--- a/apps/desktop/src/renderer/lib/fixedMenuPlacement.ts
+++ b/apps/desktop/src/renderer/lib/fixedMenuPlacement.ts
@@ -1,0 +1,46 @@
+/**
+ * Place a `position: fixed` menu above an anchor using only the anchor rect
+ * for the vertical axis.
+ *
+ * `bottom: window.innerHeight - rect.top` is correct under Electron webFrame
+ * zoom, where innerHeight and getBoundingClientRect share a CSS-pixel space.
+ * Hosted web applies CSS `zoom` on <body>: innerHeight stays in viewport
+ * pixels, then `bottom` is multiplied by zoom, and the menu jumps to the top
+ * of the window. That is why the permission picker (always opens upward)
+ * drifted while Radix/model pickers that set `top` from the rect did not.
+ *
+ * `top: rect.top` plus `translateY(calc(-100% - gap))` keeps the offset in
+ * the same zoomed space as the rect, and the percentage is the menu's own
+ * height so callers do not have to measure first.
+ */
+
+export type FixedMenuAboveAnchorStyle = {
+  left: number;
+  top: number;
+  width: number;
+  transform: string;
+};
+
+export function fixedMenuAboveAnchorStyle(
+  rect: { left: number; top: number; right: number },
+  options: {
+    width: number;
+    gap?: number;
+    gutter?: number;
+    align?: "start" | "end";
+    viewportWidth?: number;
+  },
+): FixedMenuAboveAnchorStyle {
+  const gap = options.gap ?? 8;
+  const gutter = options.gutter ?? 8;
+  const viewportWidth = options.viewportWidth ?? window.innerWidth;
+  const rawLeft = options.align === "end" ? rect.right - options.width : rect.left;
+  const maxLeft = Math.max(gutter, viewportWidth - options.width - gutter);
+  const left = Math.min(Math.max(gutter, rawLeft), maxLeft);
+  return {
+    left,
+    top: rect.top,
+    width: options.width,
+    transform: `translateY(calc(-100% - ${gap}px))`,
+  };
+}

--- a/apps/desktop/src/renderer/lib/webClientMode.ts
+++ b/apps/desktop/src/renderer/lib/webClientMode.ts
@@ -11,12 +11,24 @@
 declare global {
   interface Window {
     __adeWebClient?: boolean;
+    __adeBrowserMock?: boolean;
   }
 }
 
 /** True when the renderer is running as the hosted browser web client. */
 export function isWebClientMode(): boolean {
   return typeof window !== "undefined" && window.__adeWebClient === true;
+}
+
+/**
+ * True when the window is a browser surface that applies CSS zoom on <body>
+ * (hosted web client, or the Vite `browserMock` preview). Electron uses
+ * `h-screen` because `webFrame` shrinks the CSS viewport; these surfaces must
+ * fill the inverse-sized body with `h-full` so 100vh cannot outgrow the zoom.
+ */
+export function isCssZoomedBrowserSurface(): boolean {
+  if (typeof window === "undefined") return false;
+  return window.__adeWebClient === true || window.__adeBrowserMock === true;
 }
 
 /**

--- a/apps/desktop/src/renderer/lib/webZoom.test.ts
+++ b/apps/desktop/src/renderer/lib/webZoom.test.ts
@@ -53,6 +53,17 @@ describe("applyHostedWebZoom", () => {
     expect(parseFloat(document.body.style.width) * 1.4).toBeCloseTo(2100, 5);
   });
 
+  it("does not throw when window is a stub without EventTarget (adapter tests)", () => {
+    const originalAdd = window.addEventListener;
+    Object.defineProperty(window, "addEventListener", { configurable: true, value: undefined });
+    try {
+      expect(() => applyHostedWebZoom(1.4)).not.toThrow();
+      expect(document.documentElement.style.getPropertyValue("--ade-web-zoom-factor")).toBe("1.4");
+    } finally {
+      Object.defineProperty(window, "addEventListener", { configurable: true, value: originalAdd });
+    }
+  });
+
   it("pins html and #root to a percentage box so h-full can fill the inverse size", () => {
     const root = document.createElement("div");
     root.id = "root";

--- a/apps/desktop/src/renderer/lib/webZoom.test.ts
+++ b/apps/desktop/src/renderer/lib/webZoom.test.ts
@@ -1,0 +1,70 @@
+/* @vitest-environment jsdom */
+
+import { afterEach, describe, expect, it } from "vitest";
+import { applyHostedWebZoom, __resetHostedWebZoomForTests } from "./webZoom";
+
+describe("applyHostedWebZoom", () => {
+  afterEach(() => {
+    __resetHostedWebZoomForTests();
+  });
+
+  it("inverse-sizes body so zoomed used size matches the viewport", () => {
+    Object.defineProperty(window, "innerWidth", { configurable: true, value: 1400 });
+    Object.defineProperty(window, "innerHeight", { configurable: true, value: 900 });
+
+    applyHostedWebZoom(1.4);
+
+    const bodyStyle = document.body.style as CSSStyleDeclaration & { zoom?: string };
+    expect(document.documentElement.style.getPropertyValue("--ade-web-zoom-factor")).toBe("1.4");
+    expect(bodyStyle.zoom).toBe("1.4");
+    expect(parseFloat(bodyStyle.width) * 1.4).toBeCloseTo(1400, 5);
+    expect(parseFloat(bodyStyle.height) * 1.4).toBeCloseTo(900, 5);
+    expect(bodyStyle.minHeight).toBe(bodyStyle.height);
+  });
+
+  it("inverse-sizes at the hosted 100% factor so default zoom still fills one viewport", () => {
+    Object.defineProperty(window, "innerWidth", { configurable: true, value: 1100 });
+    Object.defineProperty(window, "innerHeight", { configurable: true, value: 880 });
+    applyHostedWebZoom(1.1);
+    expect(parseFloat(document.body.style.width) * 1.1).toBeCloseTo(1100, 5);
+    expect(parseFloat(document.body.style.height) * 1.1).toBeCloseTo(880, 5);
+  });
+
+  it("keeps a definite body box at factor 1 so h-full still fills the viewport", () => {
+    applyHostedWebZoom(1.4);
+    applyHostedWebZoom(1);
+
+    const bodyStyle = document.body.style as CSSStyleDeclaration & { zoom?: string };
+    expect(bodyStyle.zoom).toBe("");
+    expect(bodyStyle.width).toBe("100%");
+    expect(bodyStyle.height).toBe("100%");
+    expect(bodyStyle.minHeight).toBe("100%");
+    expect(document.documentElement.style.getPropertyValue("--ade-web-zoom-factor")).toBe("1");
+  });
+
+  it("repaints the inverse box on window resize", () => {
+    Object.defineProperty(window, "innerWidth", { configurable: true, value: 1400 });
+    Object.defineProperty(window, "innerHeight", { configurable: true, value: 900 });
+    applyHostedWebZoom(1.4);
+
+    Object.defineProperty(window, "innerWidth", { configurable: true, value: 2100 });
+    window.dispatchEvent(new Event("resize"));
+
+    expect(parseFloat(document.body.style.width) * 1.4).toBeCloseTo(2100, 5);
+  });
+
+  it("pins html and #root to a percentage box so h-full can fill the inverse size", () => {
+    const root = document.createElement("div");
+    root.id = "root";
+    document.body.appendChild(root);
+    try {
+      applyHostedWebZoom(1.4);
+      expect(document.documentElement.style.height).toBe("100%");
+      expect(document.documentElement.style.overflow).toBe("hidden");
+      expect(root.style.height).toBe("100%");
+      expect(root.style.overflow).toBe("hidden");
+    } finally {
+      root.remove();
+    }
+  });
+});

--- a/apps/desktop/src/renderer/lib/webZoom.ts
+++ b/apps/desktop/src/renderer/lib/webZoom.ts
@@ -68,10 +68,15 @@ function paintHostedWebZoom(): void {
 
 function ensureResizeListener(): void {
   if (resizeInstalled || typeof window === "undefined") return;
-  resizeInstalled = true;
-  onResize = () => paintHostedWebZoom();
-  window.addEventListener("resize", onResize);
-  window.visualViewport?.addEventListener("resize", onResize);
+  if (typeof window.addEventListener !== "function") return;
+  try {
+    onResize = () => paintHostedWebZoom();
+    window.addEventListener("resize", onResize);
+    window.visualViewport?.addEventListener("resize", onResize);
+    resizeInstalled = true;
+  } catch {
+    onResize = null;
+  }
 }
 
 /**
@@ -88,9 +93,17 @@ export function applyHostedWebZoom(factor: number): void {
 
 /** Test seam. */
 export function __resetHostedWebZoomForTests(): void {
-  if (typeof window !== "undefined" && onResize) {
-    window.removeEventListener("resize", onResize);
-    window.visualViewport?.removeEventListener("resize", onResize);
+  if (
+    typeof window !== "undefined"
+    && onResize
+    && typeof window.removeEventListener === "function"
+  ) {
+    try {
+      window.removeEventListener("resize", onResize);
+      window.visualViewport?.removeEventListener("resize", onResize);
+    } catch {
+      // Adapter tests stub `window` without the EventTarget methods.
+    }
   }
   onResize = null;
   resizeInstalled = false;

--- a/apps/desktop/src/renderer/lib/webZoom.ts
+++ b/apps/desktop/src/renderer/lib/webZoom.ts
@@ -1,0 +1,117 @@
+/**
+ * Hosted-web stand-in for Electron `webFrame` zoom.
+ *
+ * Desktop zoom shrinks the CSS-pixel viewport, so layout reflows and
+ * overflow/pointer math stay in one coordinate space. A bare `body { zoom }`
+ * does not: `height: 100%` is multiplied by the zoom factor, html's
+ * `overflow: hidden` crops the extra, session cards and the chat column clip,
+ * and `position: fixed` menus that mix `window.innerHeight` with a zoomed
+ * `getBoundingClientRect()` jump to the top of the window.
+ *
+ * Inverse-size the body first so after zoom it occupies exactly one viewport,
+ * matching Electron. Applied from the web adapter only — the desktop preload
+ * still drives `webFrame.setZoomLevel`.
+ */
+
+type ZoomStyle = CSSStyleDeclaration & { zoom?: string };
+
+let appliedFactor = 1;
+let resizeInstalled = false;
+let onResize: (() => void) | null = null;
+
+function paintHostedWebZoom(): void {
+  if (typeof document === "undefined" || typeof window === "undefined") return;
+  const body = document.body;
+  if (!body) return;
+  const factor = appliedFactor;
+  const bodyStyle = body.style as ZoomStyle;
+  try {
+    document.documentElement.style.setProperty("--ade-web-zoom-factor", String(factor));
+    const htmlStyle = document.documentElement.style;
+    const root = document.getElementById("root");
+    // Percentage-height children (AppShell `h-full`, #root) need a definite
+    // containing block. Vite's index.html does not set one; webclient.html
+    // does. Pin both so 100vh-based chrome cannot outgrow the inverse box.
+    htmlStyle.height = "100%";
+    htmlStyle.overflow = "hidden";
+    if (root) {
+      root.style.height = "100%";
+      root.style.minHeight = "100%";
+      root.style.width = "100%";
+      root.style.overflow = "hidden";
+    }
+    if (factor === 1) {
+      // Display 90% is factor 1. Vite's index.html does not give body a
+      // definite height, so clearing the box would leave AppShell's `h-full`
+      // with no containing block. Keep 100% (identity zoom) and only drop zoom.
+      bodyStyle.zoom = "";
+      bodyStyle.width = "100%";
+      bodyStyle.height = "100%";
+      bodyStyle.minWidth = "100%";
+      bodyStyle.minHeight = "100%";
+      return;
+    }
+    const width = window.innerWidth / factor;
+    const height = window.innerHeight / factor;
+    bodyStyle.zoom = String(factor);
+    bodyStyle.width = `${width}px`;
+    bodyStyle.height = `${height}px`;
+    // webclient.html sets min-height: 100% on body, which would otherwise
+    // force the pre-zoom box back to the viewport and re-clip after zoom.
+    bodyStyle.minWidth = `${width}px`;
+    bodyStyle.minHeight = `${height}px`;
+  } catch {
+    // A display preference must never take the adapter down — this also runs
+    // during install, where the document may be a partial stub.
+  }
+}
+
+function ensureResizeListener(): void {
+  if (resizeInstalled || typeof window === "undefined") return;
+  resizeInstalled = true;
+  onResize = () => paintHostedWebZoom();
+  window.addEventListener("resize", onResize);
+  window.visualViewport?.addEventListener("resize", onResize);
+}
+
+/**
+ * Apply the hosted-web zoom factor (1 = 100% CSS pixels). Safe to call
+ * repeatedly; a single resize listener keeps the inverse box in sync with
+ * the viewport.
+ */
+export function applyHostedWebZoom(factor: number): void {
+  const safe = Number.isFinite(factor) && factor > 0 ? factor : 1;
+  appliedFactor = safe;
+  ensureResizeListener();
+  paintHostedWebZoom();
+}
+
+/** Test seam. */
+export function __resetHostedWebZoomForTests(): void {
+  if (typeof window !== "undefined" && onResize) {
+    window.removeEventListener("resize", onResize);
+    window.visualViewport?.removeEventListener("resize", onResize);
+  }
+  onResize = null;
+  resizeInstalled = false;
+  appliedFactor = 1;
+  if (typeof document === "undefined") return;
+  const bodyStyle = document.body?.style as ZoomStyle | undefined;
+  if (bodyStyle) {
+    bodyStyle.zoom = "";
+    bodyStyle.width = "";
+    bodyStyle.height = "";
+    bodyStyle.minWidth = "";
+    bodyStyle.minHeight = "";
+  }
+  document.documentElement?.style.removeProperty("--ade-web-zoom-factor");
+  document.documentElement.style.height = "";
+  document.documentElement.style.overflow = "";
+  const root = document.getElementById("root");
+  if (root) {
+    root.style.height = "";
+    root.style.minHeight = "";
+    root.style.width = "";
+    root.style.overflow = "";
+  }
+}

--- a/apps/desktop/src/renderer/webclient/adapter/misc.ts
+++ b/apps/desktop/src/renderer/webclient/adapter/misc.ts
@@ -12,6 +12,7 @@ import {
 } from "../../../shared/types";
 import { KEYBINDING_DEFINITIONS } from "../../../shared/keybindings";
 import { getStoredZoomLevel, zoomFactorForDisplay, zoomFactorForLevel } from "../../lib/zoom";
+import { applyHostedWebZoom } from "../../lib/webZoom";
 import { chatSessionFromRemoteSummary } from "./infra/chatSessionShape";
 import { createGithubNamespace, githubDisconnectedStatus } from "./githubStub";
 import type { AdapterInfra, AdeNamespace } from "./types";
@@ -640,30 +641,14 @@ export function createMiscNamespaces(infra: AdapterInfra): MiscNamespaces {
 
 function createZoomNamespace(infra: AdapterInfra): Record<string, unknown> {
   const { localState } = infra;
-  function setCssZoom(factor: number): void {
-    if (typeof document === "undefined") return;
-    try {
-      document.documentElement?.style?.setProperty("--ade-web-zoom-factor", String(factor));
-      // Zoom the <body>, not the root element: percentages resolve across the
-      // zoom boundary, so body/#root still measure exactly one viewport at every
-      // level (verified in Chrome 150 and Chromium 146 — no page scrollbar in or
-      // out), while the root element is the one place engines have historically
-      // reserved for browser/pinch zoom.
-      const bodyStyle = document.body?.style as (CSSStyleDeclaration & { zoom?: string }) | undefined;
-      if (bodyStyle) bodyStyle.zoom = String(factor);
-    } catch {
-      // A display preference must never take the adapter down — this also runs
-      // during install, where the document may be a partial stub.
-    }
-  }
   // AppShell re-applies the stored level on mount; doing it at install too means
   // a reload paints at the user's zoom instead of flashing 100% first.
-  setCssZoom(zoomFactorForDisplay(getStoredZoomLevel()));
+  applyHostedWebZoom(zoomFactorForDisplay(getStoredZoomLevel()));
   return {
     getLevel: () => localState.get("zoomLevel", 0),
     setLevel: (level: number) => {
       localState.set("zoomLevel", level);
-      setCssZoom(zoomFactorForLevel(level));
+      applyHostedWebZoom(zoomFactorForLevel(level));
     },
     getFactor: () => zoomFactorForLevel(localState.get("zoomLevel", 0)),
     onCommand: () => () => {},

--- a/docs/features/web-client/README.md
+++ b/docs/features/web-client/README.md
@@ -402,12 +402,19 @@ Browser `window.ade` adapter:
   so the web adapter synthesizes a completed onboarding state in browser-local
   storage — left to the fallback proxy those reads resolve to null and
   `CtoPage` parks forever, because its ensure-session effect bails while
-  onboarding state is null. `app.ts` applies the display zoom preference to
-  `<body>` rather than the root element, since percentages resolve across the
-  zoom boundary and body/`#root` then still measure exactly one viewport at
-  every level; it is applied at install as well as on `AppShell` mount, so a
-  reload paints at the user's zoom instead of flashing 100% first, and a failure
-  there can never take the adapter down.
+  onboarding state is null. `misc.ts` applies the display zoom preference
+  through `applyHostedWebZoom`: CSS zoom still lives on `<body>` (the root
+  element is reserved for browser pinch-zoom), but the body's specified
+  width/height are divided by the factor first so the zoomed used box is
+  exactly one viewport. At identity zoom (displayed 90%) the inverse px box
+  is skipped and body stays `height: 100%` so `h-full` still has a containing
+  block — Vite's `index.html` does not set one, unlike `webclient.html`. A
+  bare `body { zoom }` multiplied `height: 100%` past
+  the html overflow clip — session cards, the chat column, and the launch
+  shelf cropped, and `position: fixed` menus that mixed `window.innerHeight`
+  into `bottom` jumped to the top of the window. Applied at install as well
+  as on `AppShell` mount, so a reload paints at the user's zoom instead of
+  flashing 100% first, and a failure there can never take the adapter down.
   `personalChats.ts` invokes
   runtime-scoped `personalChats.*` actions with `requireProject: false`, adds
   explicit `chatScope: "personal"` transcript subscriptions, dedupes their
@@ -531,11 +538,19 @@ Reused desktop renderer (web-mode adaptation):
   loads, and `WEB_CLIENT_TAB_PATHS` lists the only surfaced tabs
   (`/work`, `/lanes`, `/files`, `/prs`, `/chats`). There is no hosted-only
   landing route: the pre-project surface is the shared welcome page on `/work`.
-  Desktop-only chrome
+  `isCssZoomedBrowserSurface()` is true for the hosted client and the Vite
+  `browserMock` preview so `AppShell` fills the inverse-sized body with
+  `h-full` instead of `100vh`. Desktop-only chrome
   (`AppShell.tsx`, `TopBar.tsx`, `TabNav.tsx`, `OnboardingBootstrap.tsx`,
-  `WelcomeVideoGate.tsx`) reads this flag to hide native window controls, the
-  updater, the onboarding tour, and tabs with no sync-protocol backing instead
-  of rendering broken affordances.
+  `WelcomeVideoGate.tsx`) reads the web-client flag to hide native window
+  controls, the updater, the onboarding tour, and tabs with no sync-protocol
+  backing instead of rendering broken affordances.
+- `apps/desktop/src/renderer/lib/webZoom.ts` - hosted-web stand-in for
+  Electron `webFrame` zoom. Inverse-sizes `<body>` then applies CSS `zoom` so
+  the used box is one viewport.
+- `apps/desktop/src/renderer/lib/fixedMenuPlacement.ts` - `position: fixed`
+  menus that open above an anchor use `top` plus `translateY(-100%)` so
+  vertical math never mixes `window.innerHeight` with a CSS-zoomed rect.
 - `apps/desktop/src/renderer/components/activity/HeaderActivityControl.tsx`
   and `ActivityPane.tsx` - the project-independent header popover and the
   expanded pane its "Open all" raises. Activity is a global utility surface, not


### PR DESCRIPTION
## Summary
- Inverse-size the hosted web `<body>` before CSS zoom so the Work tab fills one viewport (session cards, launch shelf, chat column) instead of clipping against html overflow.
- Place upward menus with `top` + `translateY(-100%)` so permission/lane/machine pickers stay on their trigger at zoom, and widen the Work gutter hit target so the sessions/view split stays draggable.

## Test plan
- [ ] Open the hosted web client (or Vite preview) at 130% display zoom (factor 1.4) and confirm session cards stay inside the pane, the launch shelf is fully visible, and chat prose is not clipped.
- [ ] Drag the sessions/view divider; it should grab and resize.
- [ ] Open the permission picker, lane combobox, and machine picker from the empty-state composer; menus should sit on the trigger, not at the window origin.
- [ ] Check 90% (identity factor) and 100% (factor 1.1) still fill the window.

Merging this to `main` deploys `ade-web-client` via `deploy-web.yml`. No desktop version bump or `/release` run is required for the hosted client to go live.

<!-- ade:link v=1 type=pr repo=arul28/ADE branch=ade%2Fweb-zoom-layout-fixes num=1176 -->
<p>
  <img src="https://ade-app.dev/logo.png" height="18" align="left" alt="ADE">
  &nbsp;&nbsp;<strong>Open in ADE</strong>
  &nbsp;·&nbsp; <a href="https://ade-app.dev/open?type=branch&amp;repo=arul28%2FADE&amp;branch=ade%2Fweb-zoom-layout-fixes&amp;pr=1176">ade/web-zoom-layout-fixes branch</a>
  &nbsp;·&nbsp; <a href="https://ade-app.dev/open?type=pr&amp;repo=arul28%2FADE&amp;number=1176">PR #1176</a>
</p>
<!-- /ade:link -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved browser zoom behavior in hosted web experiences, including consistent sizing during viewport changes.
  * Improved pop-up menu positioning across chat, terminal, and permission controls.
  * Added more reliable alignment and viewport clamping for menus opened above their triggers.

* **Bug Fixes**
  * Fixed menu placement issues that could occur when browser zoom was active.
  * Improved work-tab splitter hit areas and hover visibility.
  * Enhanced layout consistency between desktop and hosted browser surfaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->