### PR TITLE
docs(release): prepare v1.2.72 notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.2.72] - 2026-09-02
+
+### Claude
+
+- Claude chats now run Claude Code 2.1.258. ADE pins Claude Agent SDK 0.3.258 so Fable 5.1 can actually run on the shipped CLI (#1204).
+
+### Model picker
+
+- Grok, Kimi, Qwen, and GitHub Copilot are in the picker. Desktop, ADE Code, and iOS share the same catalog and provider order.
+
+### Cursor Cloud
+
+- Cloud chats send the model you picked and keep Cursor's agent name instead of swapping in a generic one (#1203).
+
+### Work chat
+
+- Ticks, menus, and a pending model pick stay consistent while a turn is running (#1201).
+
+### Updates
+
+- A newer ADE release replaces a staged update without requiring a relaunch first (#1200).
+
+### iOS
+
+- Work's model picker includes Grok, Kimi, Qwen, and GitHub Copilot, matching desktop.
+
 ## [1.2.71] - 2026-09-01
 
 ### Claude models
@@ -1873,7 +1899,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Initial public release.
 
-[Unreleased]: https://github.com/arul28/ADE/compare/v1.2.71...HEAD
+[Unreleased]: https://github.com/arul28/ADE/compare/v1.2.72...HEAD
+[1.2.72]: https://github.com/arul28/ADE/compare/v1.2.71...v1.2.72
 [1.2.71]: https://github.com/arul28/ADE/compare/v1.2.70...v1.2.71
 [1.2.70]: https://github.com/arul28/ADE/compare/v1.2.69...v1.2.70
 [1.2.69]: https://github.com/arul28/ADE/compare/v1.2.68...v1.2.69

--- a/changelog/index.mdx
+++ b/changelog/index.mdx
@@ -5,6 +5,6 @@ description: "Latest ADE release notes and release history."
 
 ADE release notes live here in newest-first order. Start with the latest release, or browse the release list in the sidebar.
 
-<Card title="Latest release" icon="tag" href="/changelog/v1.2.71">
-  v1.2.71 - Add Claude Fable 5.1, recover drafts after a remote disconnect, and keep iOS Work chat on-screen with the keyboard.
+<Card title="Latest release" icon="tag" href="/changelog/v1.2.72">
+  v1.2.72 - Run Claude Code 2.1.258 for Fable 5.1, add Grok/Kimi/Qwen/Copilot to the picker, and let a newer release replace a staged update without relaunching.
 </Card>

--- a/changelog/v1.2.72.mdx
+++ b/changelog/v1.2.72.mdx
@@ -1,0 +1,32 @@
+---
+title: "v1.2.72"
+description: "Release notes for ADE v1.2.72 - September 2, 2026"
+---
+
+Claude chats now run Claude Code 2.1.258, which Fable 5.1 needs. Grok, Kimi, Qwen, and GitHub Copilot are in the model picker. A newer ADE release replaces a staged update without relaunching.
+
+---
+
+## Claude
+
+- **Claude Code is 2.1.258.** ADE pins Claude Agent SDK 0.3.258 so Fable 5.1 can actually run on the shipped CLI.
+
+## Model picker
+
+- **Grok, Kimi, Qwen, and GitHub Copilot are in the picker.** Desktop, ADE Code, and iOS share the same catalog and provider order.
+
+## Cursor Cloud
+
+- **Cloud chats send the model you picked** and keep Cursor's agent name instead of swapping in a generic one.
+
+## Work chat
+
+- **Ticks, menus, and a pending model pick stay consistent** while a turn is running.
+
+## Updates
+
+- **A newer ADE release replaces a staged update** without requiring a relaunch first.
+
+## iOS
+
+- **Work's model picker includes Grok, Kimi, Qwen, and GitHub Copilot**, matching desktop.

--- a/docs.json
+++ b/docs.json
@@ -214,6 +214,7 @@
             "expanded": true,
             "pages": [
               "changelog",
+              "changelog/v1.2.72",
               "changelog/v1.2.71",
               "changelog/v1.2.70",
               "changelog/v1.2.69",


### PR DESCRIPTION
## Summary
- Public changelog for **v1.2.72**: Claude Code 2.1.258 / SDK 0.3.258 so Fable 5.1 can run, Grok/Kimi/Qwen/Copilot in the picker, Cursor Cloud model params, Work chat consistency, and staged-update supersede.
- Updates `changelog/v1.2.72.mdx`, `changelog/index.mdx`, `docs.json`, and `CHANGELOG.md`. `node scripts/validate-docs.mjs` passed (257 files).

## Test plan
- [x] `node scripts/validate-docs.mjs`
- [ ] CI `validate-docs` on this PR


Made with [Cursor](https://cursor.com)