### PR TITLE
docs(release): prepare v1.2.71 notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.2.71] - 2026-09-01
+
 ### Claude models
 
-- Claude Fable 5.1 is the default Claude model. Pickers list Fable 5.1, Opus 5, Sonnet 5, Haiku 4.5, then Opus 4.8. Opus 4.8 drops the 1M suffix. Fable 5 and Opus 4.7 ids, including the old 1M aliases, resolve forward and no longer appear as rows.
+- Claude Fable 5.1 is the default Claude model. Pickers list Fable 5.1, Opus 5, Sonnet 5, Haiku 4.5, then Opus 4.8. Opus 4.8 drops the 1M suffix. Fable 5 and Opus 4.7 ids, including the old 1M aliases, resolve forward and no longer appear as rows (#1197).
+
+### Remote machines
+
+- A disconnected remote no longer traps a draft. ADE falls back to this computer, keeps recovery visible, and offers a guarded way to send locally (#1196).
+
+### iOS
+
+- Work chat stays on-screen when the keyboard opens. Following the transcript re-pins across keyboard and composer shrink; scrolling up still keeps your place (#1198).
 
 ## [1.2.70] - 2026-09-01
 
@@ -1863,7 +1873,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Initial public release.
 
-[Unreleased]: https://github.com/arul28/ADE/compare/v1.2.69...HEAD
+[Unreleased]: https://github.com/arul28/ADE/compare/v1.2.71...HEAD
+[1.2.71]: https://github.com/arul28/ADE/compare/v1.2.70...v1.2.71
 [1.2.70]: https://github.com/arul28/ADE/compare/v1.2.69...v1.2.70
 [1.2.69]: https://github.com/arul28/ADE/compare/v1.2.68...v1.2.69
 [1.2.68]: https://github.com/arul28/ADE/compare/v1.2.67...v1.2.68

--- a/changelog/index.mdx
+++ b/changelog/index.mdx
@@ -5,6 +5,6 @@ description: "Latest ADE release notes and release history."
 
 ADE release notes live here in newest-first order. Start with the latest release, or browse the release list in the sidebar.
 
-<Card title="Latest release" icon="tag" href="/changelog/v1.2.70">
-  v1.2.70 - Keep Cursor chats stable through worker recovery and bound Codex fork replay.
+<Card title="Latest release" icon="tag" href="/changelog/v1.2.71">
+  v1.2.71 - Add Claude Fable 5.1, recover drafts after a remote disconnect, and keep iOS Work chat on-screen with the keyboard.
 </Card>

--- a/changelog/v1.2.71.mdx
+++ b/changelog/v1.2.71.mdx
@@ -1,0 +1,20 @@
+---
+title: "v1.2.71"
+description: "Release notes for ADE v1.2.71 - September 1, 2026"
+---
+
+Claude Fable 5.1 is the default Claude model. Drafts fall back to this computer when a remote machine drops, and iOS Work chat stays on-screen when the keyboard opens.
+
+---
+
+## Claude models
+
+- **Fable 5.1 is first in the Claude picker.** Order is Fable 5.1, Opus 5, Sonnet 5, Haiku 4.5, then Opus 4.8. Opus 4.8 no longer carries a 1M suffix. Fable 5 and Opus 4.7 ids, including old 1M aliases, resolve forward and no longer appear as rows.
+
+## Remote machines
+
+- **A disconnected remote no longer traps a draft.** ADE falls back to this computer, keeps recovery visible, and offers a guarded way to send locally.
+
+## iOS
+
+- **Work chat stays on-screen when the keyboard opens.** Following the transcript re-pins across keyboard and composer shrink; scrolling up still keeps your place.

--- a/docs.json
+++ b/docs.json
@@ -214,6 +214,7 @@
             "expanded": true,
             "pages": [
               "changelog",
+              "changelog/v1.2.71",
               "changelog/v1.2.70",
               "changelog/v1.2.69",
               "changelog/v1.2.68",


### PR DESCRIPTION
## Summary
- Public changelog for ADE v1.2.71: Claude Fable 5.1, remote-draft recovery, iOS keyboard follow.

## Test plan
- [x] `node scripts/validate-docs.mjs` (254 files)


Made with [Cursor](https://cursor.com)