### PR TITLE
feat(sdk): report the SDK's own version in doctor() (0.1.1)

### DIFF
--- a/packages/chat-ui/package.json
+++ b/packages/chat-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ade-dev/chat-ui",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Embeddable React chat components for the ADE SDK.",
   "license": "AGPL-3.0-only",
   "type": "module",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ade-dev/sdk",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Typed Node/Electron-main client that owns a slim ADE runtime and exposes chat as durable named threads.",
   "license": "AGPL-3.0-only",
   "type": "module",

--- a/packages/sdk/src/client.ts
+++ b/packages/sdk/src/client.ts
@@ -18,6 +18,7 @@ import { DEFAULT_ADE_ROLE, startSidecar, type Sidecar } from "./sidecar.js";
 import { resolveRuntimeSocketPath } from "./socketPath.js";
 import { Thread, type AdeThread } from "./thread.js";
 import { ThreadStore } from "./threadStore.js";
+import { SDK_VERSION } from "./version.js";
 import type {
   AdeInitializeResult,
   AdeProvider,
@@ -735,6 +736,7 @@ export async function createAdeChat(
       const providersOk = Object.values(providerStatus).some((entry) => entry.available);
       return {
         ok: socketConnected && events.transport !== "unavailable" && providersOk,
+        sdkVersion: SDK_VERSION,
         binary: {
           path: binary.binaryPath || "(attached)",
           version: version ?? null,

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -49,6 +49,7 @@ export type {
   ThreadModelSelection,
 } from "./thread.js";
 export { AdeError, type AdeErrorCode } from "./errors.js";
+export { SDK_VERSION } from "./version.js";
 export type { PermissionPreset } from "./permissions.js";
 export { SUPPORTED_PROVIDERS } from "./permissions.js";
 

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -355,6 +355,13 @@ export type ThreadSummary = {
 
 export type DoctorReport = {
   ok: boolean;
+  /**
+   * Version of this SDK package. Reported alongside the runtime version
+   * because a mismatched pair is the first thing to check when an embedder's
+   * chat misbehaves: the two ship on separate cadences, and the SDK is the
+   * half that lives inside the embedder's own build.
+   */
+  sdkVersion: string;
   binary: {
     path: string;
     /** Version string reported by `<binary> --version`, when it answered. */

--- a/packages/sdk/src/version.ts
+++ b/packages/sdk/src/version.ts
@@ -1,0 +1,19 @@
+/**
+ * The package version, injected at build time from package.json.
+ *
+ * A support conversation about an embedder's chat starts with "which SDK is
+ * running?", and the answer has to survive bundling: an app that bundles this
+ * package into its own output has no `node_modules/@ade-dev/sdk/package.json`
+ * to read, and reading one at runtime differs between the ESM and CJS builds.
+ * So the value is substituted by tsup's `define` (see tsup.config.ts) and the
+ * literal below is only what a source-level consumer — vitest, `tsx`, a
+ * repo-local import — sees.
+ *
+ * `packageVersionForBuild()` in tsup.config.ts reads package.json, so the two
+ * cannot drift in a published build; a test pins the source literal to
+ * package.json so they cannot drift here either.
+ */
+declare const __ADE_SDK_VERSION__: string | undefined;
+
+export const SDK_VERSION: string =
+  typeof __ADE_SDK_VERSION__ === "string" ? __ADE_SDK_VERSION__ : "0.1.1";

--- a/packages/sdk/test/client.test.ts
+++ b/packages/sdk/test/client.test.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { createAdeChat, type InternalAdeChatOptions } from "../src/client.js";
 import type { AdeChatClient } from "../src/client.js";
+import { SDK_VERSION } from "../src/version.js";
 import type { AgentChatEventEnvelope } from "../src/types.js";
 import { MockRuntime } from "./mockRuntime.js";
 
@@ -852,6 +853,10 @@ describe("providers, models and doctor", () => {
     expect(report.threads).toEqual({ tracked: 1, live: 1 });
     expect(Object.keys(report.providers).sort()).toEqual(["claude", "codex"]);
     expect(Array.isArray(report.recentErrors)).toBe(true);
+    // The SDK half of the version pair. It must be the real package version,
+    // not a placeholder, or a support report says nothing.
+    expect(report.sdkVersion).toBe(SDK_VERSION);
+    expect(report.sdkVersion).toMatch(/^\d+\.\d+\.\d+/);
   });
 
   it("records a failing RPC in the doctor report instead of throwing it away", async () => {

--- a/packages/sdk/test/units.test.ts
+++ b/packages/sdk/test/units.test.ts
@@ -2,6 +2,7 @@ import { createHash } from "node:crypto";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
+import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
 import { findOnPath, resolveBinary } from "../src/binary.js";
 import {
@@ -19,6 +20,7 @@ import {
 } from "../src/download.js";
 import { chatEnvelopeFromBufferedEvent, isBufferedEvent } from "../src/eventStream.js";
 import { permissionArgs } from "../src/permissions.js";
+import { SDK_VERSION } from "../src/version.js";
 import {
   createExitHooks,
   DEFAULT_ADE_ROLE,
@@ -856,5 +858,22 @@ describe("stopChild teardown per platform (B3-4, B3-5)", () => {
     await stopping;
     expect(child.signals).toEqual(["SIGTERM"]);
     expect(hardKills).toBe(0);
+  });
+});
+
+describe("SDK_VERSION", () => {
+  // A published build gets this value from tsup's `define`, reading
+  // package.json at build time. The source literal is what a repo-local
+  // consumer (this suite, tsx, the demo app) sees, so it has to be pinned to
+  // the same package.json or the two answers to "which SDK is this?" diverge
+  // the moment someone bumps one and forgets the other.
+  it("matches the version in package.json", () => {
+    const manifestPath = fileURLToPath(new URL("../package.json", import.meta.url));
+    const manifest = JSON.parse(fs.readFileSync(manifestPath, "utf8")) as { version: string };
+    expect(SDK_VERSION).toBe(manifest.version);
+  });
+
+  it("is a plain semver string, not a placeholder", () => {
+    expect(SDK_VERSION).toMatch(/^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$/);
   });
 });

--- a/packages/sdk/tsup.config.ts
+++ b/packages/sdk/tsup.config.ts
@@ -1,6 +1,23 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
 import { defineConfig } from "tsup";
 
+/**
+ * Read the version from package.json at build time so `SDK_VERSION` in a
+ * published build can never disagree with the version on the registry.
+ */
+function packageVersionForBuild(): string {
+  const manifestPath = fileURLToPath(new URL("./package.json", import.meta.url));
+  const manifest = JSON.parse(readFileSync(manifestPath, "utf8")) as { version?: unknown };
+  if (typeof manifest.version !== "string" || manifest.version.length === 0) {
+    throw new Error("packages/sdk/package.json has no usable version field");
+  }
+  return manifest.version;
+}
+
 export default defineConfig({
+  define: { __ADE_SDK_VERSION__: JSON.stringify(packageVersionForBuild()) },
   entry: ["src/index.ts"],
   format: ["esm", "cjs"],
   dts: true,


### PR DESCRIPTION
Small, real SDK change whose second purpose is to **prove the auto-publish path end to end** — see #1188 for the workflow it exercises.

## What it does
`doctor()` reported the runtime version but not the SDK's own. Those two ship on separate cadences, and the SDK is the half that lives inside the *embedder's* build, so a mismatched pair is the first thing to check when someone's chat misbehaves. `DoctorReport.sdkVersion` closes that, and `SDK_VERSION` is exported for callers who want it directly.

## Why build-time injection
`SDK_VERSION` is substituted by tsup's `define`, reading package.json at build time:
- a published build cannot disagree with the version on the registry;
- it survives an embedder bundling the package (there is no `node_modules/@ade-dev/sdk/package.json` to read, and runtime resolution differs between the ESM and CJS builds).

A test pins the source-level literal to package.json so repo-local consumers (vitest, tsx, the demo app) cannot drift either. Verified in the built artifact: `node -e "require('./dist/index.cjs').SDK_VERSION"` → `0.1.1`.

## Publish rehearsal
Both packages bump to **0.1.1** in lockstep (the workflow requires equal versions). Merge order matters: **#1188 must merge first** — it publishes `0.1.0` and installs the merge trigger — then this PR publishes `0.1.1`, which exercises the recurring path (bump → auto-publish) and, on any later unbumped merge, the skip-if-already-published branch.

`npm pack --dry-run` on both packages: dist + README + LICENSE + package.json, 9 files each, no `src/` or `test/` leakage.

## Verification
- sdk: typecheck clean, **158 tests pass** (11 live skipped), build clean
- chat-ui: typecheck clean, **133 tests pass**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive public API and diagnostic field only; no auth, data, or runtime behavior changes beyond version reporting.
> 
> **Overview**
> **`doctor()` now reports the embedder-facing SDK version** alongside the runtime/binary versions via a new **`DoctorReport.sdkVersion`** field, and **`SDK_VERSION`** is exported for callers that want it without running diagnostics.
> 
> Version identity is wired through a new **`version.ts`** module: **tsup injects the value from `package.json` at build time** (`__ADE_SDK_VERSION__`) so published/bundled builds stay aligned with the registry, with a source-level fallback for vitest/tsx. Tests assert **`doctor()` returns the real semver** and that **`SDK_VERSION` matches `package.json`**.
> 
> **`@ade-dev/sdk` and `@ade-dev/chat-ui` are bumped to 0.1.1** in lockstep for the publish workflow; chat-ui has no functional code changes in this diff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit db2a33dd773e0925ac36f344e552e471b47fda2b. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->