### PR TITLE
feat(sdk): auto-publish on main merges + SDK mirror-parity pass in /test

### DIFF
--- a/.agents/skills/test/SKILL.md
+++ b/.agents/skills/test/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: test
-description: 'Prove the new code works: enforce the logging/PostHog ground truth, prune dead tests, consolidate fragments, add only tests that prove new contracts, turn accepted /quality correctness findings into named regression tests, then run CI-mirrored shards. Also keeps docs/mobile/CLI/TUI parity in lockstep.'
+description: 'Prove the new code works: enforce the logging/PostHog ground truth, prune dead tests, consolidate fragments, add only tests that prove new contracts, turn accepted /quality correctness findings into named regression tests, then run CI-mirrored shards. Also keeps docs/mobile/CLI/TUI parity in lockstep, and syncs the published @ade-dev SDK packages when a mirrored ADE surface changes (mirror-sync only, never scope expansion).'
 ---
 
 # /test — Test Suite Steward
@@ -279,11 +279,11 @@ Fix until passing before moving to the next.
 
 ---
 
-## Parity Passes (4–7)
+## Parity Passes (4–8)
 
-After the test-suite work above, run four parity reviewers that keep docs, iOS, the CLI, and the TUI in lockstep with the desktop changes on this branch. They are independent of one another and of Passes 1–3.
+After the test-suite work above, run five parity reviewers that keep docs, iOS, the CLI, the TUI, and the published SDK packages in lockstep with the desktop changes on this branch. They are independent of one another and of Passes 1–3.
 
-**Preferred: TeamCreate** for these four passes so progress is tracked and a single completion event surfaces the batch. Per the global git-worktrees policy, do not pass worktree isolation. Fallback: parallel `Agent` calls in a single tool-call round if TeamCreate is unavailable.
+**Preferred: TeamCreate** for these five passes so progress is tracked and a single completion event surfaces the batch. Per the global git-worktrees policy, do not pass worktree isolation. Fallback: parallel `Agent` calls in a single tool-call round if TeamCreate is unavailable.
 
 ---
 
@@ -588,7 +588,85 @@ Report:
 - typecheck and test results
 ```
 
-Wait for all four parity agents to complete before moving to Verification.
+---
+
+## Pass 8: SDK parity (mirror-sync only — never scope expansion)
+
+`packages/sdk` (`@ade-dev/sdk`) and `packages/chat-ui` (`@ade-dev/chat-ui`) are
+published npm packages that MIRROR a deliberately small subset of real ADE.
+The SDK's scope is frozen by design: when ADE changes something the SDK
+already mirrors, the SDK must be updated to match in the same PR; when ADE
+adds something new, the SDK does NOT grow to cover it. "Sync what exists,
+never add what doesn't" is the whole rule.
+
+Spawn a general-purpose agent with this prompt:
+
+```
+You are the ADE SDK parity reviewer.
+
+packages/sdk (@ade-dev/sdk) and packages/chat-ui (@ade-dev/chat-ui) are
+published npm packages that mirror a FROZEN subset of real ADE. Your job:
+if this branch touched anything that subset mirrors, update the packages to
+match. You must NOT expand the SDK's surface to cover new ADE features —
+scope expansion is a product decision, not a parity fix. If the branch adds
+a brand-new capability with no existing SDK mirror, report "not mirrored —
+out of SDK scope" and move on.
+
+Step 1: Get branch context
+  git diff "$TEST_REVIEW_BASE" --name-only
+  git status --short
+  git log "$TEST_REVIEW_BASE"..HEAD --oneline
+
+Step 2: The mirrored surfaces (the complete inventory — check each against
+the branch diff; most files carry "source of truth" / "mirrored in"
+provenance comments at both ends, grep for those markers too):
+
+| Real ADE source of truth | SDK mirror |
+|---|---|
+| apps/desktop/src/shared/types/chat.ts — AgentChatEventEnvelope/AgentChatEvent, AgentChatCreateArgs (mcpServers, strictMcpConfig), AgentChatSessionSummary (mcpServers/strictMcpConfig/mcpCapability), AgentChatMcpCapability, AgentChatMcpServerConfig | packages/sdk/src/types.ts (hand-copied subset) + normalizers in client.ts |
+| apps/desktop/src/shared/types/personalChats.ts — action list, capability flags, PersonalChatSubscribeEventsArgs/Result | packages/sdk/src/types.ts + personalChats.ts wrapper |
+| apps/desktop/src/shared/callerMcpServers.ts — CALLER_MCP_SUPPORT per-provider levels/residuals, validation rules (name charset, URL schemes, caps, reserved names, unsupported transports) | packages/sdk/src/client.ts TSDoc provider table + test/mockRuntime.ts PROVIDER_MCP_VERDICTS (pins claude/pi) |
+| apps/ade-cli/src/multiProjectRpcServer.ts — ade/initialize handshake, protocolVersion, personalChats.call/subscribeEvents/unsubscribeEvents wire shapes, runtime/event notification shape (scope, projectId:null, eventEpoch/gap) | packages/sdk/src/jsonRpc.ts + eventStream.ts + client.ts |
+| apps/ade-cli embedded profile contract — `ade runtime run --socket <p> --profile embedded` flags, ADE_EMBEDDED_PARENT_PID, sync-off guarantee, withheld machine-authority methods | packages/sdk/src/sidecar.ts + test/live.integration.test.ts |
+| apps/ade-cli/src/lib/trustedWindowsTools.ts — GLOBALROOT alias + canonical/escape checks (byte-identical security logic) | packages/sdk/src/windowsSystemTools.ts |
+| apps/desktop/src/shared/types/chat.ts event envelope semantics consumed by the transcript | packages/chat-ui/src/sdkTypes.ts (view contract) + transcript/transcriptRows.ts (port of chatTranscriptRows.ts) |
+| Binary release URL scheme / SHA256SUMS layout (apps/ade-cli/scripts/install-runtime.sh, apps/web/api/install.ts) | packages/sdk/src/download.ts |
+
+Step 3: For each mirrored surface the branch touched, apply the matching
+update in packages/sdk and/or packages/chat-ui: sync the copied types,
+normalizers, tables, TSDoc provider tables, the mock fixture's pinned rows,
+and the chat-ui view mapping. Keep both ends' provenance comments accurate.
+Additive-optional wire fields the SDK does not consume may be deliberately
+skipped — note the decision instead of copying blindly.
+
+Step 4: Versioning — this drives auto-publish. If you changed ANY published
+package content (src/, README, LICENSE, package.json), bump BOTH package
+versions to the same next patch (or minor for a behavior change) — the two
+packages version in lockstep and publish-sdk-packages.yml requires equal
+versions. A merge to main with a bumped version auto-publishes; an unbumped
+content change is a CI-visible mistake. If you changed nothing, bump
+nothing.
+
+Step 5: Validate
+  npm run typecheck:sdk && npm run test:sdk
+  npm run typecheck:chat-ui && npm run test:chat-ui
+  cd packages/demo && npm run e2e:preflight   # no live provider turns
+
+Out of scope:
+- Do NOT add new methods, options, events, or components for new ADE
+  features. Report them as "not mirrored — out of SDK scope".
+- Do NOT touch apps/** or docs/ (other passes own those).
+- Do NOT run npm publish or the live token-spending e2e.
+
+Report:
+- packages/* files changed (or "no SDK changes required")
+- For each branch change: mirrored surface → sync applied, or "not
+  mirrored — out of SDK scope", or "not SDK-relevant"
+- Version bump decision and reasoning
+- typecheck/test/preflight results
+```
+
+Wait for all five parity agents to complete before moving to Verification.
 
 ### Windows parity and Computer Use evidence
 
@@ -717,6 +795,7 @@ Parity:
 - Mobile: <iOS files changed, or "none required"> — validation PASS / blocked
 - CLI: <apps/ade-cli files changed, or "none required"> — typecheck + tests PASS / blocked
 - TUI: <apps/ade-cli/src/tuiClient files changed, or "none required"> — typecheck + tests PASS / blocked
+- SDK: <packages/sdk + packages/chat-ui files changed + version bump, or "no mirrored surface touched", with any "not mirrored — out of SDK scope" items listed> — typecheck + tests + preflight PASS / blocked
 - Breaking flag/command/slash renames: <list, or "none">
 
 Verification:

--- a/.github/workflows/publish-sdk-packages.yml
+++ b/.github/workflows/publish-sdk-packages.yml
@@ -57,8 +57,13 @@ jobs:
 
       - name: Require NPM_TOKEN
         id: token
+        # The secret arrives through env, never interpolated into the script
+        # body: `${{ secrets.* }}` inside `run:` puts the value in the rendered
+        # command line, where a `set -x` or a crash dump can echo it.
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
-          if [ -z "${{ secrets.NPM_TOKEN }}" ]; then
+          if [ -z "$NPM_TOKEN" ]; then
             echo "NPM_TOKEN is not configured; skipping publish." >> "$GITHUB_STEP_SUMMARY"
             echo "present=false" >> "$GITHUB_OUTPUT"
           else

--- a/.github/workflows/publish-sdk-packages.yml
+++ b/.github/workflows/publish-sdk-packages.yml
@@ -1,21 +1,32 @@
-# Publish `@ade-dev/sdk` then `@ade-dev/chat-ui` from a dedicated tag.
+# Publish `@ade-dev/sdk` then `@ade-dev/chat-ui`.
 #
 # Desktop/runtime releases stay on `v*` (see release.yml). These packages use
 # `ade-sdk-v*` so a desktop tag cannot publish an npm version by accident.
 #
-# The first 0.1.0 publish is from a maintainer machine after this workflow
-# lands on main. Later versions: bump both package.json versions, land on
-# main, tag `ade-sdk-vX.Y.Z` (X.Y.Z must match both package.json versions),
-# push the tag.
+# Two publish routes, one job:
+# - Auto: a push to `main` that touches either package publishes any version
+#   that is not on the registry yet. A version that already exists is skipped,
+#   so merges that touch package code WITHOUT bumping versions are a no-op
+#   here. The /test skill's SDK-parity pass owns the bump decision.
+# - Manual: an `ade-sdk-vX.Y.Z` tag (must match both package.json versions)
+#   or workflow_dispatch with confirm=publish. On these routes an
+#   already-published version is an error, not a skip.
 #
 # Required repo secret: NPM_TOKEN — an automation token for the `ade-dev` org
 # with permission to publish `@ade-dev/sdk` and `@ade-dev/chat-ui` only.
+# Until the secret exists, runs end early with a notice instead of failing.
 # Provenance needs `id-token: write` on GitHub-hosted runners.
 
 name: Publish ADE SDK packages
 
 on:
   push:
+    branches:
+      - main
+    paths:
+      - "packages/sdk/**"
+      - "packages/chat-ui/**"
+      - ".github/workflows/publish-sdk-packages.yml"
     tags:
       - "ade-sdk-v*"
   workflow_dispatch:
@@ -29,6 +40,10 @@ permissions:
   contents: read
   id-token: write
 
+concurrency:
+  group: publish-sdk-packages
+  cancel-in-progress: false
+
 jobs:
   publish:
     if: ${{ github.event_name != 'workflow_dispatch' || inputs.confirm == 'publish' }}
@@ -40,7 +55,19 @@ jobs:
           node-version: 22
           registry-url: https://registry.npmjs.org
 
+      - name: Require NPM_TOKEN
+        id: token
+        run: |
+          if [ -z "${{ secrets.NPM_TOKEN }}" ]; then
+            echo "NPM_TOKEN is not configured; skipping publish." >> "$GITHUB_STEP_SUMMARY"
+            echo "present=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "present=true" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Require matching package versions
+        if: steps.token.outputs.present == 'true'
+        id: versions
         run: |
           SDK_VER=$(node -p "require('./packages/sdk/package.json').version")
           UI_VER=$(node -p "require('./packages/chat-ui/package.json').version")
@@ -48,16 +75,39 @@ jobs:
             echo "package versions differ: sdk=$SDK_VER chat-ui=$UI_VER"
             exit 1
           fi
-          if [ "${{ github.event_name }}" = "push" ]; then
+          if [ "${{ github.ref_type }}" = "tag" ]; then
             TAG="${GITHUB_REF_NAME#ade-sdk-v}"
             if [ "$TAG" != "$SDK_VER" ]; then
               echo "tag $GITHUB_REF_NAME does not match package version $SDK_VER"
               exit 1
             fi
           fi
-          echo "publishing $SDK_VER"
+          echo "version=$SDK_VER" >> "$GITHUB_OUTPUT"
+
+      - name: Decide what to publish
+        if: steps.token.outputs.present == 'true'
+        id: plan
+        run: |
+          VER="${{ steps.versions.outputs.version }}"
+          AUTO="false"
+          if [ "${{ github.ref_type }}" = "branch" ]; then AUTO="true"; fi
+          for PKG in "@ade-dev/sdk" "@ade-dev/chat-ui"; do
+            KEY=$( [ "$PKG" = "@ade-dev/sdk" ] && echo sdk || echo ui )
+            if npm view "$PKG@$VER" version >/dev/null 2>&1; then
+              if [ "$AUTO" = "true" ]; then
+                echo "$PKG@$VER already published; skipping." >> "$GITHUB_STEP_SUMMARY"
+                echo "$KEY=skip" >> "$GITHUB_OUTPUT"
+              else
+                echo "$PKG@$VER already exists on the registry; a tag/dispatch publish must use a new version."
+                exit 1
+              fi
+            else
+              echo "$KEY=publish" >> "$GITHUB_OUTPUT"
+            fi
+          done
 
       - name: Install and build @ade-dev/sdk
+        if: steps.plan.outputs.sdk == 'publish'
         run: |
           cd packages/sdk
           npm ci
@@ -66,12 +116,14 @@ jobs:
           npm run build
 
       - name: Publish @ade-dev/sdk
+        if: steps.plan.outputs.sdk == 'publish'
         working-directory: packages/sdk
         run: npm publish --access public --provenance
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Install and build @ade-dev/chat-ui
+        if: steps.plan.outputs.ui == 'publish'
         run: |
           cd packages/chat-ui
           npm ci
@@ -80,6 +132,7 @@ jobs:
           npm run build
 
       - name: Publish @ade-dev/chat-ui
+        if: steps.plan.outputs.ui == 'publish'
         working-directory: packages/chat-ui
         run: npm publish --access public --provenance
         env:

--- a/.github/workflows/publish-sdk-packages.yml
+++ b/.github/workflows/publish-sdk-packages.yml
@@ -12,10 +12,26 @@
 #   or workflow_dispatch with confirm=publish. On these routes an
 #   already-published version is an error, not a skip.
 #
-# Required repo secret: NPM_TOKEN — an automation token for the `ade-dev` org
-# with permission to publish `@ade-dev/sdk` and `@ade-dev/chat-ui` only.
-# Until the secret exists, runs end early with a notice instead of failing.
-# Provenance needs `id-token: write` on GitHub-hosted runners.
+# Credentials — two supported modes, in order of preference:
+#
+# 1. Trusted publishing (OIDC, no secret at all). npm mints a short-lived
+#    credential from this workflow's identity. Configure it per package on
+#    npmjs.com → Settings → Trusted Publisher: repository `arul28/ADE`,
+#    workflow `publish-sdk-packages.yml`. npm requires the PACKAGE TO ALREADY
+#    EXIST to configure it, so the first version of each package ships by mode
+#    2 (or from a maintainer machine); everything after can be token-free.
+#    Then set repo variable `SDK_TRUSTED_PUBLISHING=true` to tell this workflow
+#    the trusted publisher is live, and delete the NPM_TOKEN secret.
+# 2. `NPM_TOKEN` secret — a GRANULAR access token limited to the two
+#    `@ade-dev` packages, with an expiry. Not a classic token, and never a
+#    reason to turn off account 2FA: granular tokens are the supported way to
+#    publish from CI with 2FA on.
+#
+# With neither configured, runs end early with a notice instead of failing.
+# Both modes produce provenance; OIDC needs `id-token: write` on a
+# GitHub-hosted runner (self-hosted runners are not eligible), and npm CLI
+# >= 11.5.1, which is newer than the npm bundled with Node 22 — hence the
+# explicit npm upgrade step below.
 
 name: Publish ADE SDK packages
 
@@ -55,19 +71,32 @@ jobs:
           node-version: 22
           registry-url: https://registry.npmjs.org
 
-      - name: Require NPM_TOKEN
+      - name: Upgrade npm for trusted publishing
+        # Node 22 bundles npm 10.x; OIDC needs >= 11.5.1. Harmless for the
+        # token path, so it runs unconditionally rather than being another
+        # branch to get wrong.
+        run: npm install -g npm@latest && npm --version
+
+      - name: Resolve publish credentials
         id: token
         # The secret arrives through env, never interpolated into the script
         # body: `${{ secrets.* }}` inside `run:` puts the value in the rendered
         # command line, where a `set -x` or a crash dump can echo it.
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          TRUSTED: ${{ vars.SDK_TRUSTED_PUBLISHING }}
         run: |
-          if [ -z "$NPM_TOKEN" ]; then
-            echo "NPM_TOKEN is not configured; skipping publish." >> "$GITHUB_STEP_SUMMARY"
-            echo "present=false" >> "$GITHUB_OUTPUT"
-          else
+          if [ "$TRUSTED" = "true" ]; then
+            echo "Publishing via trusted publisher (OIDC); no token used." >> "$GITHUB_STEP_SUMMARY"
             echo "present=true" >> "$GITHUB_OUTPUT"
+            echo "mode=oidc" >> "$GITHUB_OUTPUT"
+          elif [ -n "$NPM_TOKEN" ]; then
+            echo "present=true" >> "$GITHUB_OUTPUT"
+            echo "mode=token" >> "$GITHUB_OUTPUT"
+          else
+            echo "Neither SDK_TRUSTED_PUBLISHING nor NPM_TOKEN is configured; skipping publish." >> "$GITHUB_STEP_SUMMARY"
+            echo "present=false" >> "$GITHUB_OUTPUT"
+            echo "mode=none" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Require matching package versions
@@ -123,9 +152,12 @@ jobs:
       - name: Publish @ade-dev/sdk
         if: steps.plan.outputs.sdk == 'publish'
         working-directory: packages/sdk
+        # In OIDC mode NODE_AUTH_TOKEN is deliberately empty: npm then mints a
+        # short-lived credential from this workflow's identity. --provenance is
+        # implied there, and harmless to state.
         run: npm publish --access public --provenance
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ steps.token.outputs.mode == 'token' && secrets.NPM_TOKEN || '' }}
 
       - name: Install and build @ade-dev/chat-ui
         if: steps.plan.outputs.ui == 'publish'
@@ -141,4 +173,4 @@ jobs:
         working-directory: packages/chat-ui
         run: npm publish --access public --provenance
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ steps.token.outputs.mode == 'token' && secrets.NPM_TOKEN || '' }}


### PR DESCRIPTION
Two dev-loop upgrades for the newly shipped `@ade-dev/sdk` + `@ade-dev/chat-ui` packages (#1187):

## 1. Auto-publish on merge
`publish-sdk-packages.yml` gains a push-to-main trigger, paths-filtered to `packages/sdk/**` and `packages/chat-ui/**`. It publishes any package version that is not on the registry yet and **skips** already-published versions, so unbumped merges are a no-op. The tag (`ade-sdk-v*`) and manual-dispatch routes keep strict fail-on-existing semantics. While `NPM_TOKEN` is unset, runs end early with a step-summary notice instead of failing. A concurrency group prevents overlapping publishes.

## 2. /test Pass 8: SDK parity (mirror-sync only)
The dev loop now keeps the published packages in lockstep with real ADE **without** growing their scope: when a branch touches a surface the SDK mirrors (the copied chat/personalChats type subsets, the RPC wire + handshake, `CALLER_MCP_SUPPORT`, the embedded-profile contract, the trusted-Windows-tools logic, the transcript envelope, the binary release layout), the pass syncs the mirror and bumps both package versions in lockstep — which is exactly what triggers the auto-publish above. New ADE capabilities are explicitly out of SDK scope: the pass reports "not mirrored — out of SDK scope" instead of expanding the API. The pass carries the complete mirrored-surface inventory so nothing depends on memory.

Docs-and-workflow only; no runtime code changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes npm publish automation and release semantics on main; mistakes in version bumps could publish unintended versions, though skip-on-existing and tag/dispatch strictness limit accidental re-publishes.
> 
> **Overview**
> Extends the **`/test`** dev loop so published **`@ade-dev/sdk`** and **`@ade-dev/chat-ui`** stay in lockstep with ADE without growing SDK scope. Parity passes are now **4–8** (five reviewers); **Pass 8** defines a frozen mirror inventory (chat/personalChats types, RPC wire shapes, MCP tables, embedded profile, Windows tools, transcript view, download layout), requires mirror-only sync with explicit **"not mirrored — out of SDK scope"** for new ADE features, and ties **in-lockstep version bumps** to the publish workflow. The **`/test` summary** template gains an **SDK** parity line.
> 
> **`publish-sdk-packages.yml`** adds a **push-to-`main`** path filter on `packages/sdk/**`, `packages/chat-ui/**`, and the workflow file. **Auto** publishes any version not yet on npm and **skips** already-published versions (unbumped merges are no-ops); **tag** (`ade-sdk-v*`) and **workflow_dispatch** still **fail** if the version exists. Missing **`NPM_TOKEN`** exits with a summary notice instead of failing; a **concurrency** group serializes publishes; build/publish steps run only when each package is slated to publish.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6ae3f923a6fc5710e3a802ec45cbc39732f8356d. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic publishing for updated SDK packages after changes reach the main branch.
  * Added manual publishing options for release tags and on-demand runs.
* **Bug Fixes**
  * Prevented duplicate publications when a package version is already available.
  * Added version consistency checks for tagged releases.
  * Improved handling when publishing credentials are unavailable.
* **Chores**
  * Serialized publishing runs to prevent conflicting releases.
  * Added SDK parity validation and reporting for mirrored updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->