### PR TITLE
docs(release): v1.2.69 release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,35 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.2.69] - 2026-08-31
+
+### Pull requests
+
+- The PRs tab is about the PR, not the lane. GitHub rows, checks, merge state, and the detail pane stay keyed to the pull request so a stacked or reused lane no longer swaps the review surface out from under you (#1186).
+- Checks and merge metadata spend less GitHub quota. Relay caching, poller backoff, and merge-box GraphQL brakes cut repeated list/status calls that were burning the hourly budget (#1183).
+
+### Chat recovery
+
+- Usage-limit recovery can resume automatically. Claude and Codex sessions can schedule a durable, cancellable resume when a provider reports a reset time, with a cap on consecutive retries and clear status in the recovery card and Chat info (#1182).
+- Pending questions stay visible until they are resolved. A question can outlive the turn that raised it without wedging the chat or disappearing from the Work surface (#1184).
+- Settled chat activity is quieter. Completion notices fold together and settled sessions file consistently across local and paired runtimes (#1182).
+
+### Chat streaming and attachments
+
+- Assistant text reveals at a paced rate instead of dumping a whole buffered burst at once (#1185).
+- Attachments work across local and remote sessions. ADE stages files up to 50 MB, uses a path-copy route locally and a ticketed upload route remotely, and provides composer chips plus a shared preview modal (#1182).
+- Metadata refreshes use focused context. Title, lane, and status regeneration sends only the requested identity and recent assistant context (#1181).
+
+### Updates, triage, and iOS
+
+- macOS in-app update re-downloads vanished archives before handing off to Squirrel (#1189).
+- `ade triage` creates a safe handoff for broken installations (#1182).
+- iOS follows the pending-input recovery rules and the PR-centric review surface (#1184, #1186).
+
+### ADE SDK
+
+- `@ade-dev/sdk` and `@ade-dev/chat-ui` are on npm as an embeddable chat sidecar. Public docs are the Mintlify SDK tab. Strict MCP isolation is enforced only on Claude; read `mcpCapability` before telling users that only their tools are loaded (#1187, #1188, #1190, #1191).
+
 ## [1.2.68] - 2026-08-29
 
 ### Agent reliability
@@ -1819,7 +1848,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Initial public release.
 
-[Unreleased]: https://github.com/arul28/ADE/compare/v1.2.68...HEAD
+[Unreleased]: https://github.com/arul28/ADE/compare/v1.2.69...HEAD
+[1.2.69]: https://github.com/arul28/ADE/compare/v1.2.68...v1.2.69
 [1.2.68]: https://github.com/arul28/ADE/compare/v1.2.67...v1.2.68
 [1.2.67]: https://github.com/arul28/ADE/compare/v1.2.66...v1.2.67
 [1.2.66]: https://github.com/arul28/ADE/compare/v1.2.65...v1.2.66

--- a/changelog/index.mdx
+++ b/changelog/index.mdx
@@ -5,6 +5,6 @@ description: "Latest ADE release notes and release history."
 
 ADE release notes live here in newest-first order. Start with the latest release, or browse the release list in the sidebar.
 
-<Card title="Latest release" icon="tag" href="/changelog/v1.2.68">
-  v1.2.68 - Keep background helpers on the intended model, send screenshots without stalling workers, and keep hosted-web zoom menus in place.
+<Card title="Latest release" icon="tag" href="/changelog/v1.2.69">
+  v1.2.69 - Rebuild the PRs tab around the pull request, recover chats from usage limits, and publish the ADE SDK.
 </Card>

--- a/changelog/v1.2.69.mdx
+++ b/changelog/v1.2.69.mdx
@@ -1,0 +1,35 @@
+---
+title: "v1.2.69"
+description: "Release notes for ADE v1.2.69 - August 31, 2026"
+---
+
+The PRs tab is rebuilt around the pull request. Chat recovers from usage limits, keeps pending questions visible, and streams assistant text more smoothly. Attachments, `ade triage`, in-app updates, and a public ADE SDK land in the same cut.
+
+---
+
+## Pull requests
+
+- **The PRs tab is about the PR, not the lane.** GitHub rows, checks, merge state, and the detail pane stay keyed to the pull request so a stacked or reused lane no longer swaps the review surface out from under you.
+- **Checks and merge metadata spend less GitHub quota.** Relay caching, poller backoff, and merge-box GraphQL brakes cut repeated list/status calls that were burning the hourly budget.
+
+## Chat recovery
+
+- **Usage-limit recovery can resume automatically.** Claude and Codex sessions can schedule a durable, cancellable resume when a provider reports a reset time, with a cap on consecutive retries and clear status in the recovery card and Chat info.
+- **Pending questions stay visible until they are resolved.** A question can outlive the turn that raised it without wedging the chat or disappearing from the Work surface. Answering a question whose caller has gone away records the resolution consistently across runtimes and iOS.
+- **Settled chat activity is quieter.** Completion notices fold together and settled sessions file consistently across local and paired runtimes.
+
+## Chat streaming and attachments
+
+- **Assistant text reveals at a paced rate** instead of dumping a whole buffered burst at once, with stream-smoothness instrumentation behind it.
+- **Attachments work across local and remote sessions.** ADE stages files up to 50 MB, uses a path-copy route locally and a ticketed upload route remotely, and provides composer chips plus a shared preview modal.
+- **Metadata refreshes use focused context.** Title, lane, and status regeneration sends only the requested identity and recent assistant context, while Work surfaces show which fields are being refreshed.
+
+## Updates, triage, and iOS
+
+- **macOS in-app update re-downloads vanished archives** before handing off to Squirrel, so a cache that was cleaned out no longer fails the install with a missing zip.
+- **`ade triage` creates a safe handoff for broken installations.** It gathers redacted context, maintains a troubleshooting playbook, and can hand the result to the user's own agent CLI or print it for an already-running agent.
+- **iOS follows the pending-input recovery rules** and the PR-centric review surface. The companion app keeps unresolved questions visible, applies the first receipt only, and avoids duplicate resolution notices.
+
+## ADE SDK
+
+- **`@ade-dev/sdk` and `@ade-dev/chat-ui` are on npm** as an embeddable chat sidecar. Public docs are the Mintlify **SDK** tab. Strict MCP isolation is enforced only on Claude; read `mcpCapability` (`strictRequested`, then `level === "enforced"`) before telling users that only their tools are loaded.

--- a/docs.json
+++ b/docs.json
@@ -214,6 +214,7 @@
             "expanded": true,
             "pages": [
               "changelog",
+              "changelog/v1.2.69",
               "changelog/v1.2.68",
               "changelog/v1.2.67",
               "changelog/v1.2.66",


### PR DESCRIPTION
## Problem

Desktop, iOS, and the public SDK have all moved since v1.2.68. A release cannot tag `main` until changelog surfaces exist on that commit.

## Change and boundary

Release notes only: `changelog/v1.2.69.mdx`, changelog index, `docs.json`, and `CHANGELOG.md`. No product code.

Covers the PRs-tab rebuild, chat recovery and attachments, paced streaming, GitHub quota, macOS updater handoff, `ade triage`, iOS pending-input/PR parity, and the Mintlify SDK tab.

Tag `v1.2.69` only after this squash is on `main` **and** `ci-pass` is green on that SHA. iOS build 67 and Cloudflare reconciliation follow the desktop tag.

## Verification

- `node scripts/validate-docs.mjs` — 252 files PASS

<!-- ade:link v=1 type=pr repo=arul28/ADE branch=ade%2Fcut-release num=1192 -->
<p>
  <img src="https://ade-app.dev/logo.png" height="18" align="left" alt="ADE">
  &nbsp;&nbsp;<strong>Open in ADE</strong>
  &nbsp;·&nbsp; <a href="https://ade-app.dev/open?type=branch&amp;repo=arul28%2FADE&amp;branch=ade%2Fcut-release&amp;pr=1192">ade/cut-release branch</a>
  &nbsp;·&nbsp; <a href="https://ade-app.dev/open?type=pr&amp;repo=arul28%2FADE&amp;number=1192">PR #1192</a>
</p>
<!-- /ade:link -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changelog and Mintlify navigation updates; no runtime or product behavior changes in this diff.
> 
> **Overview**
> **Adds public release documentation for v1.2.69** (2026-08-31) so `main` can be tagged after merge—no application code changes.
> 
> Introduces `changelog/v1.2.69.mdx` with Mintlify release notes (PR-centric PRs tab, chat recovery/streaming/attachments, GitHub quota, macOS updater, `ade triage`, iOS parity, npm SDK packages). **`CHANGELOG.md`** gets a matching `[1.2.69]` section with PR references and updated `[Unreleased]` / compare links. **`changelog/index.mdx`** “Latest release” card now points at v1.2.69, and **`docs.json`** registers the new page at the top of the Changelog sidebar.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 293c60f9e8123911bfbcbcb63ab86eb1a65e8e68. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->