### PR TITLE
fix(chat): preserve provider modes and recover queued messages

### DIFF
--- a/apps/ade-cli/src/adeRpcServer.test.ts
+++ b/apps/ade-cli/src/adeRpcServer.test.ts
@@ -2430,6 +2430,41 @@ describe("adeRpcServer", () => {
     });
   });
 
+  it("preserves explicit Droid native autonomy in start_cli_session", async () => {
+    const fixture = createRuntime();
+    fixture.runtime.sessionService.get.mockReturnValue({
+      id: "session-1",
+      laneId: "lane-1",
+      ptyId: "pty-1",
+      tracked: true,
+      toolType: "droid",
+      title: "Droid",
+      status: "running",
+      resumeCommand: null,
+      resumeMetadata: null,
+    });
+    const handler = createAdeRpcRequestHandler({ runtime: fixture.runtime, serverVersion: "test" });
+
+    await initialize(handler, { role: "orchestrator" });
+    const response = await callTool(handler, "start_cli_session", {
+      laneId: "lane-1",
+      provider: "droid",
+      permissionMode: "default",
+      droidPermissionMode: "agi",
+    });
+
+    expect(response?.isError).toBeUndefined();
+    const createCall = fixture.runtime.ptyService.create.mock.calls.at(-1)?.[0] as {
+      startupCommand?: string;
+    };
+    expect(createCall.startupCommand).toContain('\\\"interactionMode\\\":\\\"agi\\\"');
+    expect(createCall.startupCommand).toContain('\\\"autonomyLevel\\\":\\\"off\\\"');
+    expect(response.structuredContent).toMatchObject({
+      provider: "droid",
+      droidPermissionMode: "agi",
+    });
+  });
+
   it("persists CLI spawn lineage in resume metadata without assigning terminal ownership", async () => {
     const fixture = createRuntime();
     fixture.runtime.sessionService.get.mockReturnValue({

--- a/apps/ade-cli/src/adeRpcServer.ts
+++ b/apps/ade-cli/src/adeRpcServer.ts
@@ -75,6 +75,7 @@ import { BUILT_IN_BROWSER_ACTOR_CAPABILITY_PARAM } from "./services/builtInBrows
 import { resolveCodexComputerUseMcpConfig } from "../../desktop/src/main/utils/codexComputerUse";
 import { parseTrackedCliLaunchConfig } from "../../desktop/src/main/utils/terminalSessionSignals";
 import { RUNTIME_COMPAT_LEVEL } from "../../desktop/src/shared/adeRuntimeProtocol";
+import { AGENT_CHAT_DROID_PERMISSION_MODE_VALUES } from "../../desktop/src/shared/types/chat";
 
 // Cross-surface (desktop + TUI + iOS) model picker favorites & recents.
 // Backed by the per-project cr-sqlite CRR DB (runtime.db) so the three surfaces
@@ -1244,7 +1245,7 @@ const CTO_OPERATOR_TOOL_SPECS: ToolSpec[] = [
         modelId: { type: "string" },
         reasoningEffort: { type: "string" },
         permissionMode: { type: "string", enum: ["default", "auto", "plan", "edit", "full-auto", "config-toml"] },
-        droidPermissionMode: { type: "string", enum: ["read-only", "auto-low", "auto-medium", "auto-high"] },
+        droidPermissionMode: { type: "string", enum: [...AGENT_CHAT_DROID_PERMISSION_MODE_VALUES] },
         title: { type: "string" },
         initialPrompt: { type: "string" },
         openInUi: { type: "boolean" }

--- a/apps/ade-cli/src/adeRpcServer.ts
+++ b/apps/ade-cli/src/adeRpcServer.ts
@@ -60,7 +60,7 @@ import {
   type LaunchProfile,
   type TrackedCliLaunchCommand,
 } from "../../desktop/src/shared/cliLaunch";
-import type { AgentChatPermissionMode, AgentChatSpawnKind, TerminalResumeMetadata, TerminalSessionSummary } from "../../desktop/src/shared/types";
+import type { AgentChatDroidPermissionMode, AgentChatPermissionMode, AgentChatSpawnKind, TerminalResumeMetadata, TerminalSessionSummary } from "../../desktop/src/shared/types";
 import type { AdeRuntime } from "./bootstrap";
 import {
   recordUsageInteraction,
@@ -75,7 +75,11 @@ import { BUILT_IN_BROWSER_ACTOR_CAPABILITY_PARAM } from "./services/builtInBrows
 import { resolveCodexComputerUseMcpConfig } from "../../desktop/src/main/utils/codexComputerUse";
 import { parseTrackedCliLaunchConfig } from "../../desktop/src/main/utils/terminalSessionSignals";
 import { RUNTIME_COMPAT_LEVEL } from "../../desktop/src/shared/adeRuntimeProtocol";
-import { AGENT_CHAT_DROID_PERMISSION_MODE_VALUES } from "../../desktop/src/shared/types/chat";
+import {
+  AGENT_CHAT_DROID_PERMISSION_MODE_VALUES,
+  AGENT_CHAT_PERMISSION_MODE_VALUES,
+  isAgentChatDroidPermissionMode,
+} from "../../desktop/src/shared/types/chat";
 
 // Cross-surface (desktop + TUI + iOS) model picker favorites & recents.
 // Backed by the per-project cr-sqlite CRR DB (runtime.db) so the three surfaces
@@ -237,7 +241,7 @@ const TOOL_SPECS: ToolSpec[] = [
         runId: { type: "string" },
         stepId: { type: "string" },
         attemptId: { type: "string" },
-        permissionMode: { type: "string", enum: ["default", "auto", "plan", "edit", "full-auto", "config-toml"], default: "default" },
+        permissionMode: { type: "string", enum: [...AGENT_CHAT_PERMISSION_MODE_VALUES], default: "default" },
         toolWhitelist: { type: "array", items: { type: "string" }, maxItems: 24 },
         maxPromptChars: { type: "number", minimum: 256, maximum: 12000 },
         contextFilePath: { type: "string" },
@@ -334,7 +338,8 @@ const TOOL_SPECS: ToolSpec[] = [
       properties: {
         laneId: { type: "string", minLength: 1 },
         provider: { type: "string", enum: ["claude", "codex", "cursor", "droid", "opencode", "pi", "qwen", "kimi", "grok", "copilot", "shell"] },
-        permissionMode: { type: "string", enum: ["default", "auto", "plan", "edit", "full-auto", "config-toml"], default: "default" },
+        permissionMode: { type: "string", enum: [...AGENT_CHAT_PERMISSION_MODE_VALUES], default: "default" },
+        droidPermissionMode: { type: "string", enum: [...AGENT_CHAT_DROID_PERMISSION_MODE_VALUES] },
         title: { type: "string" },
         initialInput: { type: "string" },
         cols: { type: "number", minimum: 20, maximum: 400, default: 120 },
@@ -1244,7 +1249,7 @@ const CTO_OPERATOR_TOOL_SPECS: ToolSpec[] = [
         laneId: { type: "string" },
         modelId: { type: "string" },
         reasoningEffort: { type: "string" },
-        permissionMode: { type: "string", enum: ["default", "auto", "plan", "edit", "full-auto", "config-toml"] },
+        permissionMode: { type: "string", enum: [...AGENT_CHAT_PERMISSION_MODE_VALUES] },
         droidPermissionMode: { type: "string", enum: [...AGENT_CHAT_DROID_PERMISSION_MODE_VALUES] },
         title: { type: "string" },
         initialPrompt: { type: "string" },
@@ -1712,6 +1717,16 @@ function parseCliSessionPermissionMode(value: unknown): AgentChatPermissionMode 
   throw new JsonRpcError(
     JsonRpcErrorCode.invalidParams,
     "permissionMode must be one of default, auto, plan, edit, full-auto, or config-toml",
+  );
+}
+
+function parseCliSessionDroidPermissionMode(value: unknown): AgentChatDroidPermissionMode | undefined {
+  const mode = asTrimmedString(value).toLowerCase();
+  if (!mode) return undefined;
+  if (isAgentChatDroidPermissionMode(mode)) return mode;
+  throw new JsonRpcError(
+    JsonRpcErrorCode.invalidParams,
+    "droidPermissionMode must be one of read-only, auto-low, auto-medium, auto-high, or agi",
   );
 }
 
@@ -4012,6 +4027,13 @@ async function runTool(args: {
     const laneId = assertNonEmptyString(toolArgs.laneId, "laneId");
     const provider = parseCliSessionProvider(toolArgs.provider);
     const permissionMode = parseCliSessionPermissionMode(toolArgs.permissionMode);
+    const droidPermissionMode = parseCliSessionDroidPermissionMode(toolArgs.droidPermissionMode);
+    if (droidPermissionMode && provider !== "droid") {
+      throw new JsonRpcError(
+        JsonRpcErrorCode.invalidParams,
+        "droidPermissionMode is only supported for Droid CLI sessions.",
+      );
+    }
     const orchestrationParentSessionId = toolArgs.orchestrationParentSessionId == null
       ? null
       : assertNonEmptyString(toolArgs.orchestrationParentSessionId, "orchestrationParentSessionId");
@@ -4070,6 +4092,7 @@ async function runTool(args: {
       return buildTrackedCliLaunchCommand({
         provider,
         permissionMode,
+        ...(droidPermissionMode ? { droidPermissionMode } : {}),
         sessionId: preassignedSessionId,
         model,
         reasoningEffort,
@@ -4131,6 +4154,7 @@ async function runTool(args: {
       laneId,
       title,
       permissionMode,
+      droidPermissionMode: droidPermissionMode ?? null,
       model: provider === "claude" ? model ?? null : null,
       ptyId: created.ptyId,
       sessionId: created.sessionId,

--- a/apps/ade-cli/src/cli.test.ts
+++ b/apps/ade-cli/src/cli.test.ts
@@ -3344,6 +3344,51 @@ describe("ADE CLI", () => {
     });
   });
 
+  it("forwards explicit Droid autonomy through new chat CLI mode", () => {
+    const plan = buildCliPlan([
+      "new",
+      "chat",
+      "--mode",
+      "cli",
+      "--lane",
+      "lane-1",
+      "--provider",
+      "droid",
+      "--permissions",
+      "default",
+      "--droid-autonomy",
+      "agi",
+      "--prompt",
+      "Run the Droid child.",
+    ]);
+
+    const executePlan = expectExecutePlan(plan);
+    const launchParams = (executePlan.steps[0]?.params as (v: Record<string, unknown>) => Record<string, unknown>)({});
+    expect(launchParams).toMatchObject({
+      name: "start_cli_session",
+      arguments: {
+        provider: "droid",
+        permissionMode: "default",
+        droidPermissionMode: "agi",
+        initialInput: "Run the Droid child.",
+      },
+    });
+  });
+
+  it("rejects invalid Droid autonomy values on every chat planning surface", () => {
+    const invalid = "not-a-droid-tier";
+    const plans = [
+      ["chat", "create", "--lane", "lane-1", "--provider", "droid", "--droid-autonomy", invalid],
+      ["chat", "create", "--personal", "--provider", "droid", "--model", "droid/model", "--droid-autonomy", invalid],
+      ["chat", "update", "personal-1", "--personal", "--droid-autonomy", invalid],
+      ["shell", "start-cli", "--lane", "lane-1", "--provider", "droid", "--droid-autonomy", invalid],
+    ];
+
+    for (const args of plans) {
+      expect(() => buildCliPlan(args)).toThrow(/droidPermissionMode must be one of/);
+    }
+  });
+
   it("adds a valid --type to new chat createSession args and rejects invalid values", () => {
     const plan = buildCliPlan([
       "new",

--- a/apps/ade-cli/src/cli.test.ts
+++ b/apps/ade-cli/src/cli.test.ts
@@ -3789,6 +3789,53 @@ describe("ADE CLI", () => {
     });
   });
 
+  it("previews the Cursor mode a create actually persists", () => {
+    const cursorMode = (permissions: string) => {
+      const plan = buildCliPlan([
+        "chat",
+        "create",
+        "--lane",
+        "lane-1",
+        "--provider",
+        "cursor",
+        "--model",
+        "cursor/composer-2",
+        "--permissions",
+        permissions,
+        "--print-config",
+      ]);
+      return (expectStaticPlan(plan).value as { resolved: { cursorMode: string } }).resolved.cursorMode;
+    };
+
+    expect(cursorMode("full-auto")).toBe("full-auto");
+    expect(cursorMode("plan")).toBe("plan");
+    // `edit` previewed as "ask" — a read-only mode no create path has ever
+    // persisted. Cursor runs both `edit` and `default` as `agent`.
+    expect(cursorMode("edit")).toBe("agent");
+    expect(cursorMode("default")).toBe("agent");
+  });
+
+  it("preserves an explicit Droid autonomy tier in the create preview", () => {
+    const plan = buildCliPlan([
+      "chat",
+      "create",
+      "--lane",
+      "lane-1",
+      "--provider",
+      "droid",
+      "--model",
+      "droid/model",
+      "--permissions",
+      "edit",
+      "--droid-permission-mode",
+      "auto-high",
+      "--print-config",
+    ]);
+
+    expect((expectStaticPlan(plan).value as { resolved: { droidPermissionMode: string } }).resolved.droidPermissionMode)
+      .toBe("auto-high");
+  });
+
   it("prints chat create from Linear dry-run with attachment flags", () => {
     const plan = buildCliPlan([
       "chat",
@@ -8539,6 +8586,53 @@ describe("ADE CLI", () => {
     const sendArgs = (sendParams.arguments as { args: { text: string } }).args;
     expect(sendArgs.text).toContain("ENG-431");
     expect(sendArgs.text).toContain("https://linear.app/x/ENG-431");
+  });
+
+  it("forwards provider-native Droid autonomy through Linear and personal launches", () => {
+    const linearPlan = expectExecutePlan(buildCliPlan([
+      "lanes",
+      "create-from-linear",
+      "--linear-issue-json",
+      '{"id":"issue-1","identifier":"ENG-431","title":"Fix OAuth"}',
+      "--start-chat",
+      "--provider",
+      "droid",
+      "--model",
+      "droid/model",
+      "--droid-permission-mode",
+      "auto-high",
+    ]));
+    const chatParams = (linearPlan.steps[1]?.params as (v: Record<string, unknown>) => Record<string, unknown>)({
+      lane: { domain: "lane", action: "create", result: { lane: { id: "lane-new" } } },
+    });
+    expect(chatParams).toMatchObject({
+      arguments: {
+        args: {
+          provider: "droid",
+          droidPermissionMode: "auto-high",
+        },
+      },
+    });
+
+    const personalPlan = expectExecutePlan(buildCliPlan([
+      "chat",
+      "create",
+      "--personal",
+      "--provider",
+      "droid",
+      "--model",
+      "droid/model",
+      "--droid-permission-mode",
+      "auto-medium",
+    ]));
+    expect(personalPlan.steps[0]).toMatchObject({
+      params: {
+        action: "create",
+        args: {
+          droidPermissionMode: "auto-medium",
+        },
+      },
+    });
   });
 
   it("requires and persists a spawn type when create-from-linear starts a child chat", () => {

--- a/apps/ade-cli/src/cli.ts
+++ b/apps/ade-cli/src/cli.ts
@@ -72,6 +72,11 @@ import {
   machineStatusLine,
 } from "../../desktop/src/shared/machinePresence";
 import { SEARCH_DOC_KINDS } from "../../desktop/src/shared/types/search";
+import {
+  droidPermissionModeFromLegacyPermissionMode,
+  isAgentChatDroidPermissionMode,
+  type AgentChatDroidPermissionMode,
+} from "../../desktop/src/shared/types/chat";
 import type { AgentChatDispatchSteerMode } from "../../desktop/src/shared/types/chat";
 import type { TerminalSessionSummary } from "../../desktop/src/shared/types/sessions";
 import {
@@ -2944,6 +2949,18 @@ const DROID_PERMISSION_MODE_FLAGS = [
   "--autonomy",
 ];
 
+function readDroidPermissionMode(args: string[]): AgentChatDroidPermissionMode | null {
+  const value = readValue(args, DROID_PERMISSION_MODE_FLAGS);
+  if (value == null) return null;
+  const normalized = value.trim().toLowerCase();
+  if (isAgentChatDroidPermissionMode(normalized)) {
+    return normalized;
+  }
+  throw new CliUsageError(
+    "droidPermissionMode must be one of read-only, auto-low, auto-medium, auto-high, or agi.",
+  );
+}
+
 function readValue(args: string[], names: string[]): string | null {
   for (let index = 0; index < args.length; index += 1) {
     const token = args[index];
@@ -4890,7 +4907,7 @@ function readChatLaunchConfig(args: string[]): JsonObject {
   maybePut(
     config,
     "droidPermissionMode",
-    readValue(args, DROID_PERMISSION_MODE_FLAGS),
+    readDroidPermissionMode(args),
   );
   if (fastMode !== undefined) {
     config.fastMode = fastMode;
@@ -5019,6 +5036,7 @@ function buildNewChatPlan(args: string[], defaultMode: "chat" | "cli"): CliPlan 
   const modelArg = readValue(args, ["--model", "--model-id"]);
   const reasoningEffort = readValue(args, ["--reasoning-effort", "--effort", "--reasoning"]);
   const permissionMode = readValue(args, ["--permission-mode", "--permissions"]);
+  const droidPermissionMode = readDroidPermissionMode(args);
   const fastMode = readFastModeFlag(args);
   const title = readValue(args, ["--title"]);
   const printConfig = readFlag(args, ["--print-config", "--dry-run"]);
@@ -5028,6 +5046,9 @@ function buildNewChatPlan(args: string[], defaultMode: "chat" | "cli"): CliPlan 
   }
   if (mode === "chat" && provider === "shell") {
     throw new CliUsageError("Chat mode provider must be claude, codex, cursor, droid, opencode, pi, qwen, kimi, grok, or copilot.");
+  }
+  if (droidPermissionMode && provider !== "droid") {
+    throw new CliUsageError("Droid autonomy is only supported for Droid chat sessions.");
   }
   if (mode === "cli") {
     const effectivePermissionMode = permissionMode ?? "default";
@@ -5063,7 +5084,7 @@ function buildNewChatPlan(args: string[], defaultMode: "chat" | "cli"): CliPlan 
         permissionMode,
         ...(orchestrationParentSessionId ? { orchestrationParentSessionId } : {}),
         ...(spawnKind ? { spawnKind } : {}),
-        droidPermissionMode: readValue(args, DROID_PERMISSION_MODE_FLAGS),
+        ...(droidPermissionMode ? { droidPermissionMode } : {}),
         title,
         surface: readValue(args, ["--surface"]) ?? "work",
         ...(fastMode !== undefined ? { fastMode, codexFastMode: fastMode } : {}),
@@ -5076,6 +5097,7 @@ function buildNewChatPlan(args: string[], defaultMode: "chat" | "cli"): CliPlan 
         model: modelArg,
         modelId: modelArg,
         reasoningEffort,
+        ...(droidPermissionMode ? { droidPermissionMode } : {}),
         ...(fastMode !== undefined ? { fastMode, codexFastMode: fastMode } : {}),
         // Spawn lineage rides on resume metadata, which only agent providers
         // have — plain shell terminals can't persist it, so don't pretend.
@@ -5225,7 +5247,7 @@ function codexPermissionPreview(permissionMode: string): JsonObject | null {
 }
 
 function permissionModePreview(permissionMode: string, droidPermissionMode?: string | null): JsonObject {
-  const mode = permissionMode || "default";
+  const mode = isTrackedCliPermissionMode(permissionMode) ? permissionMode : "default";
   return {
     permissionMode: mode,
     claudePermissionMode: mode === "full-auto"
@@ -5242,13 +5264,9 @@ function permissionModePreview(permissionMode: string, droidPermissionMode?: str
     // preview as `ask`, which no create path has ever produced: Cursor runs
     // both `edit` and `default` as `agent`.
     cursorMode: effectiveCursorModeId(null, mode),
-    droidPermissionMode: droidPermissionMode ?? (mode === "full-auto"
-      ? "auto-high"
-      : mode === "edit"
-        ? "auto-low"
-        : mode === "plan"
-          ? "read-only"
-          : "auto-medium"),
+    droidPermissionMode: droidPermissionMode
+      ?? droidPermissionModeFromLegacyPermissionMode(mode)
+      ?? "auto-medium",
     opencodePermissionMode: mode === "default" ? "edit" : mode,
   };
 }
@@ -6994,6 +7012,10 @@ function buildCliSessionStartPlan(
     : readValue(args, ["--message", "--prompt", "--initial-input"]);
   const permissionMode =
     readValue(args, ["--permission-mode", "--permissions"]) ?? "default";
+  const droidPermissionMode = readDroidPermissionMode(args);
+  if (droidPermissionMode && provider !== "droid") {
+    throw new CliUsageError("Droid autonomy is only supported for Droid CLI sessions.");
+  }
   if (!isTrackedCliPermissionMode(permissionMode)) {
     throw new CliUsageError(
       "permissionMode must be one of default, auto, plan, edit, full-auto, or config-toml.",
@@ -7023,6 +7045,7 @@ function buildCliSessionStartPlan(
     chatSessionId: readValue(args, ["--chat-session", "--chat-session-id"]),
     ...(orchestrationParentSessionId ? { orchestrationParentSessionId } : {}),
     ...(spawnKind ? { spawnKind } : {}),
+    ...(droidPermissionMode ? { droidPermissionMode } : {}),
     tracked: !readFlag(args, ["--untracked"]),
   });
 
@@ -7782,7 +7805,7 @@ function buildChatPlan(args: string[]): CliPlan {
           "--permission-mode",
           "--permissions",
         ]),
-        droidPermissionMode: readValue(args, DROID_PERMISSION_MODE_FLAGS),
+        droidPermissionMode: readDroidPermissionMode(args),
         title: readValue(args, ["--title"]),
         surface: readValue(args, ["--surface"]) ?? "work",
         ...(fastMode !== undefined ? { fastMode, codexFastMode: fastMode } : {}),
@@ -8558,7 +8581,7 @@ function buildPersonalChatPlan(sub: string, args: string[]): CliPlan {
     const model = readValue(args, ["--model", "--model-id"]);
     const provider = readValue(args, ["--provider"]);
     const prompt = readValue(args, ["--prompt", "--kickoff", "--kickoff-prompt"]);
-    const droidPermissionMode = readValue(args, DROID_PERMISSION_MODE_FLAGS);
+    const droidPermissionMode = readDroidPermissionMode(args);
     const fastMode = readFastModeFlag(args);
     const createArgs = collectGenericObjectArgs(args, {
       provider,
@@ -8687,7 +8710,7 @@ function buildPersonalChatPlan(sub: string, args: string[]): CliPlan {
     const provider = readValue(args, ["--provider"]);
     const reasoningEffort = readValue(args, ["--reasoning-effort", "--effort"]);
     const permissionMode = readValue(args, ["--permission-mode", "--permissions"]);
-    const droidPermissionMode = readValue(args, DROID_PERMISSION_MODE_FLAGS);
+    const droidPermissionMode = readDroidPermissionMode(args);
     const fastMode = readFastModeFlag(args);
     return {
       ...base,

--- a/apps/ade-cli/src/cli.ts
+++ b/apps/ade-cli/src/cli.ts
@@ -61,6 +61,7 @@ import { buildPairingQrPayload } from "../../desktop/src/shared/pairingQr";
 import { buildWebClientPairUrl } from "../../desktop/src/shared/webClientUrl";
 import { abbreviatePathTail } from "../../desktop/src/shared/pathDisplay";
 import { CURSOR_CLI_EXECUTABLES } from "../../desktop/src/shared/providerCliExecutables";
+import { effectiveCursorModeId } from "../../desktop/src/shared/cursorModes";
 import {
   accountMachineDisplayName,
   accountMachineConnectionState,
@@ -1767,6 +1768,9 @@ const HELP_BY_COMMAND: Record<string, string> = {
     --model <id>           Runtime model id.
     --reasoning-effort <v> Reasoning tier. Alias: --effort.
     --permissions <mode>   default | auto | plan | edit | full-auto | config-toml.
+    --droid-permission-mode <m>
+                           Droid only: read-only | auto-low | auto-medium | auto-high | agi.
+                           Aliases: --droid-autonomy, --autonomy.
     --fast                 Request fast service tier when supported.
     --no-fast, --standard  Disable fast service tier explicitly.
     --prompt <text>        First chat message or CLI initial input.
@@ -2235,6 +2239,9 @@ const HELP_BY_COMMAND: Record<string, string> = {
     --kickoff <text>        Alias for --prompt.
     --permissions <mode>    Alias for --permission-mode.
     --permission-mode <m>   default | auto | plan | edit | full-auto | config-toml.
+    --droid-permission-mode <m>
+                            Droid only: read-only | auto-low | auto-medium | auto-high | agi.
+                            Aliases: --droid-autonomy, --autonomy.
     --fast                  Request fast service tier when supported.
     --no-fast, --standard   Disable fast mode explicitly.
     --print                 Start the session runtime in print mode.
@@ -2930,6 +2937,12 @@ function parseRuntimeProfile(value: string | null | undefined): "embedded" | und
     `Unknown runtime profile '${trimmed}'. The only profile ade runtime run accepts is 'embedded'.`,
   );
 }
+
+const DROID_PERMISSION_MODE_FLAGS = [
+  "--droid-permission-mode",
+  "--droid-autonomy",
+  "--autonomy",
+];
 
 function readValue(args: string[], names: string[]): string | null {
   for (let index = 0; index < args.length; index += 1) {
@@ -4874,6 +4887,11 @@ function readChatLaunchConfig(args: string[]): JsonObject {
     "permissionMode",
     readValue(args, ["--permission-mode", "--permissions"]),
   );
+  maybePut(
+    config,
+    "droidPermissionMode",
+    readValue(args, DROID_PERMISSION_MODE_FLAGS),
+  );
   if (fastMode !== undefined) {
     config.fastMode = fastMode;
     // Mirror to the deprecated alias so older daemons (pre-rename) still see the selection.
@@ -5045,11 +5063,7 @@ function buildNewChatPlan(args: string[], defaultMode: "chat" | "cli"): CliPlan 
         permissionMode,
         ...(orchestrationParentSessionId ? { orchestrationParentSessionId } : {}),
         ...(spawnKind ? { spawnKind } : {}),
-        droidPermissionMode: readValue(args, [
-          "--droid-permission-mode",
-          "--droid-autonomy",
-          "--autonomy",
-        ]),
+        droidPermissionMode: readValue(args, DROID_PERMISSION_MODE_FLAGS),
         title,
         surface: readValue(args, ["--surface"]) ?? "work",
         ...(fastMode !== undefined ? { fastMode, codexFastMode: fastMode } : {}),
@@ -5210,7 +5224,7 @@ function codexPermissionPreview(permissionMode: string): JsonObject | null {
   };
 }
 
-function permissionModePreview(permissionMode: string): JsonObject {
+function permissionModePreview(permissionMode: string, droidPermissionMode?: string | null): JsonObject {
   const mode = permissionMode || "default";
   return {
     permissionMode: mode,
@@ -5224,20 +5238,17 @@ function permissionModePreview(permissionMode: string): JsonObject {
             ? "auto"
             : "default",
     codex: codexPermissionPreview(mode),
-    cursorMode: mode === "full-auto"
-      ? "full-auto"
-      : mode === "plan"
-        ? "plan"
-        : mode === "edit"
-          ? "ask"
-          : "agent",
-    droidPermissionMode: mode === "full-auto"
+    // Preview the mode the created session actually persists. `edit` used to
+    // preview as `ask`, which no create path has ever produced: Cursor runs
+    // both `edit` and `default` as `agent`.
+    cursorMode: effectiveCursorModeId(null, mode),
+    droidPermissionMode: droidPermissionMode ?? (mode === "full-auto"
       ? "auto-high"
       : mode === "edit"
         ? "auto-low"
         : mode === "plan"
           ? "read-only"
-          : "auto-medium",
+          : "auto-medium"),
     opencodePermissionMode: mode === "default" ? "edit" : mode,
   };
 }
@@ -5304,7 +5315,7 @@ function buildChatCreateConfigPreview(
       model: asString(input.model) ?? asString(input.modelId) ?? null,
       reasoningEffort: asString(input.reasoningEffort) ?? null,
       fastMode: typeof input.fastMode === "boolean" ? input.fastMode : null,
-      ...permissionModePreview(permissionMode),
+      ...permissionModePreview(permissionMode, asString(input.droidPermissionMode)),
     },
   };
 }
@@ -7771,11 +7782,7 @@ function buildChatPlan(args: string[]): CliPlan {
           "--permission-mode",
           "--permissions",
         ]),
-        droidPermissionMode: readValue(args, [
-          "--droid-permission-mode",
-          "--droid-autonomy",
-          "--autonomy",
-        ]),
+        droidPermissionMode: readValue(args, DROID_PERMISSION_MODE_FLAGS),
         title: readValue(args, ["--title"]),
         surface: readValue(args, ["--surface"]) ?? "work",
         ...(fastMode !== undefined ? { fastMode, codexFastMode: fastMode } : {}),
@@ -8551,6 +8558,7 @@ function buildPersonalChatPlan(sub: string, args: string[]): CliPlan {
     const model = readValue(args, ["--model", "--model-id"]);
     const provider = readValue(args, ["--provider"]);
     const prompt = readValue(args, ["--prompt", "--kickoff", "--kickoff-prompt"]);
+    const droidPermissionMode = readValue(args, DROID_PERMISSION_MODE_FLAGS);
     const fastMode = readFastModeFlag(args);
     const createArgs = collectGenericObjectArgs(args, {
       provider,
@@ -8559,6 +8567,7 @@ function buildPersonalChatPlan(sub: string, args: string[]): CliPlan {
       title: readValue(args, ["--title"]),
       reasoningEffort: readValue(args, ["--reasoning-effort", "--effort"]),
       permissionMode: readValue(args, ["--permission-mode", "--permissions"]),
+      ...(droidPermissionMode ? { droidPermissionMode } : {}),
       ...(fastMode !== undefined ? { fastMode, codexFastMode: fastMode } : {}),
       ...(prompt ? { kickoffText: prompt } : {}),
     });
@@ -8678,6 +8687,7 @@ function buildPersonalChatPlan(sub: string, args: string[]): CliPlan {
     const provider = readValue(args, ["--provider"]);
     const reasoningEffort = readValue(args, ["--reasoning-effort", "--effort"]);
     const permissionMode = readValue(args, ["--permission-mode", "--permissions"]);
+    const droidPermissionMode = readValue(args, DROID_PERMISSION_MODE_FLAGS);
     const fastMode = readFastModeFlag(args);
     return {
       ...base,
@@ -8690,6 +8700,7 @@ function buildPersonalChatPlan(sub: string, args: string[]): CliPlan {
         ...(model ? { model, modelId: model } : {}),
         ...(reasoningEffort ? { reasoningEffort } : {}),
         ...(permissionMode ? { permissionMode } : {}),
+        ...(droidPermissionMode ? { droidPermissionMode } : {}),
         ...(fastMode !== undefined ? { fastMode } : {}),
       }))],
     };

--- a/apps/ade-cli/src/services/sync/syncRemoteCommandService.ts
+++ b/apps/ade-cli/src/services/sync/syncRemoteCommandService.ts
@@ -3,6 +3,9 @@ import path from "node:path";
 import { createHash, randomUUID } from "node:crypto";
 import { fileURLToPath } from "node:url";
 import {
+  AGENT_CHAT_DROID_PERMISSION_MODE_VALUES,
+  droidPermissionModeFromLegacyPermissionMode,
+  isAgentChatDroidPermissionMode,
   isAgentChatTurnRecoveryAction,
   normalizeAgentChatSessionMetadataFields,
 } from "../../../../desktop/src/shared/types/chat";
@@ -1052,7 +1055,7 @@ function parsePrepareCrossMachineHandoffArgs(
   const codexSandbox = parseEnum("codexSandbox", ["read-only", "workspace-write", "danger-full-access"] as const);
   const codexConfigSource = parseEnum("codexConfigSource", ["flags", "config-toml"] as const);
   const opencodePermissionMode = parseEnum("opencodePermissionMode", ["plan", "edit", "full-auto", "config-toml"] as const);
-  const droidPermissionMode = parseEnum("droidPermissionMode", ["read-only", "auto-low", "auto-medium", "auto-high", "agi"] as const);
+  const droidPermissionMode = parseEnum("droidPermissionMode", AGENT_CHAT_DROID_PERMISSION_MODE_VALUES);
   const permissionMode = parseEnum("permissionMode", ["default", "auto", "plan", "edit", "full-auto", "config-toml"] as const);
   const cursorModeId = parseNullableString("cursorModeId");
   const cursorConfigValues = parseConfigValues();
@@ -1675,6 +1678,13 @@ function parseCliPermissionMode(value: unknown): SyncStartCliSessionArgs["permis
   return isTrackedCliPermissionMode(mode) ? mode : "default";
 }
 
+function parseCliDroidPermissionMode(value: unknown): SyncStartCliSessionArgs["droidPermissionMode"] {
+  const mode = asTrimmedString(value)?.toLowerCase();
+  if (!mode) return undefined;
+  if (isAgentChatDroidPermissionMode(mode)) return mode;
+  throw new Error("work.startCliSession requires a valid droidPermissionMode.");
+}
+
 function parseOptionalCliPermissionMode(value: unknown): SyncSendToSessionArgs["permissionMode"] {
   const mode = asTrimmedString(value);
   return isTrackedCliPermissionMode(mode) ? mode : undefined;
@@ -1702,6 +1712,10 @@ function parseOptionalCodexConfigSource(value: unknown): SyncSendToSessionArgs["
 function parseStartCliSessionArgs(value: Record<string, unknown>): SyncStartCliSessionArgs {
   const laneId = requireString(value.laneId, "work.startCliSession requires laneId.");
   const provider = parseCliProvider(value.provider);
+  const droidPermissionMode = parseCliDroidPermissionMode(value.droidPermissionMode);
+  if (droidPermissionMode && provider !== "droid") {
+    throw new Error("work.startCliSession droidPermissionMode is only supported for Droid.");
+  }
   const initialInput = typeof value.initialInput === "string" && value.initialInput.trim().length > 0
     ? value.initialInput.slice(0, 20_000)
     : null;
@@ -1709,6 +1723,7 @@ function parseStartCliSessionArgs(value: Record<string, unknown>): SyncStartCliS
     laneId,
     provider,
     permissionMode: parseCliPermissionMode(value.permissionMode),
+    ...(droidPermissionMode !== undefined ? { droidPermissionMode } : {}),
     title: asTrimmedString(value.title),
     initialInput,
     cols: asOptionalNumber(value.cols),
@@ -2017,9 +2032,10 @@ function mapPrAiPermissionModeToNativeFields(
     return { codexApprovalPolicy: "on-request", codexSandbox: "read-only", codexConfigSource: "flags" };
   }
   if (provider === "droid") {
-    if (legacy === "full-auto") return { droidPermissionMode: "auto-high" };
-    if (legacy === "edit") return { droidPermissionMode: "auto-low" };
-    return { droidPermissionMode: "read-only" };
+    // PR-AI's generic default intentionally remains review-safe read-only;
+    // the shared conversion handles the explicit plan/edit/full-auto tiers.
+    if (legacy === "default") return { droidPermissionMode: "read-only" };
+    return { droidPermissionMode: droidPermissionModeFromLegacyPermissionMode(legacy) ?? "read-only" };
   }
   if (provider === "cursor") {
     if (legacy === "full-auto") return { cursorModeId: "full-auto" };
@@ -4351,6 +4367,7 @@ function registerWorkRemoteCommands({ args, register }: RemoteCommandRegistratio
       return buildTrackedCliLaunchCommand({
         provider,
         permissionMode,
+        ...(parsed.droidPermissionMode !== undefined ? { droidPermissionMode: parsed.droidPermissionMode } : {}),
         sessionId: preassignedSessionId,
         model: parsed.modelId ?? parsed.model ?? undefined,
         reasoningEffort: parsed.reasoningEffort ?? undefined,

--- a/apps/ade-cli/src/tuiClient/__tests__/adeApi.test.ts
+++ b/apps/ade-cli/src/tuiClient/__tests__/adeApi.test.ts
@@ -1663,7 +1663,7 @@ describe("steer helpers", () => {
     expect(calls).toEqual([
       { domain: "chat", action: "steer", args: { sessionId: "chat-1", text: "while busy" } },
       { domain: "chat", action: "editSteer", args: { sessionId: "chat-1", steerId: "steer-1", text: "updated" } },
-      { domain: "chat", action: "cancelSteer", args: { sessionId: "chat-1", steerId: "steer-1" } },
+      { domain: "chat", action: "cancelSteer", args: { sessionId: "chat-1", steerId: "steer-1", requireQueued: true } },
       { domain: "chat", action: "dispatchSteer", args: { sessionId: "chat-1", steerId: "steer-1", mode: "inline" } },
     ]);
   });

--- a/apps/ade-cli/src/tuiClient/__tests__/adeApi.test.ts
+++ b/apps/ade-cli/src/tuiClient/__tests__/adeApi.test.ts
@@ -1663,7 +1663,7 @@ describe("steer helpers", () => {
     expect(calls).toEqual([
       { domain: "chat", action: "steer", args: { sessionId: "chat-1", text: "while busy" } },
       { domain: "chat", action: "editSteer", args: { sessionId: "chat-1", steerId: "steer-1", text: "updated" } },
-      { domain: "chat", action: "cancelSteer", args: { sessionId: "chat-1", steerId: "steer-1", requireQueued: true } },
+      { domain: "chat", action: "cancelSteer", args: { sessionId: "chat-1", steerId: "steer-1" } },
       { domain: "chat", action: "dispatchSteer", args: { sessionId: "chat-1", steerId: "steer-1", mode: "inline" } },
     ]);
   });

--- a/apps/ade-cli/src/tuiClient/adeApi.ts
+++ b/apps/ade-cli/src/tuiClient/adeApi.ts
@@ -912,10 +912,10 @@ export async function cancelSteerMessage(
   sessionId: string,
   steerId: string,
 ): Promise<void> {
-  // This helper is only used for rows already rendered in the staged-steer
-  // strip. Refuse a delivery race instead of reporting success after the row
-  // has already left the queue.
-  await connection.action("chat", "cancelSteer", { sessionId, steerId, requireQueued: true });
+  // Ordinary cancellation must also work for persisted staged messages when
+  // the runtime is offline. The service owns the queue-race policy; callers
+  // should not turn a local cancel into a live-runtime-only operation.
+  await connection.action("chat", "cancelSteer", { sessionId, steerId });
 }
 
 /**

--- a/apps/ade-cli/src/tuiClient/adeApi.ts
+++ b/apps/ade-cli/src/tuiClient/adeApi.ts
@@ -912,7 +912,10 @@ export async function cancelSteerMessage(
   sessionId: string,
   steerId: string,
 ): Promise<void> {
-  await connection.action("chat", "cancelSteer", { sessionId, steerId });
+  // This helper is only used for rows already rendered in the staged-steer
+  // strip. Refuse a delivery race instead of reporting success after the row
+  // has already left the queue.
+  await connection.action("chat", "cancelSteer", { sessionId, steerId, requireQueued: true });
 }
 
 /**

--- a/apps/ade-cli/src/tuiClient/app.tsx
+++ b/apps/ade-cli/src/tuiClient/app.tsx
@@ -8159,7 +8159,13 @@ export function AdeCodeApp({ project, forceEmbedded, requireSocket, socketPath, 
           codexConfigSource: configSession.codexConfigSource ?? prev.codexConfigSource,
           opencodePermissionMode: configSession.opencodePermissionMode ?? prev.opencodePermissionMode,
           droidPermissionMode: configSession.droidPermissionMode ?? prev.droidPermissionMode,
-          cursorModeId: configSession.cursorModeId ?? configSession.cursorModeSnapshot?.currentModeId ?? prev.cursorModeId,
+          // `null` is an intentional clear for the legacy permission-only
+          // paths. Only an omitted field should fall back to the snapshot or
+          // the previous chat's value; `??` would leak the previous Cursor
+          // mode into a newly hydrated session.
+          cursorModeId: configSession.cursorModeId !== undefined
+            ? configSession.cursorModeId
+            : configSession.cursorModeSnapshot?.currentModeId ?? prev.cursorModeId,
           cursorAvailableModeIds: configSession.cursorModeSnapshot?.availableModeIds ?? prev.cursorAvailableModeIds,
           cursorConfigValues: configSession.cursorConfigValues ?? prev.cursorConfigValues,
         }));

--- a/apps/ade-cli/src/tuiClient/modelState.ts
+++ b/apps/ade-cli/src/tuiClient/modelState.ts
@@ -15,6 +15,7 @@ import type {
   AgentChatModelInfo,
   AgentChatPermissionMode,
 } from "../../../desktop/src/shared/types/chat";
+import { AGENT_CHAT_DROID_PERMISSION_MODE_VALUES } from "../../../desktop/src/shared/types/chat";
 import { DEFAULT_CODEX_REASONING_EFFORT, type CliTerminalProvider } from "./adeApi";
 import { theme } from "./theme";
 import type { AdeCodeInterfaceMode, AdeCodeModelState, AdeCodeProvider, SetupPaneRow, SetupPaneRowKind } from "./types";
@@ -25,7 +26,7 @@ export const EFFORTS = ["low", "medium", "high", "xhigh", "max", "ultra"];
 export const CODEX_PRESETS = ["default", "edit", "plan", "full-auto", "config-toml"] as const;
 export const CLAUDE_PERMISSION_OPTIONS = ["default", "auto", "plan", "acceptEdits", "bypassPermissions"] as const;
 export const OPENCODE_PERMISSION_OPTIONS = ["plan", "edit", "full-auto", "config-toml"] as const;
-export const DROID_PERMISSION_OPTIONS = ["read-only", "auto-low", "auto-medium", "auto-high", "agi"] as const;
+export const DROID_PERMISSION_OPTIONS = AGENT_CHAT_DROID_PERMISSION_MODE_VALUES;
 
 export type CodexPreset = (typeof CODEX_PRESETS)[number];
 

--- a/apps/desktop/src/main/services/ai/tools/ctoOperatorTools.test.ts
+++ b/apps/desktop/src/main/services/ai/tools/ctoOperatorTools.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi, beforeEach } from "vitest";
 import { createCtoOperatorTools, type CtoOperatorToolDeps } from "./ctoOperatorTools";
+import { AGENT_CHAT_PERMISSION_MODE_VALUES } from "../../../../shared/types/chat";
 
 // Mock only execFileSync on node:child_process so searchCodebase can exercise it deterministically.
 // Preserve the rest of the module (e.g. spawn, exec) for unrelated tests.
@@ -341,6 +342,60 @@ describe("createCtoOperatorTools", () => {
         count: 1,
         truncated: false,
       });
+    });
+
+    it("forwards an explicit spawnChat permissionMode to the chat create contract", async () => {
+      const deps = buildDeps();
+      const tools = createCtoOperatorTools(deps);
+
+      await (tools.spawnChat as any).execute({
+        title: "Full auto worker",
+        permissionMode: "full-auto",
+      });
+
+      expect(deps.createChat).toHaveBeenCalledWith(expect.objectContaining({
+        permissionMode: "full-auto",
+      }));
+    });
+
+    it("forwards a provider-native Droid permission tier", async () => {
+      const deps = buildDeps();
+      const tools = createCtoOperatorTools(deps);
+
+      await (tools.spawnChat as any).execute({
+        droidPermissionMode: "auto-high",
+      });
+
+      expect(deps.createChat).toHaveBeenCalledWith(expect.objectContaining({
+        droidPermissionMode: "auto-high",
+      }));
+    });
+
+    it("omits permissionMode entirely when spawnChat is not given one", async () => {
+      const deps = buildDeps();
+      const tools = createCtoOperatorTools(deps);
+
+      await (tools.spawnChat as any).execute({ title: "Default worker" });
+
+      // A substituted default here would be persisted as a real selection and
+      // pin the spawned chat to it. Absence has to stay absent.
+      expect(deps.createChat).toHaveBeenCalledWith(
+        expect.not.objectContaining({ permissionMode: expect.anything() }),
+      );
+    });
+
+    it("exposes the complete ADE permission contract at the schema layer", () => {
+      const tools = createCtoOperatorTools(buildDeps());
+
+      // The model reads the schema as the contract; values that fail deeper in
+      // the stack burn a turn. Keep this in lockstep with AgentChatPermissionMode
+      // and the ADE RPC spawnChat action.
+      for (const permissionMode of AGENT_CHAT_PERMISSION_MODE_VALUES) {
+        expect((tools.spawnChat as any).inputSchema.safeParse({ permissionMode }).success).toBe(true);
+      }
+      expect((tools.spawnChat as any).inputSchema.safeParse({ droidPermissionMode: "auto-high" }).success).toBe(true);
+      expect((tools.spawnChat as any).inputSchema.safeParse({ permissionMode: "yolo" }).success).toBe(false);
+      expect((tools.spawnChat as any).inputSchema.safeParse({}).success).toBe(true);
     });
 
     it("persists a requested chat title and returns navigation metadata when spawning chats", async () => {

--- a/apps/desktop/src/main/services/ai/tools/ctoOperatorTools.ts
+++ b/apps/desktop/src/main/services/ai/tools/ctoOperatorTools.ts
@@ -30,6 +30,10 @@ import type { CtoMemoryService } from "../../cto/ctoMemoryService";
 import { getErrorMessage, nowIso, parseIsoToEpoch } from "../../shared/utils";
 import { buildAdePrUrl } from "../../../../shared/deeplinks";
 import { settleAbortMessage } from "../../sessions/settleTerminalSession";
+import {
+  AGENT_CHAT_DROID_PERMISSION_MODE_VALUES,
+  AGENT_CHAT_PERMISSION_MODE_VALUES,
+} from "../../../../shared/types/chat";
 
 export interface CtoOperatorToolDeps {
   currentSessionId: string;
@@ -418,6 +422,9 @@ export function createCtoOperatorTools(deps: CtoOperatorToolDeps): Record<string
       "'anthropic/claude-haiku-4-5' for Haiku, 'openai/gpt-5.6-sol' for Sol). " +
       "If no modelId is passed, the CTO's default model preference is used. " +
       "Set initialPrompt to seed the chat with a task description — the agent will begin working immediately. " +
+      "Pass permissionMode only when the user asks for a specific access level; omitting it keeps the provider's " +
+      "own default, which is the safe choice. It accepts ADE's full permission contract, including auto and " +
+      "config-toml; for Droid's finer-grained levels, pass droidPermissionMode. " +
       "This creates a full ADE chat with UI, streaming, tool approval, and service integration. " +
       "Use this when the user asks for 'a chat' or 'an agent'. If they explicitly want a terminal or CLI tool, use createTerminal instead.",
     inputSchema: z.object({
@@ -426,9 +433,22 @@ export function createCtoOperatorTools(deps: CtoOperatorToolDeps): Record<string
       reasoningEffort: z.string().nullable().optional().describe("Reasoning effort advertised by the model, including 'max' or Codex 'ultra' when supported."),
       title: z.string().optional().describe("Display title for the chat session."),
       initialPrompt: z.string().optional().describe("Task description to seed the chat. The agent starts working immediately."),
+      permissionMode: z
+        .enum(AGENT_CHAT_PERMISSION_MODE_VALUES)
+        .optional()
+        .describe(
+          "Access level for the spawned agent, translated to each provider's native controls: "
+          + "'default' uses the provider default, 'auto' delegates approvals where supported, "
+          + "'plan' is read-only, 'edit' accepts file edits, 'full-auto' skips every approval, "
+          + "and 'config-toml' uses provider config. Omit to inherit the provider default.",
+        ),
+      droidPermissionMode: z
+        .enum(AGENT_CHAT_DROID_PERMISSION_MODE_VALUES)
+        .optional()
+        .describe("Droid-native access level; use with a Droid model when its read-only/auto/agi tier is important."),
       openInUi: z.boolean().optional().default(true).describe("Whether to open the chat in the ADE UI."),
     }),
-    execute: async ({ laneId, modelId, reasoningEffort, title, initialPrompt, openInUi }) => {
+    execute: async ({ laneId, modelId, reasoningEffort, title, initialPrompt, permissionMode, droidPermissionMode, openInUi }) => {
       try {
         // Resolve model: supports full IDs (anthropic/claude-sonnet-5), short IDs (sonnet), and aliases (opus)
         const rawModelId = modelId?.trim() || null;
@@ -447,6 +467,10 @@ export function createCtoOperatorTools(deps: CtoOperatorToolDeps): Record<string
           model: resolved.model,
           ...(selectedModelId ? { modelId: selectedModelId } : {}),
           reasoningEffort: reasoningEffort ?? deps.defaultReasoningEffort ?? null,
+          // Absent means absent. Sending a substituted default here would be
+          // persisted as a real selection and pin the spawned chat to it.
+          ...(permissionMode !== undefined ? { permissionMode } : {}),
+          ...(droidPermissionMode !== undefined ? { droidPermissionMode } : {}),
           surface: "work",
           sessionProfile: "workflow",
         });
@@ -476,6 +500,8 @@ export function createCtoOperatorTools(deps: CtoOperatorToolDeps): Record<string
           provider: session.provider,
           model: session.model,
           modelId: session.modelId ?? null,
+          permissionMode: session.permissionMode ?? null,
+          droidPermissionMode: session.droidPermissionMode ?? null,
         };
       } catch (error) {
         return { success: false, error: getErrorMessage(error) };

--- a/apps/desktop/src/main/services/chat/agentChatService.test.ts
+++ b/apps/desktop/src/main/services/chat/agentChatService.test.ts
@@ -39601,7 +39601,7 @@ describe("createAgentChatService", () => {
         ],
       });
 
-      await service.cancelSteer({ sessionId: session.id, steerId: cancelledSteerId });
+      await service.cancelSteer({ sessionId: session.id, steerId: cancelledSteerId, requireQueued: true });
 
       expect(readPersistedChatState(session.id).pendingSteers).toEqual([
         { steerId: survivingSteerId, text: "Keep me" },
@@ -44613,6 +44613,55 @@ it("fails a cleanly ended OpenCode event stream and clears active child sessions
       permissionMode: "default",
     });
     expect(updated.cursorModeId ?? null).toBeNull();
+    expect(updated.permissionMode).toBe("default");
+    await expect(service.getSessionSummary(session.id)).resolves.toMatchObject({
+      cursorModeId: null,
+      cursorModeIdWasCleared: true,
+    });
+  });
+
+  it("broadcasts an explicit Cursor mode clear when lowering legacy permissions", async () => {
+    const events: AgentChatEventEnvelope[] = [];
+    const { service } = createService({
+      onEvent: (event: AgentChatEventEnvelope) => events.push(event),
+    });
+    const cursorSession = await service.createSession({
+      laneId: "lane-1",
+      provider: "cursor",
+      model: "composer-2",
+      modelId: "cursor/composer-2",
+      permissionMode: "full-auto",
+    });
+    events.length = 0;
+
+    await service.updateSession({
+      sessionId: cursorSession.id,
+      permissionMode: "default",
+    });
+
+    const metaEvent = events
+      .map((envelope) => envelope.event)
+      .find((event): event is Extract<typeof event, { type: "session_meta_updated" }> =>
+        event.type === "session_meta_updated");
+    expect(metaEvent).toMatchObject({
+      permissionMode: "default",
+      cursorModeId: null,
+    });
+  });
+
+  it("preserves an explicit Cursor mode clear during native permission normalization", async () => {
+    const { service, session } = await setupCursorPermissionSession({
+      permissionMode: "full-auto",
+    });
+    expect(session.cursorModeId).toBe("full-auto");
+
+    const updated = await service.updateSession({
+      sessionId: session.id,
+      cursorModeId: null,
+    });
+
+    expect(updated.cursorModeId).toBeNull();
+    expect(updated.permissionMode).toBe("default");
   });
 
   it("pushes Cursor SDK mode changes into the live worker while a turn is active", async () => {

--- a/apps/desktop/src/main/services/chat/agentChatService.test.ts
+++ b/apps/desktop/src/main/services/chat/agentChatService.test.ts
@@ -1012,7 +1012,7 @@ import {
 } from "./crossProviderReplayFork";
 import { acquireDroidSdkConnection } from "./droidSdkPool";
 import { clearCursorCliModelsCache } from "./cursorModelsDiscovery";
-import type { AgentChatCreateScheduledWorkArgs, AgentChatCrossMachineHandoffCapsule, AgentChatEventEnvelope, ComputerUseBackendStatus, LaneLinearIssue, PendingInputRequest } from "../../../shared/types";
+import type { AgentChatCreateArgs, AgentChatCreateScheduledWorkArgs, AgentChatCrossMachineHandoffCapsule, AgentChatEventEnvelope, ComputerUseBackendStatus, LaneLinearIssue, PendingInputRequest } from "../../../shared/types";
 import { PTY_SEND_PRE_DELIVERY_ERROR_CODE } from "../../../shared/types";
 import { makeLinearIssueContextAttachment } from "../../../shared/chatContextAttachments";
 import { stableStringify } from "../shared/utils";
@@ -15867,6 +15867,29 @@ describe("createAgentChatService", () => {
       mockState.codexResponseOverrides.set("initialize", { userAgent: "codex/0.149.1" });
     };
 
+    const setupQueuedCodexTurn = async () => {
+      pin149();
+      const events: AgentChatEventEnvelope[] = [];
+      const { service } = createService({
+        onEvent: (event: AgentChatEventEnvelope) => events.push(event),
+      });
+      const session = await service.createSession({
+        laneId: "lane-1",
+        provider: "codex",
+        model: "gpt-5.4",
+      });
+      await service.sendMessage({
+        sessionId: session.id,
+        text: "Keep this turn active.",
+      }, { awaitDispatch: true });
+      mockState.emitCodexPayload({
+        jsonrpc: "2.0",
+        method: "item/started",
+        params: { turnId: "turn-1", item: { id: "compact-1", type: "contextCompaction" } },
+      });
+      return { service, session, events };
+    };
+
     it("sends ! and /shell drafts through thread/shellCommand", async () => {
       pin149();
       const { service } = createService();
@@ -16040,6 +16063,115 @@ describe("createAgentChatService", () => {
         event.event.type === "system_notice"
         && event.event.message === "Duplicate check-in ignored.",
       )).toBe(true);
+    });
+
+    it("cancels a queued Codex message and clears the staged chip", async () => {
+      const { service, session, events } = await setupQueuedCodexTurn();
+
+      const { steerId } = await service.steer({ sessionId: session.id, text: "check in" });
+      await service.cancelSteer({ sessionId: session.id, steerId });
+
+      expect(mockState.codexRequestPayloads.some((payload) => payload.method === "thread/queue/delete")).toBe(true);
+      expect(events.some((event) =>
+        event.event.type === "system_notice"
+        && event.event.message === "Queued message cancelled."
+        && event.event.steerId === steerId,
+      )).toBe(true);
+    });
+
+    it("recovers the Codex queue submission id when the in-memory mapping is missing", async () => {
+      // `queuedSubmissionBySteerId` lives only on the runtime object, so a
+      // restart, a rehydration, or a remote-handled cancel arrives with it
+      // empty while the transcript still renders the staged chip. The server
+      // is the durable half of the mapping.
+      const { service, session } = await setupQueuedCodexTurn();
+
+      // A queue/add that reports no id leaves the runtime with no mapping —
+      // the same state a restart or a rehydrated session produces — while the
+      // server still holds the submission under the steerId ADE sent it as.
+      mockState.codexResponseOverrides.set("thread/queue/add", (payload) => ({
+        queuedSubmission: {
+          clientUserMessageId: (payload.params as { clientUserMessageId?: string }).clientUserMessageId,
+        },
+      }));
+      const { steerId } = await service.steer({ sessionId: session.id, text: "check in" });
+      mockState.codexResponseOverrides.set("thread/queue/list", {
+        queuedSubmissions: [{ id: "recovered-submission", clientUserMessageId: steerId }],
+      });
+
+      await service.cancelSteer({ sessionId: session.id, steerId, requireQueued: true });
+
+      expect(mockState.codexRequestPayloads.some((payload) =>
+        payload.method === "thread/queue/delete"
+        && (payload.params as { id?: string }).id === "recovered-submission",
+      )).toBe(true);
+    });
+
+    it("raises instead of reporting a cancellation Codex refused", async () => {
+      // Swallowing this cleared the chip while the submission stayed queued and
+      // still ran — a false success, which is worse than a visible failure.
+      const { service, session, events } = await setupQueuedCodexTurn();
+
+      const { steerId } = await service.steer({ sessionId: session.id, text: "check in" });
+      mockState.codexResponseOverrides.set("thread/queue/delete", {
+        error: { code: -32000, message: "queue is locked" },
+      });
+
+      await expect(service.cancelSteer({ sessionId: session.id, steerId })).rejects.toThrow("queue is locked");
+      expect(events.some((event) =>
+        event.event.type === "system_notice"
+        && event.event.message === "Queued message cancelled."
+        && event.event.steerId === steerId,
+      )).toBe(false);
+    });
+
+    it("keeps the staged Codex message when queue recovery itself fails", async () => {
+      const { service, session, events } = await setupQueuedCodexTurn();
+
+      mockState.codexResponseOverrides.set("thread/queue/add", (payload) => ({
+        queuedSubmission: {
+          clientUserMessageId: (payload.params as { clientUserMessageId?: string }).clientUserMessageId,
+        },
+      }));
+      const { steerId } = await service.steer({ sessionId: session.id, text: "check in" });
+      mockState.codexResponseOverrides.set("thread/queue/list", {
+        error: { code: -32000, message: "queue temporarily unavailable" },
+      });
+
+      await expect(service.cancelSteer({ sessionId: session.id, steerId })).rejects.toThrow(
+        "Could not inspect Codex's queued messages: queue temporarily unavailable",
+      );
+      expect(events.some((event) =>
+        event.event.type === "system_notice"
+        && event.event.message === "Queued message cancelled."
+        && event.event.steerId === steerId,
+      )).toBe(false);
+      expect(mockState.codexRequestPayloads.some((payload) => payload.method === "thread/queue/delete")).toBe(false);
+    });
+
+    it("clears an unrecoverable staged Codex message instead of silently doing nothing", async () => {
+      const { service, session, events } = await setupQueuedCodexTurn();
+
+      // Mapping never recorded AND the server queue is empty: nothing can
+      // deliver this message, so the chip has to clear rather than sit there
+      // with a button that does nothing every time it is pressed.
+      mockState.codexResponseOverrides.set("thread/queue/add", (payload) => ({
+        queuedSubmission: {
+          clientUserMessageId: (payload.params as { clientUserMessageId?: string }).clientUserMessageId,
+        },
+      }));
+      const { steerId } = await service.steer({ sessionId: session.id, text: "check in" });
+
+      await service.cancelSteer({ sessionId: session.id, steerId });
+
+      expect(events.some((event) =>
+        event.event.type === "system_notice"
+        && event.event.message === "Queued message cancelled."
+        && event.event.steerId === steerId,
+      )).toBe(true);
+      await expect(
+        service.cancelSteer({ sessionId: session.id, steerId, requireQueued: true }),
+      ).rejects.toThrow("no longer queued");
     });
 
     it("runs mid-turn ! commands as user shell instead of steer", async () => {
@@ -39448,6 +39580,39 @@ describe("createAgentChatService", () => {
       expect(deliveredSteer).toBeUndefined();
     });
 
+    it("does not resurrect a cancelled persisted steer when no runtime is attached", async () => {
+      const events: AgentChatEventEnvelope[] = [];
+      const { service } = createService({
+        onEvent: (event: AgentChatEventEnvelope) => events.push(event),
+      });
+      const session = await service.createSession({
+        laneId: "lane-1",
+        provider: "cursor",
+        model: "composer-2",
+        modelId: "cursor/composer-2",
+      });
+      const cancelledSteerId = "persisted-steer-to-cancel";
+      const survivingSteerId = "persisted-steer-to-keep";
+      writePersistedChatState(session.id, {
+        ...readPersistedChatState(session.id),
+        pendingSteers: [
+          { steerId: cancelledSteerId, text: "Remove me" },
+          { steerId: survivingSteerId, text: "Keep me" },
+        ],
+      });
+
+      await service.cancelSteer({ sessionId: session.id, steerId: cancelledSteerId });
+
+      expect(readPersistedChatState(session.id).pendingSteers).toEqual([
+        { steerId: survivingSteerId, text: "Keep me" },
+      ]);
+      expect(events.some((event) =>
+        event.event.type === "system_notice"
+        && event.event.message === "Queued message cancelled."
+        && event.event.steerId === cancelledSteerId,
+      )).toBe(true);
+    });
+
     it("editSteer updates the queued steer text and cancels on interrupt", async () => {
       const events: AgentChatEventEnvelope[] = [];
       const send = vi.fn().mockResolvedValue(undefined);
@@ -44375,6 +44540,79 @@ it("fails a cleanly ended OpenCode event stream and clears active child sessions
     await expect(service.getSessionSummary(session.id)).resolves.toMatchObject({
       cursorModeId: "agent",
     });
+  });
+
+  const setupCursorPermissionSession = async (
+    controls: Pick<AgentChatCreateArgs, "permissionMode" | "cursorModeId"> = {},
+  ) => {
+    process.env.CURSOR_API_KEY = "cursor-test-key";
+    const { service } = createService();
+    const session = await service.createSession({
+      laneId: "lane-1",
+      provider: "cursor",
+      model: "composer-2",
+      modelId: "cursor/composer-2",
+      ...controls,
+    });
+    return { service, session };
+  };
+
+  it("persists the native Cursor full-auto mode for a permissionMode-only create", async () => {
+    // `ade new chat --provider cursor --permissions full-auto` sends only
+    // `permissionMode`; the desktop composer is the only caller that sends
+    // `cursorModeId`. The session used to run full-auto while reporting mode
+    // "agent", so every mode-reading surface disagreed with the policy.
+    const { service, session } = await setupCursorPermissionSession({
+      permissionMode: "full-auto",
+    });
+
+    expect(session.cursorModeId).toBe("full-auto");
+
+    await service.sendMessage({
+      sessionId: session.id,
+      text: "Run in full auto.",
+    }, { awaitDispatch: true });
+
+    await expect(service.getSessionSummary(session.id)).resolves.toMatchObject({
+      cursorModeId: "full-auto",
+      cursorModeSnapshot: expect.objectContaining({ currentModeId: "full-auto" }),
+    });
+  });
+
+  it("leaves cursorModeId absent for the legacy modes Cursor runs as plain agent", async () => {
+    // Materialising "agent" here would be read back as a real selection and
+    // pin the chat to it, which is the durable-pin bug the Droid and Claude
+    // native controls carry the same warning about.
+    for (const permissionMode of ["default", "edit"] as const) {
+      const { session } = await setupCursorPermissionSession({
+        permissionMode,
+      });
+      expect(session.cursorModeId ?? null).toBeNull();
+    }
+  });
+
+  it("does not let an explicit Cursor mode be overwritten by the legacy permission mode", async () => {
+    const { session } = await setupCursorPermissionSession({
+      permissionMode: "full-auto",
+      cursorModeId: "agent",
+    });
+
+    expect(session.cursorModeId).toBe("agent");
+  });
+
+  it("clears a derived Cursor full-auto mode when the permission mode is lowered", async () => {
+    const { service, session } = await setupCursorPermissionSession({
+      permissionMode: "full-auto",
+    });
+    expect(session.cursorModeId).toBe("full-auto");
+
+    // Without this the derived mode outlives the request that set it and the
+    // chat keeps running full-auto after the caller asked it not to.
+    const updated = await service.updateSession({
+      sessionId: session.id,
+      permissionMode: "default",
+    });
+    expect(updated.cursorModeId ?? null).toBeNull();
   });
 
   it("pushes Cursor SDK mode changes into the live worker while a turn is active", async () => {

--- a/apps/desktop/src/main/services/chat/agentChatService.ts
+++ b/apps/desktop/src/main/services/chat/agentChatService.ts
@@ -794,7 +794,7 @@ import {
 } from "./cursorSdkSystemPrompt";
 import { promises as fsPromises } from "node:fs";
 import { mapStopReasonToTerminalEvents } from "./stopReasonEvents";
-import { CURSOR_AVAILABLE_MODE_IDS } from "../../../shared/cursorModes";
+import { CURSOR_AVAILABLE_MODE_IDS, legacyPermissionModeToCursorModeId } from "../../../shared/cursorModes";
 import { getApiKey } from "../ai/apiKeyStore";
 import type { createOrchestrationService } from "../orchestration/orchestrationService";
 import {
@@ -5418,6 +5418,35 @@ function reopenSteerSettlement(managed: ManagedChatSession, steerId: string): vo
   settledSteerIds.get(managed)?.delete(steerId);
 }
 
+/**
+ * Steers cancelled while the session had no runtime to cancel them on.
+ *
+ * `persistChatState` carries the previous file's `pendingSteers` forward
+ * verbatim whenever the live runtime is not Claude, which includes "there is no
+ * runtime". Without this set a cancel on a torn-down session clears the chip and
+ * the next Claude runtime hydrates the steer straight back onto the queue, so
+ * the cancel reads as a UI glitch and the message is still sent.
+ */
+const cancelledPersistedSteerIds = new WeakMap<ManagedChatSession, Set<string>>();
+
+function forgetPersistedSteer(managed: ManagedChatSession, steerId: string): void {
+  let ids = cancelledPersistedSteerIds.get(managed);
+  if (!ids) {
+    ids = new Set<string>();
+    cancelledPersistedSteerIds.set(managed, ids);
+  }
+  ids.add(steerId);
+}
+
+function survivingPersistedSteers(
+  managed: ManagedChatSession,
+  steers: readonly PersistedPendingSteer[],
+): PersistedPendingSteer[] {
+  const cancelled = cancelledPersistedSteerIds.get(managed);
+  if (!cancelled?.size) return [...steers];
+  return steers.filter((steer) => !cancelled.has(steer.steerId));
+}
+
 function cursorSdkSilentRunError(): Error {
   const error = new Error(CURSOR_SDK_SILENT_RUN_MESSAGE);
   error.name = CURSOR_SDK_SILENT_RUN_ERROR_NAME;
@@ -6990,7 +7019,7 @@ function syncLegacyPermissionMode(session: Pick<
 function applyLegacyPermissionModeToNativeControls(
   session: Pick<
     AgentChatSession,
-    "provider" | "permissionMode" | "interactionMode" | "claudePermissionMode" | "codexApprovalPolicy" | "codexSandbox" | "codexConfigSource" | "opencodePermissionMode" | "droidPermissionMode"
+    "provider" | "permissionMode" | "interactionMode" | "claudePermissionMode" | "codexApprovalPolicy" | "codexSandbox" | "codexConfigSource" | "opencodePermissionMode" | "droidPermissionMode" | "cursorModeId"
   >,
   mode: AgentChatSession["permissionMode"] | undefined,
 ): void {
@@ -7019,6 +7048,12 @@ function applyLegacyPermissionModeToNativeControls(
   if (session.provider === "pi") return;
 
   session.opencodePermissionMode = legacyPermissionModeToOpenCodePermissionMode(mode);
+  if (session.provider === "cursor") {
+    // Overwrite, never fill: this runs when the caller explicitly changed
+    // `permissionMode`, so a stale `full-auto` from an earlier request has to
+    // clear rather than outlive the mode that set it.
+    session.cursorModeId = legacyPermissionModeToCursorModeId(mode);
+  }
 }
 
 type ClaudePlanModeTransition = "entered_plan_mode" | "exited_plan_mode";
@@ -7047,10 +7082,25 @@ function buildClaudePlanModeNoticeDetail(
 }
 
 
+/**
+ * Fill an absent Cursor mode from the legacy `permissionMode` the session was
+ * created or updated with. Fill only — an explicit mode is the user's own
+ * selection and outranks whatever the legacy field says, which is how picking
+ * `agent` on a `full-auto` chat stays `agent`.
+ */
+function applyCursorModeIdFromLegacyPermissionMode(
+  session: Pick<AgentChatSession, "provider" | "permissionMode" | "cursorModeId">,
+): void {
+  if (session.provider !== "cursor") return;
+  if (typeof session.cursorModeId === "string" && session.cursorModeId.trim().length) return;
+  const derived = legacyPermissionModeToCursorModeId(session.permissionMode);
+  if (derived) session.cursorModeId = derived;
+}
+
 function hydrateNativePermissionControls(
   session: Pick<
     AgentChatSession,
-    "provider" | "permissionMode" | "interactionMode" | "claudePermissionMode" | "codexApprovalPolicy" | "codexSandbox" | "codexConfigSource" | "opencodePermissionMode" | "droidPermissionMode"
+    "provider" | "permissionMode" | "interactionMode" | "claudePermissionMode" | "codexApprovalPolicy" | "codexSandbox" | "codexConfigSource" | "opencodePermissionMode" | "droidPermissionMode" | "cursorModeId"
   >,
 ): void {
   const orchestrationMode = isOrchestrationInteractionMode(session.interactionMode)
@@ -7076,6 +7126,7 @@ function hydrateNativePermissionControls(
   } else {
     if (orchestrationMode) session.interactionMode = orchestrationMode;
     session.opencodePermissionMode = session.opencodePermissionMode ?? legacyPermissionModeToOpenCodePermissionMode(session.permissionMode);
+    applyCursorModeIdFromLegacyPermissionMode(session);
   }
 
   session.permissionMode = syncLegacyPermissionMode(session);
@@ -7866,7 +7917,7 @@ function normalizeDroidReportedModelId(
 function normalizeSessionNativePermissionControls(
   session: Pick<
     AgentChatSession,
-    "provider" | "permissionMode" | "interactionMode" | "claudePermissionMode" | "codexApprovalPolicy" | "codexSandbox" | "codexConfigSource" | "opencodePermissionMode" | "droidPermissionMode"
+    "provider" | "permissionMode" | "interactionMode" | "claudePermissionMode" | "codexApprovalPolicy" | "codexSandbox" | "codexConfigSource" | "opencodePermissionMode" | "droidPermissionMode" | "cursorModeId"
   >,
   config: ResolvedChatConfig,
 ): void {
@@ -7904,6 +7955,7 @@ function normalizeSessionNativePermissionControls(
     if (orchestrationMode) session.interactionMode = orchestrationMode;
     else delete session.interactionMode;
     session.opencodePermissionMode = resolveSessionOpenCodePermissionMode(session, config.opencodePermissionMode);
+    applyCursorModeIdFromLegacyPermissionMode(session);
   }
 
   session.permissionMode = syncLegacyPermissionMode(session);
@@ -13801,6 +13853,9 @@ export function createAgentChatService(args: {
       managed.eventSequence,
       prevPersisted?.eventSequence,
     );
+    const survivingPreviousPendingSteers = prevPersisted?.pendingSteers?.length
+      ? survivingPersistedSteers(managed, prevPersisted.pendingSteers)
+      : [];
     const payload: PersistedChatState = {
       version: 2,
       sessionId: managed.session.id,
@@ -13933,7 +13988,11 @@ export function createAgentChatService(args: {
               })),
             }
           : {}
-        : prevPersisted?.pendingSteers?.length ? { pendingSteers: prevPersisted.pendingSteers } : {}),
+        : prevPersisted?.pendingSteers?.length
+          ? survivingPreviousPendingSteers.length
+            ? { pendingSteers: survivingPreviousPendingSteers }
+            : {}
+          : {}),
       ...(managed.runtime?.kind === "opencode"
         ? { providerSessionId: managed.runtime.handle.sessionId }
         : managed.session.provider === "opencode"
@@ -28506,6 +28565,16 @@ export function createAgentChatService(args: {
     return stringOrNull(queued?.id) ?? stringOrNull(record.id);
   };
 
+  type CodexQueueSubmission = { id?: string; clientUserMessageId?: string };
+  type CodexQueueListResponse = { queuedSubmissions?: CodexQueueSubmission[] };
+  const listCodexQueueSubmissions = async (
+    runtime: CodexRuntime,
+    threadId: string,
+  ): Promise<CodexQueueSubmission[]> => {
+    const listed = await runtime.request<CodexQueueListResponse>("thread/queue/list", { threadId });
+    return listed.queuedSubmissions ?? [];
+  };
+
   const startCodexQueuedFollowUp = async (
     managed: ManagedChatSession,
     runtime: CodexRuntime,
@@ -30053,11 +30122,9 @@ export function createAgentChatService(args: {
       const threadId = managed.session.threadId;
       if (!threadId) return;
       try {
-        const listed = await runtime.request<{
-          queuedSubmissions?: Array<{ id?: string; clientUserMessageId?: string }>;
-        }>("thread/queue/list", { threadId });
+        const queuedSubmissions = await listCodexQueueSubmissions(runtime, threadId);
         const liveIds = new Set(
-          (listed.queuedSubmissions ?? [])
+          queuedSubmissions
             .map((submission) => String(submission.id ?? "").trim())
             .filter(Boolean),
         );
@@ -43030,73 +43097,124 @@ export function createAgentChatService(args: {
     };
   };
 
-  const cancelSteer = async ({ sessionId, steerId, requireQueued = false }: AgentChatCancelSteerArgs): Promise<void> => {
-    const managed = ensureManagedSession(sessionId);
-    const runtime = managed.runtime;
-    if (runtime?.kind === "codex") {
-      const submissionId = runtime.queuedSubmissionBySteerId.get(steerId);
-      if (!submissionId) {
-        if (requireQueued) throw new Error("This message is no longer queued.");
-        return;
+  /**
+   * Re-derive a Codex queue submission id from the app-server.
+   *
+   * `queuedSubmissionBySteerId` lives only in the runtime object, so a restart,
+   * a rehydration, or a cancel routed in from another machine arrives with it
+   * empty while the transcript still renders the staged chip. Every queue entry
+   * carries the ADE steerId ADE sent as `clientUserMessageId`, so the server is
+   * the durable side of the mapping — read it back rather than concluding the
+   * message is gone.
+   */
+  const recoverCodexQueueSubmissionId = async (
+    managed: ManagedChatSession,
+    runtime: CodexRuntime,
+    steerId: string,
+  ): Promise<string | null> => {
+    const threadId = managed.session.threadId;
+    if (!threadId) return null;
+    if (!codexServerSupportsThreadQueue(runtime.serverVersion)) return null;
+    try {
+      const queuedSubmissions = await listCodexQueueSubmissions(runtime, threadId);
+      for (const submission of queuedSubmissions) {
+        if (String(submission.clientUserMessageId ?? "").trim() !== steerId) continue;
+        const id = String(submission.id ?? "").trim();
+        if (!id) continue;
+        runtime.queuedSubmissionBySteerId.set(steerId, id);
+        return id;
       }
-      const threadId = managed.session.threadId;
-      if (threadId) {
-        try {
-          await runtime.request("thread/queue/delete", { threadId, id: submissionId });
-        } catch (error) {
-          if (requireQueued) throw error;
-          logger.warn("codex.queue.delete_failed", {
-            sessionId,
-            error: error instanceof Error ? error.message : String(error),
-          });
-        }
-      }
-      runtime.queuedSubmissionBySteerId.delete(steerId);
-      emitChatEvent(managed, {
-        type: "system_notice",
-        noticeKind: "info",
-        steerId,
-        message: "Queued message cancelled.",
-        turnId: runtime.activeTurnId ?? undefined,
+    } catch (error) {
+      logger.debug("codex.queue.recover_failed", {
+        sessionId: managed.session.id,
+        error: error instanceof Error ? error.message : String(error),
       });
-      persistChatState(managed);
-      return;
+      // A failed queue read is not evidence that the submission disappeared.
+      // Keep the staged row and let the caller surface a retryable error rather
+      // than reporting a cancellation while the app-server may still deliver it.
+      throw new Error(
+        `Could not inspect Codex's queued messages: ${error instanceof Error ? error.message : String(error)}`,
+      );
     }
-    if (!runtime) {
-      if (requireQueued) throw new Error("This message is no longer queued.");
-      return;
-    }
+    return null;
+  };
 
-    const queue = runtime.pendingSteers;
-    // Both runtimes that track in-flight dispatches splice the row out of the
-    // queue before the dispatch completes, so without this the user would be
-    // told the message is "no longer queued" while it is in fact being sent.
-    if (
-      requireQueued
-      && (runtime.kind === "claude" || runtime.kind === "cursor")
-      && runtime.dispatchingSteerIds.has(steerId)
-    ) {
-      throw new Error("This message is already being dispatched.");
-    }
-    const idx = queue.findIndex((s) => s.steerId === steerId);
-    if (idx !== -1) {
-      const [removed] = queue.splice(idx, 1);
-      if (runtime.kind === "claude" && removed) runtime.knownQueuedMessages.delete(removed.uuid);
-    } else if (requireQueued) {
-      throw new Error("This message is no longer queued.");
-    }
-    // Always emit the cancelled notice — even when the steer already left the
-    // server-side queue (e.g. dispatched inline before this call landed) — so
-    // the client display clears the staged chip on the delete-button path.
+  const finalizeCancelledSteer = (
+    managed: ManagedChatSession,
+    steerId: string,
+    turnId?: string | null,
+  ): void => {
+    forgetPersistedSteer(managed, steerId);
     claimSteerSettlement(managed, steerId);
     emitChatEvent(managed, {
       type: "system_notice",
       noticeKind: "info",
       steerId,
       message: "Queued message cancelled.",
-      turnId: runtime.activeTurnId ?? undefined,
+      turnId: turnId ?? undefined,
     });
     persistChatState(managed);
+  };
+
+  const cancelSteer = async ({ sessionId, steerId, requireQueued = false }: AgentChatCancelSteerArgs): Promise<void> => {
+    const managed = ensureManagedSession(sessionId);
+    const runtime = managed.runtime;
+    if (runtime?.kind === "codex") {
+      const submissionId = runtime.queuedSubmissionBySteerId.get(steerId)
+        ?? await recoverCodexQueueSubmissionId(managed, runtime, steerId);
+      const threadId = managed.session.threadId;
+      if (submissionId && threadId) {
+        try {
+          await runtime.request("thread/queue/delete", { threadId, id: submissionId });
+        } catch (error) {
+          // The submission is still on the app-server queue and will run when
+          // the turn ends. Clearing the chip here would report a cancellation
+          // that did not happen, so keep the mapping and raise instead.
+          runtime.queuedSubmissionBySteerId.set(steerId, submissionId);
+          logger.warn("codex.queue.delete_failed", {
+            sessionId,
+            error: error instanceof Error ? error.message : String(error),
+          });
+          throw new Error(
+            `Codex would not drop the queued message: ${error instanceof Error ? error.message : String(error)}`,
+          );
+        }
+      } else if (requireQueued) {
+        throw new Error("This message is no longer queued.");
+      }
+      // No submission means no queue holds the message — clear the chip rather
+      // than leaving a control that does nothing every time it is pressed.
+      runtime.queuedSubmissionBySteerId.delete(steerId);
+    } else if (!runtime) {
+      if (requireQueued) throw new Error("This message is no longer queued.");
+      // A torn-down session holds no local queue, so the staged chip is the
+      // only thing left to cancel. The shared finalizer also drops the steer
+      // from persisted state before a future runtime can hydrate it.
+    } else {
+      const queue = runtime.pendingSteers;
+      // Both runtimes that track in-flight dispatches splice the row out of the
+      // queue before the dispatch completes, so without this the user would be
+      // told the message is "no longer queued" while it is in fact being sent.
+      if (
+        requireQueued
+        && (runtime.kind === "claude" || runtime.kind === "cursor")
+        && runtime.dispatchingSteerIds.has(steerId)
+      ) {
+        throw new Error("This message is already being dispatched.");
+      }
+      const idx = queue.findIndex((s) => s.steerId === steerId);
+      if (idx !== -1) {
+        const [removed] = queue.splice(idx, 1);
+        if (runtime.kind === "claude" && removed) runtime.knownQueuedMessages.delete(removed.uuid);
+      } else if (requireQueued) {
+        throw new Error("This message is no longer queued.");
+      }
+    }
+
+    // Always emit the cancelled notice — even when the steer already left the
+    // server-side queue (e.g. dispatched inline before this call landed) — so
+    // the client display clears the staged chip on the delete-button path.
+    finalizeCancelledSteer(managed, steerId, runtime?.activeTurnId);
   };
 
   const editSteer = async ({ sessionId, steerId, text }: AgentChatEditSteerArgs): Promise<void> => {
@@ -43104,7 +43222,11 @@ export function createAgentChatService(args: {
     const managed = ensureManagedSession(sessionId);
     const runtime = managed.runtime;
     if (runtime?.kind === "codex") {
-      const submissionId = runtime.queuedSubmissionBySteerId.get(steerId);
+      // Same lost-mapping case as cancelSteer: recover from the server queue
+      // before deciding the message is gone, or an edit after a restart is a
+      // silent no-op.
+      const submissionId = runtime.queuedSubmissionBySteerId.get(steerId)
+        ?? await recoverCodexQueueSubmissionId(managed, runtime, steerId);
       if (!submissionId) return;
       const threadId = managed.session.threadId;
       if (!threadId) return;

--- a/apps/desktop/src/main/services/chat/agentChatService.ts
+++ b/apps/desktop/src/main/services/chat/agentChatService.ts
@@ -409,7 +409,11 @@ import {
   providerSupportsHandoffFork,
 } from "../../../shared/types";
 import {
+  AGENT_CHAT_DROID_PERMISSION_MODE_VALUES,
+  AGENT_CHAT_PERMISSION_MODE_VALUES,
+  droidPermissionModeFromLegacyPermissionMode,
   isAcpChatProvider,
+  legacyPermissionModeFromDroidPermissionMode,
   spawnCompletedNoticeMessage,
   supportsActiveTurnDispatchMode,
   unsupportedActiveTurnDispatchModeMessage,
@@ -6769,7 +6773,7 @@ const PLAN_STEP_STATUS_MAP: Record<string, "pending" | "in_progress" | "complete
   failed: "failed",
 };
 
-const VALID_PERMISSION_MODES = new Set(["default", "auto", "plan", "edit", "full-auto", "config-toml"]);
+const VALID_PERMISSION_MODES = new Set<string>(AGENT_CHAT_PERMISSION_MODE_VALUES);
 const VALID_EXECUTION_MODES = new Set(["focused", "parallel", "subagents", "teams"]);
 const VALID_INTERACTION_MODES = new Set([
   "default",
@@ -6783,7 +6787,7 @@ const VALID_CODEX_APPROVAL_POLICIES = new Set(["untrusted", "on-request", "on-fa
 const VALID_CODEX_SANDBOXES = new Set(["read-only", "workspace-write", "danger-full-access"]);
 const VALID_CODEX_CONFIG_SOURCES = new Set(["flags", "config-toml"]);
 const VALID_OPENCODE_PERMISSION_MODES = new Set(["plan", "edit", "full-auto", "config-toml"]);
-const VALID_DROID_PERMISSION_MODES = new Set(["read-only", "auto-low", "auto-medium", "auto-high", "agi"]);
+const VALID_DROID_PERMISSION_MODES = new Set<string>(AGENT_CHAT_DROID_PERMISSION_MODE_VALUES);
 
 function normalizePersistedEnum<T extends string>(value: unknown, validSet: Set<string>): T | undefined {
   if (typeof value !== "string") return undefined;
@@ -6909,23 +6913,6 @@ function legacyPermissionModeToOpenCodePermissionMode(
   return mode === "default" ? "edit" : normalizeOpenCodePermissionMode(mode);
 }
 
-function legacyPermissionModeToDroidPermissionMode(
-  mode: AgentChatSession["permissionMode"] | undefined,
-): AgentChatDroidPermissionMode | undefined {
-  switch (mode) {
-    case "plan":
-      return "read-only";
-    case "edit":
-      return "auto-low";
-    case "default":
-      return "auto-medium";
-    case "full-auto":
-      return "auto-high";
-    default:
-      return undefined;
-  }
-}
-
 function legacyOpenCodePermissionModeToDroidPermissionMode(
   mode: AgentChatOpenCodePermissionMode | undefined,
 ): AgentChatDroidPermissionMode | undefined {
@@ -6941,26 +6928,9 @@ function legacyOpenCodePermissionModeToDroidPermissionMode(
   }
 }
 
-function droidPermissionModeToLegacyPermissionMode(
-  mode: AgentChatDroidPermissionMode | undefined,
-): AgentChatSession["permissionMode"] | undefined {
-  switch (mode) {
-    case "read-only":
-      return "plan";
-    case "auto-low":
-      return "edit";
-    case "auto-medium":
-      return "default";
-    case "auto-high":
-      return "full-auto";
-    default:
-      return undefined;
-  }
-}
-
 function syncLegacyPermissionMode(session: Pick<
   AgentChatSession,
-  "provider" | "permissionMode" | "interactionMode" | "claudePermissionMode" | "codexApprovalPolicy" | "codexSandbox" | "codexConfigSource" | "opencodePermissionMode" | "droidPermissionMode"
+  "provider" | "permissionMode" | "interactionMode" | "claudePermissionMode" | "codexApprovalPolicy" | "codexSandbox" | "codexConfigSource" | "opencodePermissionMode" | "droidPermissionMode" | "cursorModeId"
 >): AgentChatSession["permissionMode"] | undefined {
   if (session.provider === "claude") {
     if (session.interactionMode === "plan") {
@@ -6997,10 +6967,31 @@ function syncLegacyPermissionMode(session: Pick<
 
   if (session.provider === "droid") {
     if (session.interactionMode === "plan") return "plan";
-    return droidPermissionModeToLegacyPermissionMode(
+    return legacyPermissionModeFromDroidPermissionMode(
       session.droidPermissionMode
         ?? legacyOpenCodePermissionModeToDroidPermissionMode(session.opencodePermissionMode),
     );
+  }
+
+  if (session.provider === "cursor") {
+    switch (session.cursorModeId) {
+      case "full-auto":
+        return "full-auto";
+      case "plan":
+        return "plan";
+      case "ask":
+        return "edit";
+      case "agent":
+        return "default";
+      case null:
+        // A present null is an explicit native-mode clear, not a request to
+        // resurrect the previous OpenCode compatibility field.
+        return "default";
+      default:
+        // Undefined means an older/legacy caller did not send a native mode;
+        // preserve its already-selected legacy value while it is migrated.
+        return session.permissionMode;
+    }
   }
 
   if (session.provider === "pi") return session.permissionMode;
@@ -7041,19 +7032,21 @@ function applyLegacyPermissionModeToNativeControls(
 
   if (session.provider === "droid") {
     session.interactionMode = mode === "plan" ? "plan" : "default";
-    session.droidPermissionMode = legacyPermissionModeToDroidPermissionMode(mode);
+    session.droidPermissionMode = droidPermissionModeFromLegacyPermissionMode(mode);
     return;
   }
 
   if (session.provider === "pi") return;
 
-  session.opencodePermissionMode = legacyPermissionModeToOpenCodePermissionMode(mode);
   if (session.provider === "cursor") {
     // Overwrite, never fill: this runs when the caller explicitly changed
     // `permissionMode`, so a stale `full-auto` from an earlier request has to
     // clear rather than outlive the mode that set it.
+    session.opencodePermissionMode = legacyPermissionModeToOpenCodePermissionMode(mode);
     session.cursorModeId = legacyPermissionModeToCursorModeId(mode);
+    return;
   }
+  session.opencodePermissionMode = legacyPermissionModeToOpenCodePermissionMode(mode);
 }
 
 type ClaudePlanModeTransition = "entered_plan_mode" | "exited_plan_mode";
@@ -7092,6 +7085,11 @@ function applyCursorModeIdFromLegacyPermissionMode(
   session: Pick<AgentChatSession, "provider" | "permissionMode" | "cursorModeId">,
 ): void {
   if (session.provider !== "cursor") return;
+  // `undefined` means the caller did not supply a native mode. `null` is an
+  // explicit clear and must survive normalization instead of being rebuilt
+  // from the legacy permission field. Empty strings remain invalid/missing
+  // input and can still fall back to the legacy field.
+  if (session.cursorModeId === null) return;
   if (typeof session.cursorModeId === "string" && session.cursorModeId.trim().length) return;
   const derived = legacyPermissionModeToCursorModeId(session.permissionMode);
   if (derived) session.cursorModeId = derived;
@@ -7119,14 +7117,15 @@ function hydrateNativePermissionControls(
       ? "plan"
       : "default");
     session.droidPermissionMode = session.droidPermissionMode
-      ?? legacyPermissionModeToDroidPermissionMode(session.permissionMode)
+      ?? droidPermissionModeFromLegacyPermissionMode(session.permissionMode)
       ?? legacyOpenCodePermissionModeToDroidPermissionMode(session.opencodePermissionMode);
   } else if (session.provider === "pi") {
     if (orchestrationMode) session.interactionMode = orchestrationMode;
+  } else if (session.provider === "cursor") {
+    applyCursorModeIdFromLegacyPermissionMode(session);
   } else {
     if (orchestrationMode) session.interactionMode = orchestrationMode;
     session.opencodePermissionMode = session.opencodePermissionMode ?? legacyPermissionModeToOpenCodePermissionMode(session.permissionMode);
-    applyCursorModeIdFromLegacyPermissionMode(session);
   }
 
   session.permissionMode = syncLegacyPermissionMode(session);
@@ -7680,7 +7679,7 @@ function resolveSessionDroidPermissionModeOrNull(
   session: Pick<AgentChatSession, "droidPermissionMode" | "opencodePermissionMode" | "permissionMode">,
 ): AgentChatDroidPermissionMode | null {
   return session.droidPermissionMode
-    ?? legacyPermissionModeToDroidPermissionMode(session.permissionMode)
+    ?? droidPermissionModeFromLegacyPermissionMode(session.permissionMode)
     ?? legacyOpenCodePermissionModeToDroidPermissionMode(session.opencodePermissionMode)
     ?? null;
 }
@@ -7951,11 +7950,14 @@ function normalizeSessionNativePermissionControls(
   } else if (session.provider === "pi") {
     if (orchestrationMode) session.interactionMode = orchestrationMode;
     else delete session.interactionMode;
+  } else if (session.provider === "cursor") {
+    if (orchestrationMode) session.interactionMode = orchestrationMode;
+    else delete session.interactionMode;
+    applyCursorModeIdFromLegacyPermissionMode(session);
   } else {
     if (orchestrationMode) session.interactionMode = orchestrationMode;
     else delete session.interactionMode;
     session.opencodePermissionMode = resolveSessionOpenCodePermissionMode(session, config.opencodePermissionMode);
-    applyCursorModeIdFromLegacyPermissionMode(session);
   }
 
   session.permissionMode = syncLegacyPermissionMode(session);
@@ -14215,7 +14217,7 @@ export function createAgentChatService(args: {
       const opencodePermissionMode = normalizePersistedOpenCodePermissionMode(record.opencodePermissionMode ?? (record as any).unifiedPermissionMode);
       const droidPermissionMode = normalizePersistedDroidPermissionMode(record.droidPermissionMode)
         ?? (provider === "droid"
-          ? legacyPermissionModeToDroidPermissionMode(permissionMode)
+          ? droidPermissionModeFromLegacyPermissionMode(permissionMode)
             ?? legacyOpenCodePermissionModeToDroidPermissionMode(opencodePermissionMode)
           : undefined);
       const cursorModeSnapshot = record.cursorModeSnapshot && typeof record.cursorModeSnapshot === "object"
@@ -33984,7 +33986,7 @@ export function createAgentChatService(args: {
           // The desktop composer always sends one; a launch that sends nothing
           // is saying nothing, and Droid resolves it from settings.json.
           droidPermissionMode: requestedDroidPermissionMode
-            ?? legacyPermissionModeToDroidPermissionMode(effectivePermissionMode)
+            ?? droidPermissionModeFromLegacyPermissionMode(effectivePermissionMode)
             ?? legacyOpenCodePermissionModeToDroidPermissionMode(requestedOpenCodePermissionMode),
         };
       }
@@ -43143,8 +43145,9 @@ export function createAgentChatService(args: {
     managed: ManagedChatSession,
     steerId: string,
     turnId?: string | null,
+    options: { tombstonePersistedSteer?: boolean } = {},
   ): void => {
-    forgetPersistedSteer(managed, steerId);
+    if (options.tombstonePersistedSteer) forgetPersistedSteer(managed, steerId);
     claimSteerSettlement(managed, steerId);
     emitChatEvent(managed, {
       type: "system_notice",
@@ -43153,7 +43156,12 @@ export function createAgentChatService(args: {
       message: "Queued message cancelled.",
       turnId: turnId ?? undefined,
     });
-    persistChatState(managed);
+    const persisted = persistChatState(managed);
+    if (options.tombstonePersistedSteer && persisted) {
+      const cancelled = cancelledPersistedSteerIds.get(managed);
+      cancelled?.delete(steerId);
+      if (!cancelled?.size) cancelledPersistedSteerIds.delete(managed);
+    }
   };
 
   const cancelSteer = async ({ sessionId, steerId, requireQueued = false }: AgentChatCancelSteerArgs): Promise<void> => {
@@ -43186,7 +43194,11 @@ export function createAgentChatService(args: {
       // than leaving a control that does nothing every time it is pressed.
       runtime.queuedSubmissionBySteerId.delete(steerId);
     } else if (!runtime) {
-      if (requireQueued) throw new Error("This message is no longer queued.");
+      if (requireQueued) {
+        const persistedSteers = readPersistedState(managed.session.id)?.pendingSteers ?? [];
+        const stillPersisted = persistedSteers.some((steer) => steer.steerId === steerId);
+        if (!stillPersisted) throw new Error("This message is no longer queued.");
+      }
       // A torn-down session holds no local queue, so the staged chip is the
       // only thing left to cancel. The shared finalizer also drops the steer
       // from persisted state before a future runtime can hydrate it.
@@ -43214,7 +43226,9 @@ export function createAgentChatService(args: {
     // Always emit the cancelled notice — even when the steer already left the
     // server-side queue (e.g. dispatched inline before this call landed) — so
     // the client display clears the staged chip on the delete-button path.
-    finalizeCancelledSteer(managed, steerId, runtime?.activeTurnId);
+    finalizeCancelledSteer(managed, steerId, runtime?.activeTurnId, {
+      tombstonePersistedSteer: runtime == null && !managed.runtimeInvalidated,
+    });
   };
 
   const editSteer = async ({ sessionId, steerId, text }: AgentChatEditSteerArgs): Promise<void> => {
@@ -43227,9 +43241,9 @@ export function createAgentChatService(args: {
       // silent no-op.
       const submissionId = runtime.queuedSubmissionBySteerId.get(steerId)
         ?? await recoverCodexQueueSubmissionId(managed, runtime, steerId);
-      if (!submissionId) return;
+      if (!submissionId) throw new Error("This message is no longer queued.");
       const threadId = managed.session.threadId;
-      if (!threadId) return;
+      if (!threadId) throw new Error("This message cannot be edited because Codex has no active thread.");
       if (!trimmed.length) {
         await cancelSteer({ sessionId, steerId, requireQueued: true });
         return;
@@ -43249,10 +43263,10 @@ export function createAgentChatService(args: {
       persistChatState(managed);
       return;
     }
-    if (!runtime) return;
+    if (!runtime) throw new Error("This message is no longer queued.");
 
     const idx = runtime.pendingSteers.findIndex((s) => s.steerId === steerId);
-    if (idx === -1) return;
+    if (idx === -1) throw new Error("This message is no longer queued.");
 
     if (!trimmed.length) {
       const [removed] = runtime.pendingSteers.splice(idx, 1);
@@ -45045,6 +45059,16 @@ export function createAgentChatService(args: {
         error: error instanceof Error ? error.message : String(error),
       });
     }
+    // Preserve an explicit null from the live session instead of falling back
+    // to an older persisted native mode. The distinction matters to clients:
+    // Cursor's mode is nullable because null means the user cleared the native
+    // selection, not that the summary omitted it.
+    const summaryCursorModeId = liveSession?.cursorModeId !== undefined
+      ? liveSession.cursorModeId
+      : persisted?.cursorModeId;
+    const summaryCursorModeSnapshot = summaryCursorModeId === null
+      ? undefined
+      : liveSession?.cursorModeSnapshot ?? persisted?.cursorModeSnapshot;
     return {
       sessionId: row.id,
       laneId: row.laneId,
@@ -45088,12 +45112,13 @@ export function createAgentChatService(args: {
       ...(liveSession?.droidPermissionMode || persisted?.droidPermissionMode
         ? { droidPermissionMode: liveSession?.droidPermissionMode ?? persisted?.droidPermissionMode }
         : {}),
-      ...(liveSession?.cursorModeSnapshot || persisted?.cursorModeSnapshot
-        ? { cursorModeSnapshot: liveSession?.cursorModeSnapshot ?? persisted?.cursorModeSnapshot }
+      ...(summaryCursorModeSnapshot
+        ? { cursorModeSnapshot: summaryCursorModeSnapshot }
         : {}),
-      ...(liveSession?.cursorModeId !== undefined || persisted?.cursorModeId !== undefined
-        ? { cursorModeId: liveSession?.cursorModeId ?? persisted?.cursorModeId ?? null }
+      ...(summaryCursorModeId !== undefined
+        ? { cursorModeId: summaryCursorModeId ?? null }
         : {}),
+      ...(summaryCursorModeId === null ? { cursorModeIdWasCleared: true } : {}),
       ...(liveSession?.cursorConfigValues || persisted?.cursorConfigValues
         ? { cursorConfigValues: liveSession?.cursorConfigValues ?? persisted?.cursorConfigValues }
         : {}),
@@ -48266,7 +48291,7 @@ export function createAgentChatService(args: {
         ...(managed.session.codexConfigSource !== undefined ? { codexConfigSource: managed.session.codexConfigSource } : {}),
         ...(managed.session.opencodePermissionMode !== undefined ? { opencodePermissionMode: managed.session.opencodePermissionMode } : {}),
         ...(managed.session.droidPermissionMode !== undefined ? { droidPermissionMode: managed.session.droidPermissionMode } : {}),
-        ...(cursorModeId !== undefined || managed.session.cursorModeId != null
+        ...(cursorModeId !== undefined || permissionMode !== undefined || managed.session.cursorModeId != null
           ? { cursorModeId: managed.session.cursorModeId ?? null }
           : {}),
         ...(managed.session.cursorModeSnapshot ? { cursorModeSnapshot: managed.session.cursorModeSnapshot } : {}),

--- a/apps/desktop/src/main/services/chat/cursorSdkPolicy.test.ts
+++ b/apps/desktop/src/main/services/chat/cursorSdkPolicy.test.ts
@@ -62,6 +62,19 @@ describe("Cursor SDK policy", () => {
     expect(resolveCursorSdkPolicy({ cursorModeId: "full-auto" }).disallowedTools).toBeUndefined();
   });
 
+  it("does not resurrect an OpenCode full-auto value after Cursor is explicitly cleared", () => {
+    expect(resolveCursorSdkPolicy({
+      cursorModeId: null,
+      permissionMode: "default",
+      opencodePermissionMode: "full-auto",
+    })).toMatchObject({
+      chatMode: "agent",
+      approvalPolicy: "on-request",
+      sandbox: "ade",
+      fullAuto: false,
+    });
+  });
+
   it("maps ADE modes onto SDK agent/plan + local tools/sandbox/autoReview and never names a mode auto", () => {
     const expected: Record<string, {
       mode: "agent" | "plan";

--- a/apps/desktop/src/main/services/chat/cursorSdkPolicy.ts
+++ b/apps/desktop/src/main/services/chat/cursorSdkPolicy.ts
@@ -125,13 +125,14 @@ export function resolveCursorSdkChatMode(session: CursorSessionModeInput): Curso
   const explicit = typeof session.cursorModeId === "string" ? session.cursorModeId.trim().toLowerCase() : "";
   if (explicit === "ask" || explicit === "plan") return explicit;
   if (explicit === "agent" || explicit === "default") return "agent";
-  const legacy = typeof session.opencodePermissionMode === "string"
-    ? session.opencodePermissionMode
-    : session.permissionMode === "plan"
-      ? "plan"
-      : session.permissionMode === "full-auto"
-        ? "full-auto"
-        : "edit";
+  // `permissionMode` is the canonical legacy field for Cursor. The OpenCode
+  // field remains only as a migration fallback when an older session has no
+  // canonical value at all; it must not override an explicit Cursor clear.
+  const legacy = session.permissionMode !== undefined
+    ? session.permissionMode
+    : typeof session.opencodePermissionMode === "string"
+      ? session.opencodePermissionMode
+      : "edit";
   return legacy === "plan" ? "plan" : "agent";
 }
 
@@ -147,7 +148,10 @@ export function resolveCursorSdkPolicy(session: CursorSessionModeInput): CursorS
   const explicit = typeof session.cursorModeId === "string" ? session.cursorModeId.trim().toLowerCase() : "";
   const legacyFullAuto =
     !explicit.length
-    && (session.opencodePermissionMode === "full-auto" || session.permissionMode === "full-auto");
+    && (
+      session.permissionMode === "full-auto"
+      || (session.permissionMode === undefined && session.opencodePermissionMode === "full-auto")
+    );
   if (legacyFullAuto || explicit === "full-auto") {
     return {
       chatMode: "agent",

--- a/apps/desktop/src/main/services/cto/ctoStateService.ts
+++ b/apps/desktop/src/main/services/cto/ctoStateService.ts
@@ -12,6 +12,7 @@ import type {
 import { ADE_CLI_INLINE_GUIDANCE } from "../../../shared/adeCliGuidance";
 import { getCtoPersonalityPreset } from "../../../shared/ctoPersonalityPresets";
 import { getDefaultModelDescriptor, listModelDescriptorsForProvider, type ModelProviderGroup } from "../../../shared/modelRegistry";
+import { AGENT_CHAT_PERMISSION_MODE_VALUES } from "../../../shared/types/chat";
 import type { AdeDb } from "../state/kvDb";
 import { nowIso, parseIsoToEpoch, safeJsonParse, uniqueStrings, writeTextAtomic } from "../shared/utils";
 import { createLogIntegrityService } from "../projects/logIntegrityService";
@@ -136,6 +137,7 @@ const CTO_MEMORY_SYSTEM_GUIDANCE = [
 ].join("\n");
 
 function buildCtoEnvironmentKnowledge(): string {
+  const permissionModes = AGENT_CHAT_PERMISSION_MODE_VALUES.map((mode) => `'${mode}'`).join(" | ");
   return [
   "# ADE Architecture & Concepts",
   "",
@@ -149,7 +151,8 @@ function buildCtoEnvironmentKnowledge(): string {
   "  Tools: listLanes, inspectLane, createLane, deleteLane, renameLane, archiveLane.",
   "",
   "Native ADE Chat: A persistent AI chat session in the ADE UI with streaming responses, tool approval flow, file diff display, and full service integration. This is the primary way work gets done in ADE.",
-  "  - Created with spawnChat({ laneId?, modelId?, reasoningEffort?, title?, initialPrompt? }).",
+  "  - Created with spawnChat({ laneId?, modelId?, reasoningEffort?, title?, initialPrompt?, permissionMode? }).",
+  `  - permissionMode is ${permissionModes}. Pass it only when the user asks for a specific access level; omitting it keeps the provider default. Droid also accepts droidPermissionMode: 'read-only' | 'auto-low' | 'auto-medium' | 'auto-high' | 'agi' (read-only orchestrator mode).`,
   "  - Supports any registered model (Claude, GPT, local models).",
   "  - Has a message composer with slash commands, file attachments, model selector.",
   "  - Chat sessions belong to a lane and can be listed, steered, interrupted, or ended.",

--- a/apps/desktop/src/main/services/sync/syncRemoteCommandService.test.ts
+++ b/apps/desktop/src/main/services/sync/syncRemoteCommandService.test.ts
@@ -2231,6 +2231,19 @@ describe("createSyncRemoteCommandService", () => {
       }));
     });
 
+    it("work.startCliSession forwards explicit Droid native autonomy", async () => {
+      await service.execute(makePayload("work.startCliSession", {
+        laneId: "lane-1",
+        provider: "droid",
+        permissionMode: "default",
+        droidPermissionMode: "agi",
+      }));
+
+      const call = ptyService.create.mock.calls.at(-1)?.[0];
+      expect(call?.startupCommand).toContain('\\\"interactionMode\\\":\\\"agi\\\"');
+      expect(call?.startupCommand).toContain('\\\"autonomyLevel\\\":\\\"off\\\"');
+    });
+
     it("work.startCliSession uses desktop-sized defaults when dimensions are omitted", async () => {
       await service.execute(makePayload("work.startCliSession", {
         laneId: "lane-1",

--- a/apps/desktop/src/main/utils/terminalSessionSignals.test.ts
+++ b/apps/desktop/src/main/utils/terminalSessionSignals.test.ts
@@ -147,6 +147,7 @@ describe("terminalSessionSignals", () => {
       "droid",
     )).toEqual({
       permissionMode: "edit",
+      droidPermissionMode: "auto-low",
       model: "gpt-5.4",
       reasoningEffort: "xhigh",
     });
@@ -155,8 +156,16 @@ describe("terminalSessionSignals", () => {
       "droid",
     )).toEqual({
       permissionMode: "plan",
+      droidPermissionMode: "read-only",
       model: "claude-sonnet-5",
       reasoningEffort: "high",
+    });
+    expect(parseTrackedCliLaunchConfig(
+      "ADE_DROID_SETTINGS=\"$(mktemp \"${TMPDIR:-/tmp}/ade-droid-settings.XXXXXX.json\")\" && printf %s \"{\\\"sessionDefaultSettings\\\":{\\\"interactionMode\\\":\\\"agi\\\",\\\"autonomyLevel\\\":\\\"off\\\"}}\" > \"$ADE_DROID_SETTINGS\" && droid --settings \"$ADE_DROID_SETTINGS\"",
+      "droid",
+    )).toEqual({
+      permissionMode: "plan",
+      droidPermissionMode: "agi",
     });
     expect(parseTrackedCliLaunchConfig("OPENCODE_CONFIG_CONTENT='{\"permission\":{\"*\":\"ask\",\"edit\":\"allow\"}}' opencode", "opencode")).toEqual({
       permissionMode: "edit",

--- a/apps/desktop/src/main/utils/terminalSessionSignals.ts
+++ b/apps/desktop/src/main/utils/terminalSessionSignals.ts
@@ -2,6 +2,7 @@ import type {
   AgentChatClaudePermissionMode,
   AgentChatCodexApprovalPolicy,
   AgentChatCodexSandbox,
+  AgentChatDroidPermissionMode,
   AgentChatPermissionMode,
   TerminalResumeLaunchConfig,
   TerminalResumeMetadata,
@@ -114,16 +115,26 @@ function extractDroidSettings(command: string): Record<string, unknown> | null {
   }
 }
 
-function droidPermissionModeFromSettings(settings: Record<string, unknown> | null): AgentChatPermissionMode | null {
+function droidNativePermissionModeFromSettings(settings: Record<string, unknown> | null): AgentChatDroidPermissionMode | null {
   const defaults = settings?.sessionDefaultSettings;
   if (!defaults || typeof defaults !== "object" || Array.isArray(defaults)) return null;
   const defaultRecord = defaults as Record<string, unknown>;
   const interactionMode = String(defaultRecord.interactionMode ?? "").toLowerCase();
   const autonomyLevel = String(defaultRecord.autonomyLevel ?? "").toLowerCase();
-  if (interactionMode === "spec" || autonomyLevel === "off") return "plan";
-  if (autonomyLevel === "high") return "full-auto";
-  if (autonomyLevel === "medium") return "default";
-  if (autonomyLevel === "low") return "edit";
+  if (interactionMode === "agi") return "agi";
+  if (interactionMode === "spec" || autonomyLevel === "off") return "read-only";
+  if (autonomyLevel === "high") return "auto-high";
+  if (autonomyLevel === "medium") return "auto-medium";
+  if (autonomyLevel === "low") return "auto-low";
+  return null;
+}
+
+function droidPermissionModeFromSettings(settings: Record<string, unknown> | null): AgentChatPermissionMode | null {
+  const nativeMode = droidNativePermissionModeFromSettings(settings);
+  if (nativeMode === "read-only" || nativeMode === "agi") return "plan";
+  if (nativeMode === "auto-high") return "full-auto";
+  if (nativeMode === "auto-medium") return "default";
+  if (nativeMode === "auto-low") return "edit";
   return null;
 }
 
@@ -262,6 +273,9 @@ export function parseTrackedCliLaunchConfig(
   if (!normalized.length) return null;
 
   const droidSettings = provider === "droid" ? extractDroidSettings(normalized) : null;
+  const droidPermissionMode = provider === "droid"
+    ? droidNativePermissionModeFromSettings(droidSettings)
+    : null;
   const permissionMode = droidPermissionModeFromSettings(droidSettings)
     ?? extractTrackedCliPermissionMode(normalized, provider);
   const model = droidStringSetting(droidSettings, "model")
@@ -328,6 +342,7 @@ export function parseTrackedCliLaunchConfig(
 
   return {
     ...(permissionMode ? { permissionMode } : {}),
+    ...(droidPermissionMode ? { droidPermissionMode } : {}),
     ...(model ? { model } : {}),
     ...(reasoningEffort ? { reasoningEffort } : {}),
     ...(fastMode !== undefined ? { fastMode } : {}),

--- a/apps/desktop/src/renderer/components/chat/AgentChatComposer.styles.test.ts
+++ b/apps/desktop/src/renderer/components/chat/AgentChatComposer.styles.test.ts
@@ -1,0 +1,25 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import postcss from "postcss";
+import tailwindcss from "@tailwindcss/postcss";
+import { describe, expect, it } from "vitest";
+
+describe("queued steer action styles", () => {
+  it("compiles the visibility rules inside hover media queries", async () => {
+    const sourcePath = path.resolve(process.cwd(), "src/renderer/index.css");
+    const source = await fs.readFile(sourcePath, "utf8");
+    const { css } = await postcss([tailwindcss({ base: process.cwd() })]).process(source, {
+      from: sourcePath,
+    });
+
+    expect(css).toContain(".\\[\\@media\\(hover\\:hover\\)\\]\\:opacity-0");
+    expect(css).toContain(".\\[\\@media\\(hover\\:hover\\)\\]\\:group-hover\\:opacity-100");
+    const hiddenRuleStart = css.indexOf(".\\[\\@media\\(hover\\:hover\\)\\]\\:opacity-0");
+    const revealRuleStart = css.indexOf(".\\[\\@media\\(hover\\:hover\\)\\]\\:group-hover\\:opacity-100");
+    expect(hiddenRuleStart).toBeGreaterThanOrEqual(0);
+    expect(revealRuleStart).toBeGreaterThanOrEqual(0);
+    expect(css.slice(hiddenRuleStart, hiddenRuleStart + 260)).toContain("@media (hover:hover)");
+    expect(css.slice(hiddenRuleStart, hiddenRuleStart + 260)).toContain("opacity: 0%");
+    expect(css.slice(revealRuleStart, revealRuleStart + 320)).toContain("@media (hover:hover)");
+  });
+});

--- a/apps/desktop/src/renderer/components/chat/AgentChatComposer.test.tsx
+++ b/apps/desktop/src/renderer/components/chat/AgentChatComposer.test.tsx
@@ -514,6 +514,62 @@ describe("AgentChatComposer", () => {
     expect(onCancelSteer).toHaveBeenCalledWith("steer-1");
   });
 
+  it("uses a touch-safe class contract for queued-message controls", () => {
+    renderComposer({
+      pendingSteers: [{
+        steerId: "steer-1",
+        text: "Queued one",
+        attachments: [],
+        contextAttachments: [],
+      }],
+      onCancelSteer: vi.fn(),
+    });
+
+    const actions = screen.getByTestId("pending-steer-actions");
+    // A touch pointer never hovers, so an unconditional `opacity-0` left every
+    // control invisible on mobile and ADE Web. Both the hidden state and the
+    // reveal have to sit inside the hover media query.
+    expect(actions.className).not.toMatch(/(^|\s)opacity-0(\s|$)/);
+    expect(actions.className).toContain("[@media(hover:hover)]:opacity-0");
+    expect(actions.className).toContain("[@media(hover:hover)]:group-hover:opacity-100");
+  });
+
+  it("says why a queue-only agent cannot take the staged message mid-turn", () => {
+    renderComposer({
+      sessionProvider: "codex",
+      pendingSteers: [{
+        steerId: "steer-1",
+        text: "Queued one",
+        attachments: [],
+        contextAttachments: [],
+      }],
+      onCancelSteer: vi.fn(),
+    });
+
+    // Codex is queue-only: there is no force-send and no interrupt-and-send, so
+    // the strip has to name the limit rather than just omit the buttons.
+    expect(screen.getByText(/Codex cannot take a message mid-turn/)).toBeTruthy();
+    expect(screen.queryByRole("button", { name: "Send during turn" })).toBeNull();
+    expect(screen.queryByRole("button", { name: /^Interrupt/ })).toBeNull();
+    // "Hover to …" is simply wrong on a touch pointer.
+    expect(screen.queryByText(/Hover to/)).toBeNull();
+  });
+
+  it("does not claim Claude is queue-only when its dispatch handlers are merely unwired", () => {
+    renderComposer({
+      ...CLAUDE_STEER_OVERRIDES,
+      pendingSteers: [{
+        steerId: "steer-1",
+        text: "Queued one",
+        attachments: [],
+        contextAttachments: [],
+      }],
+      onCancelSteer: vi.fn(),
+    });
+
+    expect(screen.queryByText(/cannot take a message mid-turn/)).toBeNull();
+  });
+
   const CLAUDE_STEER_OVERRIDES = {
     sessionProvider: "claude" as const,
     modelId: "anthropic/claude-sonnet-5",

--- a/apps/desktop/src/renderer/components/chat/AgentChatComposer.tsx
+++ b/apps/desktop/src/renderer/components/chat/AgentChatComposer.tsx
@@ -1170,7 +1170,15 @@ function PendingSteerItem({
           {steer.text}
         </div>
       </div>
-      <div className="flex shrink-0 items-center gap-0.5 opacity-0 transition-opacity group-hover:opacity-100 group-focus-within:opacity-100">
+      {/* Hidden until hover ONLY where hovering exists. A touch pointer never
+          hovers, so gating on `opacity-0` alone left every queued-message
+          control invisible on mobile and ADE Web. Both rules sit inside the
+          same media query and `group-hover` outranks the base class on
+          specificity, so the reveal never depends on stylesheet order. */}
+      <div
+        data-testid="pending-steer-actions"
+        className="flex shrink-0 items-center gap-0.5 transition-opacity [@media(hover:hover)]:opacity-0 [@media(hover:hover)]:group-hover:opacity-100 [@media(hover:hover)]:group-focus-within:opacity-100"
+      >
           {onSendNow ? (
             <SmartTooltip forceEnabled content={{ label: "Send during turn", description: `${capability.agentLabel} picks this up after the current tool step, before continuing.` }}>
               <button
@@ -1261,6 +1269,33 @@ export function activeTurnSendModesForProvider(provider: string | undefined): Ac
     agentLabel: providerDisplayLabel(provider, "the agent"),
     interruptContinues: activeTurnInterruptContinues(provider),
   };
+}
+
+/**
+ * What the staged-message strip offers, plus — when the provider has no
+ * active-turn delivery at all — why waiting is the only option. The unsupported
+ * half reads `capability.modes` (the shared per-provider table) rather than the
+ * wired handlers, so a Codex chat says Codex cannot take a message mid-turn
+ * while a Claude chat whose handler is merely unwired makes no such claim.
+ *
+ * Never mentions hovering: the controls are always visible on a touch pointer,
+ * where an instruction to hover is simply wrong.
+ */
+function stagedSteerHint(args: {
+  capability: ActiveTurnSendCapability;
+  canSendNow: boolean;
+  canInterrupt: boolean;
+}): string {
+  const actions = [
+    ...(args.canSendNow ? ["send during the turn"] : []),
+    ...(args.canInterrupt ? ["interrupt with this message"] : []),
+    "edit",
+    "remove",
+  ];
+  const list = `${actions.slice(0, -1).join(", ")} or ${actions[actions.length - 1]}`;
+  const sentence = `${list.charAt(0).toUpperCase()}${list.slice(1)}.`;
+  if (args.capability.modes.some((mode) => mode !== "queue")) return sentence;
+  return `${sentence} ${args.capability.agentLabel} cannot take a message mid-turn, so this one waits for the turn to end.`;
 }
 
 function activeTurnSendCopy(
@@ -6208,11 +6243,11 @@ export function AgentChatComposer({
               Staged {pendingSteers.length === 1 ? "message" : `messages (${pendingSteers.length})`}
             </span>
             <span className="font-sans text-[length:calc(var(--chat-font-size)*9/14)] text-fg/30">
-              {onDispatchSteerInline
-                ? "Hover to send during the turn, interrupt, edit, or remove."
-                : onDispatchSteerInterrupt
-                  ? "Hover to interrupt with this message, edit, or remove."
-                  : "Hover to edit or remove."}
+              {stagedSteerHint({
+                capability: activeTurnSendCapability,
+                canSendNow: Boolean(onDispatchSteerInline),
+                canInterrupt: Boolean(onDispatchSteerInterrupt),
+              })}
             </span>
           </div>
           {pendingSteers.map((steer) => (

--- a/apps/desktop/src/renderer/components/chat/AgentChatComposer.tsx
+++ b/apps/desktop/src/renderer/components/chat/AgentChatComposer.tsx
@@ -101,7 +101,7 @@ import { GITHUB_BRAND } from "../lanes/githubBrand";
 import { LinearMark, LINEAR_BRAND } from "../lanes/linearBrand";
 import { AskQuestionComposer } from "./AskQuestionComposer";
 import { isAskQuestionRequest } from "../../../shared/pendingInputAnswers";
-import { CURSOR_MODE_LABELS } from "../../../shared/cursorModes";
+import { formatCursorModeLabel } from "../../../shared/cursorModes";
 import { ChatProposedPlanCard } from "./ChatProposedPlanCard";
 import { ChatModelSelectionPendingCard } from "./ChatModelSelectionPendingCard";
 import { ChatCommandMenu, type ChatCommandMenuItem, type ChatCommandMenuHandle } from "./ChatCommandMenu";
@@ -141,6 +141,9 @@ import {
   stageAttachmentBytesFromFile,
   type StagedAttachment,
 } from "./chatAttachmentStaging";
+import {
+  DROID_PERMISSION_OPTIONS as BASE_DROID_PERMISSION_OPTIONS,
+} from "../../lib/nativeLaunchControls";
 
 // Attachment ceilings are not a renderer constant any more: they depend on the
 // leg the bytes take, which depends on the machine that owns the chat. See
@@ -1113,24 +1116,15 @@ const OPENCODE_PERMISSION_OPTIONS: Array<PermissionModePickerOption<AgentChatOpe
   { value: "config-toml", label: "Config", detail: "Use OpenCode config files.", tone: "slate", icon: "config" },
 ];
 
-const DROID_PERMISSION_OPTIONS: Array<PermissionModePickerOption<AgentChatDroidPermissionMode>> = [
-  { value: "read-only", label: "Read-only", detail: "No auto flag. Droid stays in read-only mode for analysis and planning.", tone: "green", icon: "manual" },
-  { value: "auto-low", label: "Auto low", detail: "Passes --auto low for safe file edits and low-risk operations.", tone: "green", icon: "edit" },
-  { value: "auto-medium", label: "Auto medium", detail: "Passes --auto medium for local development operations such as builds, tests, and package installs.", tone: "amber", icon: "auto" },
-  { value: "auto-high", label: "Auto high", detail: "Passes --auto high for broad automation. Use only in trusted workspaces.", tone: "red", icon: "full" },
-  { value: "agi", label: "AGI (orchestrator)", triggerLabel: "AGI", detail: "Droid decomposes the task into a mission and spawns worker subagents (read-only at the top level). Workers appear in the subagents panel.", tone: "purple", icon: "agi" },
-];
-
-function cursorModeLabel(modeId: string): string {
-  const normalized = modeId.trim().toLowerCase();
-  if (!normalized.length) return "Agent";
-  if (CURSOR_MODE_LABELS[normalized]) return CURSOR_MODE_LABELS[normalized];
-  return normalized
-    .split(/[-_/]+/)
-    .filter(Boolean)
-    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
-    .join(" ");
-}
+const DROID_PERMISSION_OPTION_PRESENTATION: Record<AgentChatDroidPermissionMode, Pick<PermissionModePickerOption<AgentChatDroidPermissionMode>, "triggerLabel" | "tone" | "icon">> = {
+  "read-only": { tone: "green", icon: "manual" },
+  "auto-low": { tone: "green", icon: "edit" },
+  "auto-medium": { tone: "amber", icon: "auto" },
+  "auto-high": { tone: "red", icon: "full" },
+  agi: { triggerLabel: "AGI", tone: "purple", icon: "agi" },
+};
+const DROID_PERMISSION_OPTIONS: Array<PermissionModePickerOption<AgentChatDroidPermissionMode>> =
+  BASE_DROID_PERMISSION_OPTIONS.map((option) => ({ ...option, ...DROID_PERMISSION_OPTION_PRESENTATION[option.value] }));
 
 function resolveCursorModeOption(snapshot: AgentChatCursorModeSnapshot | null | undefined): AgentChatCursorConfigOption | null {
   if (!snapshot?.configOptions?.length) return null;
@@ -4216,7 +4210,7 @@ export function AgentChatComposer({
         ? cursorModeOption.options.map((option) => ({ value: option.value, label: option.label }))
         : (cmsUse?.availableModeIds ?? []).map((modeId) => ({
             value: modeId,
-            label: cursorModeLabel(modeId),
+            label: formatCursorModeLabel(modeId),
           }));
       const cursorModeOptions = modeChoices.map((option) => cursorPermissionPickerOption(option.value, option.label));
       return (

--- a/apps/desktop/src/renderer/components/chat/AgentChatPane.test.tsx
+++ b/apps/desktop/src/renderer/components/chat/AgentChatPane.test.tsx
@@ -3750,6 +3750,8 @@ describe("AgentChatPane submit recovery", () => {
 
     expect(await screen.findByText(/Couldn't remove the queued message/)).toBeTruthy();
     expect(await screen.findByText(/queue is locked/)).toBeTruthy();
+    expect(screen.getByText("Cancel me.")).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Remove queued message" })).toBeTruthy();
   });
 
   it("selects Interrupt & send, then sends it atomically", async () => {

--- a/apps/desktop/src/renderer/components/chat/AgentChatPane.test.tsx
+++ b/apps/desktop/src/renderer/components/chat/AgentChatPane.test.tsx
@@ -3717,6 +3717,41 @@ describe("AgentChatPane submit recovery", () => {
     });
   });
 
+  it("reports a failed queued-message removal instead of dropping the rejection", async () => {
+    const session = buildSession("session-1", {
+      provider: "codex",
+      model: "gpt-5.4",
+    });
+    const { cancelSteer, emitChatEvent } = installAdeMocks({
+      sessions: [session],
+      transcript: buildStatusStartedTranscript(session.sessionId),
+    });
+    // A cancel that fails leaves the message queued and the agent still sends
+    // it, so a swallowed rejection reads as a cancellation that never happened.
+    cancelSteer.mockRejectedValueOnce(new Error("Codex would not drop the queued message: queue is locked"));
+
+    renderTabbedPane(session);
+    await screen.findByPlaceholderText("Steer the active turn...");
+
+    act(() => {
+      emitChatEvent({
+        sessionId: session.sessionId,
+        timestamp: "2026-03-24T05:57:46.000Z",
+        event: {
+          type: "user_message",
+          steerId: "steer-doomed",
+          deliveryState: "queued",
+          text: "Cancel me.",
+        },
+      });
+    });
+
+    fireEvent.click(await screen.findByRole("button", { name: "Remove queued message" }));
+
+    expect(await screen.findByText(/Couldn't remove the queued message/)).toBeTruthy();
+    expect(await screen.findByText(/queue is locked/)).toBeTruthy();
+  });
+
   it("selects Interrupt & send, then sends it atomically", async () => {
     const session = buildSession("session-1", {
       provider: "claude",

--- a/apps/desktop/src/renderer/components/chat/AgentChatPane.tsx
+++ b/apps/desktop/src/renderer/components/chat/AgentChatPane.tsx
@@ -13391,7 +13391,14 @@ export function AgentChatPane({
             pendingSteers={pendingSteers}
             onCancelSteer={(steerId) => {
               if (selectedSessionId) {
-                void window.ade.agentChat.cancelSteer({ sessionId: selectedSessionId, steerId }, chatRuntimePinRef.current);
+                // A cancel that fails leaves the message queued and the agent
+                // will still send it. Report it the way the edit and dispatch
+                // paths do rather than dropping the rejection on the floor.
+                void window.ade.agentChat
+                  .cancelSteer({ sessionId: selectedSessionId, steerId }, chatRuntimePinRef.current)
+                  .catch((error: unknown) => {
+                    setError(`Couldn't remove the queued message: ${error instanceof Error ? error.message : String(error)}`);
+                  });
               }
             }}
             onEditSteer={(steerId, text, queuedAttachments, queuedContextAttachments) => {

--- a/apps/desktop/src/renderer/components/chat/AgentChatPane.tsx
+++ b/apps/desktop/src/renderer/components/chat/AgentChatPane.tsx
@@ -2397,7 +2397,10 @@ function nativeControlsFromLaunchSource(
   defaults: NativeControlState,
 ): NativeControlState {
   const codexFallbacks = codexControlsFromPermissionMode(source.permissionMode, defaults);
-  const cursorSnapshotValues = cursorConfigValuesFromSnapshot(source.cursorModeSnapshot);
+  const cursorModeWasExplicitlyCleared = source.cursorModeId === null;
+  const cursorSnapshotValues = cursorModeWasExplicitlyCleared
+    ? {}
+    : cursorConfigValuesFromSnapshot(source.cursorModeSnapshot);
   return {
     interactionMode: pickStringEnum(
       source.interactionMode,
@@ -2436,7 +2439,7 @@ function nativeControlsFromLaunchSource(
       DROID_PERMISSION_MODES,
       legacyPermissionModeToDroidPermissionMode(source.permissionMode) ?? defaults.droidPermissionMode,
     ),
-    cursorModeId: typeof source.cursorModeId === "string"
+    cursorModeId: source.cursorModeId !== undefined
       ? source.cursorModeId
       : source.cursorModeSnapshot?.currentModeId ?? defaults.cursorModeId,
     cursorConfigValues: {
@@ -5359,13 +5362,20 @@ export function AgentChatPane({
   }, []);
   const effectiveCursorModeSnapshot = useMemo(() => {
     if (sessionProvider !== "cursor") return null;
-    const base = selectedSession?.cursorModeSnapshot ?? buildFallbackCursorModeSnapshot(cursorModeId);
+    const cursorModeWasExplicitlyCleared = selectedSession?.cursorModeId === null
+      || selectedSession?.cursorModeIdWasCleared === true;
+    const base = cursorModeWasExplicitlyCleared
+      ? buildFallbackCursorModeSnapshot(null)
+      : selectedSession?.cursorModeSnapshot ?? buildFallbackCursorModeSnapshot(cursorModeId);
+    const effectiveModeId = cursorModeWasExplicitlyCleared
+      ? base.currentModeId
+      : cursorModeId ?? base.currentModeId;
     return {
       ...base,
-      currentModeId: cursorModeId ?? base.currentModeId,
+      currentModeId: effectiveModeId,
       configOptions: base.configOptions?.map((option) => {
         if (option.id === base.modeConfigId) {
-          return { ...option, currentValue: cursorModeId ?? option.currentValue };
+          return { ...option, currentValue: effectiveModeId ?? option.currentValue };
         }
         if (Object.prototype.hasOwnProperty.call(cursorConfigValues, option.id)) {
           return { ...option, currentValue: cursorConfigValues[option.id] ?? option.currentValue };
@@ -5373,7 +5383,14 @@ export function AgentChatPane({
         return option;
       }),
     };
-  }, [cursorConfigValues, cursorModeId, selectedSession?.cursorModeSnapshot, sessionProvider]);
+  }, [
+    cursorConfigValues,
+    cursorModeId,
+    selectedSession?.cursorModeId,
+    selectedSession?.cursorModeIdWasCleared,
+    selectedSession?.cursorModeSnapshot,
+    sessionProvider,
+  ]);
 
   const patchParallelSlot = useCallback((index: number, patch: Partial<ParallelModelRowState>) => {
     setParallelModelSlots((prev) => {
@@ -5546,13 +5563,19 @@ export function AgentChatPane({
         ?? legacyPermissionModeToDroidPermissionMode(session.permissionMode)
         ?? initialNativeControls.droidPermissionMode,
     );
-    setCursorModeId(session.cursorModeId ?? session.cursorModeSnapshot?.currentModeId ?? initialNativeControls.cursorModeId);
+    const cursorModeWasExplicitlyCleared = session.cursorModeId === null
+      || session.cursorModeIdWasCleared === true;
+    setCursorModeId(cursorModeWasExplicitlyCleared
+      ? null
+      : session.cursorModeId ?? session.cursorModeSnapshot?.currentModeId ?? initialNativeControls.cursorModeId);
     setCursorConfigValues(
-      Object.fromEntries(
-        (session.cursorModeSnapshot?.configOptions ?? [])
-          .filter((option) => option.id !== session.cursorModeSnapshot?.modeConfigId)
-          .flatMap((option) => option.currentValue == null ? [] : [[option.id, option.currentValue]]),
-      ),
+      cursorModeWasExplicitlyCleared
+        ? normalizeCursorConfigValues(session.cursorConfigValues)
+        : Object.fromEntries(
+            (session.cursorModeSnapshot?.configOptions ?? [])
+              .filter((option) => option.id !== session.cursorModeSnapshot?.modeConfigId)
+              .flatMap((option) => option.currentValue == null ? [] : [[option.id, option.currentValue]]),
+          ),
     );
   }, [
     applyLaunchConfigToComposer,
@@ -7753,7 +7776,10 @@ export function AgentChatPane({
         if (meta.codexConfigSource !== undefined) summaryPatch.codexConfigSource = meta.codexConfigSource;
         if (meta.opencodePermissionMode !== undefined) summaryPatch.opencodePermissionMode = meta.opencodePermissionMode;
         if (meta.droidPermissionMode !== undefined) summaryPatch.droidPermissionMode = meta.droidPermissionMode;
-        if (meta.cursorModeId !== undefined) summaryPatch.cursorModeId = meta.cursorModeId;
+        if (meta.cursorModeId !== undefined) {
+          summaryPatch.cursorModeId = meta.cursorModeId;
+          summaryPatch.cursorModeIdWasCleared = meta.cursorModeId === null;
+        }
         if (meta.cursorModeSnapshot !== undefined) summaryPatch.cursorModeSnapshot = meta.cursorModeSnapshot;
         if (meta.cursorConfigValues !== undefined) summaryPatch.cursorConfigValues = meta.cursorConfigValues;
         if (meta.spawnKind !== undefined) summaryPatch.spawnKind = meta.spawnKind;

--- a/apps/desktop/src/renderer/components/terminals/cliLaunch.test.ts
+++ b/apps/desktop/src/renderer/components/terminals/cliLaunch.test.ts
@@ -1253,6 +1253,18 @@ describe("buildTrackedCliStartupCommand", () => {
       expect(launch.initialInput).toBeUndefined();
     });
 
+    it("uses an explicit Droid native autonomy tier instead of the generic permission fallback", () => {
+      const launch = buildTrackedCliLaunchCommand({
+        provider: "droid",
+        permissionMode: "default",
+        droidPermissionMode: "agi",
+      });
+
+      expect(launch.startupCommand).toContain('\\\"interactionMode\\\":\\\"agi\\\"');
+      expect(launch.startupCommand).toContain('\\\"autonomyLevel\\\":\\\"off\\\"');
+      expect(launch.startupCommand).not.toContain('\\\"autonomyLevel\\\":\\\"medium\\\"');
+    });
+
     it("launches Droid through PowerShell on Windows with the prompt off the command line", () => {
       withProcessPlatform("win32", () => {
         const launch = buildTrackedCliLaunchCommand({

--- a/apps/desktop/src/renderer/lib/nativeLaunchControls.test.ts
+++ b/apps/desktop/src/renderer/lib/nativeLaunchControls.test.ts
@@ -54,6 +54,15 @@ describe("nativeLaunchControls", () => {
     expect(cliPermissionModeFromNativeControls("cursor/composer-2.5", controls)).toBe("plan");
   });
 
+  it("keeps legacy edit on writable Cursor Agent instead of read-only Ask", () => {
+    const controls = applyUnifiedPermissionToNativeControls(
+      "cursor/composer-2.5",
+      "edit",
+      defaultNativeControls(),
+    );
+    expect(controls.cursorModeId).toBe("agent");
+  });
+
   it("reads unified permission from default native controls", () => {
     const defaults = defaultNativeControls();
     expect(readUnifiedPermissionFromNativeControls("openai/gpt-5.5", defaults)).toBe("default");

--- a/apps/desktop/src/renderer/lib/nativeLaunchControls.ts
+++ b/apps/desktop/src/renderer/lib/nativeLaunchControls.ts
@@ -1,16 +1,20 @@
 import type {
   AgentChatClaudePermissionMode,
-  AgentChatCodexApprovalPolicy,
-  AgentChatCodexConfigSource,
-  AgentChatCodexSandbox,
-  AgentChatDroidPermissionMode,
-  AgentChatInteractionMode,
   AgentChatOpenCodePermissionMode,
   AgentChatPermissionMode,
   AgentChatProvider,
   ChatSurfaceProfile,
 } from "../../shared/types";
-import { CURSOR_AVAILABLE_MODE_IDS } from "../../shared/cursorModes";
+import {
+  AGENT_CHAT_DROID_PERMISSION_MODE_OPTIONS,
+  droidPermissionModeFromLegacyPermissionMode,
+  legacyPermissionModeFromDroidPermissionMode,
+} from "../../shared/types/chat";
+import {
+  CURSOR_AVAILABLE_MODE_IDS,
+  formatCursorModeLabel,
+  legacyPermissionModeToCursorModeId,
+} from "../../shared/cursorModes";
 import {
   getModelById,
   resolveProviderGroupForModel,
@@ -66,14 +70,6 @@ function resolveDescriptor(modelId: string): ModelDescriptor | undefined {
 export function resolveChatRuntimeProvider(modelId: string): ChatRuntimeProviderKey {
   const desc = resolveDescriptor(modelId);
   return desc ? resolveProviderGroupForModel(desc) : "opencode";
-}
-
-function droidPermissionModeToLegacyPermissionMode(mode: AgentChatDroidPermissionMode): AgentChatPermissionMode {
-  if (mode === "read-only") return "plan";
-  if (mode === "agi") return "plan";
-  if (mode === "auto-low") return "edit";
-  if (mode === "auto-medium") return "default";
-  return "full-auto";
 }
 
 export function summarizeNativeControls(
@@ -148,7 +144,7 @@ export function summarizeNativeControls(
   if (provider === "droid") {
     return {
       droidPermissionMode: controls.droidPermissionMode,
-      permissionMode: droidPermissionModeToLegacyPermissionMode(controls.droidPermissionMode),
+      permissionMode: legacyPermissionModeFromDroidPermissionMode(controls.droidPermissionMode),
     };
   }
   // Pi's native permission field IS `permissionMode` — it has no provider
@@ -242,26 +238,12 @@ export function applyUnifiedPermissionToNativeControls(
   }
 
   if (provider === "cursor") {
-    const cursorModeId =
-      mode === "plan"
-        ? "plan"
-        : mode === "full-auto"
-          ? "full-auto"
-          : mode === "edit"
-            ? "ask"
-            : "agent";
+    const cursorModeId = legacyPermissionModeToCursorModeId(mode) ?? "agent";
     return { ...next, cursorModeId };
   }
 
   if (provider === "droid") {
-    const droidPermissionMode: AgentChatDroidPermissionMode =
-      mode === "plan"
-        ? "read-only"
-        : mode === "edit"
-          ? "auto-low"
-          : mode === "default"
-            ? "auto-medium"
-            : "auto-high";
+    const droidPermissionMode = droidPermissionModeFromLegacyPermissionMode(mode) ?? "auto-high";
     return { ...next, droidPermissionMode };
   }
 
@@ -294,13 +276,7 @@ export function cursorModeChoices(): string[] {
 }
 
 export function cursorModeLabel(modeId: string): string {
-  switch (modeId) {
-    case "agent": return "Agent";
-    case "ask": return "Ask";
-    case "plan": return "Plan";
-    case "full-auto": return "Full auto";
-    default: return modeId;
-  }
+  return formatCursorModeLabel(modeId);
 }
 
 export function codexPresetFromControls(controls: NativeControlState): "default" | "edit" | "plan" | "full-auto" | "config-toml" | "custom" {
@@ -365,12 +341,7 @@ export const OPENCODE_PERMISSION_OPTIONS: Array<{ value: AgentChatOpenCodePermis
   { value: "config-toml", label: "Config" },
 ];
 
-export const DROID_PERMISSION_OPTIONS: Array<{ value: AgentChatDroidPermissionMode; label: string; detail: string }> = [
-  { value: "read-only", label: "Read-only", detail: "No auto flag. Droid stays in read-only mode." },
-  { value: "auto-low", label: "Auto low", detail: "Passes --auto low for safe file edits." },
-  { value: "auto-medium", label: "Auto medium", detail: "Passes --auto medium for local development operations." },
-  { value: "auto-high", label: "Auto high", detail: "Passes --auto high for broader automation." },
-];
+export const DROID_PERMISSION_OPTIONS = AGENT_CHAT_DROID_PERMISSION_MODE_OPTIONS;
 
 export function claudeSelectionMode(controls: NativeControlState): AgentChatClaudePermissionMode {
   return controls.interactionMode === "plan" ? "plan" : controls.claudePermissionMode;

--- a/apps/desktop/src/renderer/webclient/adapter/agentChat.ts
+++ b/apps/desktop/src/renderer/webclient/adapter/agentChat.ts
@@ -305,7 +305,7 @@ export function createAgentChatNamespace(infra: AdapterInfra): AdeNamespace<"age
       await callRequiredMutation("chat.cancelSteer", args);
     },
     editSteer: async (args: unknown) => {
-      await call("chat.editSteer", args, undefined, false);
+      await callRequiredMutation("chat.editSteer", args);
     },
     dispatchSteer: async (args, pin) => {
       guardPin("dispatchSteer", pin);

--- a/apps/desktop/src/renderer/webclient/adapter/agentChat.ts
+++ b/apps/desktop/src/renderer/webclient/adapter/agentChat.ts
@@ -299,7 +299,10 @@ export function createAgentChatNamespace(infra: AdapterInfra): AdeNamespace<"age
     },
     cancelSteer: async (args: unknown, pin?: RuntimePinArg) => {
       guardPin("cancelSteer", pin);
-      await call("chat.cancelSteer", args, undefined, false);
+      // An unreachable host must not resolve: the message stays queued and the
+      // agent still sends it, so a silent `undefined` reads as a cancellation
+      // that never happened. Every other mutation here already throws.
+      await callRequiredMutation("chat.cancelSteer", args);
     },
     editSteer: async (args: unknown) => {
       await call("chat.editSteer", args, undefined, false);

--- a/apps/desktop/src/shared/cliLaunch.ts
+++ b/apps/desktop/src/shared/cliLaunch.ts
@@ -10,6 +10,7 @@ import type {
   TerminalToolType,
   WindowsShellKind,
 } from "./types";
+import { AGENT_CHAT_PERMISSION_MODE_VALUES } from "./types/chat";
 import {
   ADE_AGENT_SKILLS_DIRS_ENV,
   getAdeAgentSkillRootsForPrompt,
@@ -162,7 +163,7 @@ export const LAUNCH_PROFILES = [
   "copilot",
   "shell",
 ] as const satisfies readonly LaunchProfile[];
-export const TRACKED_CLI_PERMISSION_MODES = ["default", "auto", "plan", "edit", "full-auto", "config-toml"] as const satisfies readonly AgentChatPermissionMode[];
+export const TRACKED_CLI_PERMISSION_MODES = AGENT_CHAT_PERMISSION_MODE_VALUES;
 
 export function sanitizeTrackedCliResumeTargetId(value: string | null | undefined): string | null {
   const target = String(value ?? "").trim();

--- a/apps/desktop/src/shared/cliLaunch.ts
+++ b/apps/desktop/src/shared/cliLaunch.ts
@@ -2,6 +2,7 @@ import type {
   AgentChatCodexApprovalPolicy,
   AgentChatCodexConfigSource,
   AgentChatCodexSandbox,
+  AgentChatDroidPermissionMode,
   AgentChatPermissionMode,
   PtySendToSessionArgs,
   TerminalResumeLaunchConfig,
@@ -10,7 +11,10 @@ import type {
   TerminalToolType,
   WindowsShellKind,
 } from "./types";
-import { AGENT_CHAT_PERMISSION_MODE_VALUES } from "./types/chat";
+import {
+  AGENT_CHAT_PERMISSION_MODE_VALUES,
+  droidPermissionModeFromLegacyPermissionMode,
+} from "./types/chat";
 import {
   ADE_AGENT_SKILLS_DIRS_ENV,
   getAdeAgentSkillRootsForPrompt,
@@ -679,6 +683,7 @@ function withAdeAgentSkillEnv(
 export function buildTrackedCliStartupCommand(args: {
   provider: CliProvider;
   permissionMode: AgentChatPermissionMode;
+  droidPermissionMode?: AgentChatDroidPermissionMode | null;
   orchestrationRole?: OrchestrationRole | null;
   /** Pre-assigned session ID for Claude CLI (enables reliable resume). */
   sessionId?: string;
@@ -701,6 +706,7 @@ export function buildTrackedCliStartupCommand(args: {
 export function buildTrackedCliLaunchCommand(args: {
   provider: CliProvider;
   permissionMode: AgentChatPermissionMode;
+  droidPermissionMode?: AgentChatDroidPermissionMode | null;
   orchestrationRole?: OrchestrationRole | null;
   /** Pre-assigned session ID for Claude CLI (enables reliable resume). */
   sessionId?: string;
@@ -839,6 +845,7 @@ export function buildTrackedCliLaunchCommand(args: {
       // Cursor already do. POSIX keeps the prompt in argv where it round-trips.
       const startupCommand = droidPowerShellCommand({
         permissionMode,
+        droidPermissionMode: args.droidPermissionMode,
         model: args.model,
         reasoningEffort: args.reasoningEffort,
       });
@@ -853,6 +860,7 @@ export function buildTrackedCliLaunchCommand(args: {
     }
     const startupCommand = buildDroidCommandLine({
       permissionMode,
+      droidPermissionMode: args.droidPermissionMode,
       model: args.model,
       reasoningEffort: args.reasoningEffort,
       prompt,
@@ -1392,15 +1400,27 @@ function permissionModeToCursorFlags(permissionMode: AgentChatPermissionMode | n
 
 function droidSettingsJson(args: {
   permissionMode: AgentChatPermissionMode | null | undefined;
+  droidPermissionMode?: AgentChatDroidPermissionMode | null;
   model?: string | null;
   reasoningEffort?: string | null;
 }): string {
+  const droidPermissionMode = args.droidPermissionMode
+    ?? droidPermissionModeFromLegacyPermissionMode(args.permissionMode);
   const sessionDefaultSettings = (() => {
-    if (args.permissionMode == null) return null;
-    if (args.permissionMode === "full-auto") return { interactionMode: "auto", autonomyLevel: "high" };
-    if (args.permissionMode === "default") return { interactionMode: "auto", autonomyLevel: "medium" };
-    if (args.permissionMode === "edit") return { interactionMode: "auto", autonomyLevel: "low" };
-    return { interactionMode: "spec", autonomyLevel: "off" };
+    switch (droidPermissionMode) {
+      case "agi":
+        return { interactionMode: "agi", autonomyLevel: "off" };
+      case "read-only":
+        return { interactionMode: "spec", autonomyLevel: "off" };
+      case "auto-low":
+        return { interactionMode: "auto", autonomyLevel: "low" };
+      case "auto-medium":
+        return { interactionMode: "auto", autonomyLevel: "medium" };
+      case "auto-high":
+        return { interactionMode: "auto", autonomyLevel: "high" };
+      default:
+        return null;
+    }
   })();
   const model = normalizeDroidCliModel(args.model);
   const reasoningEffort = normalizeCliFlagValue(args.reasoningEffort);
@@ -1409,7 +1429,7 @@ function droidSettingsJson(args: {
   };
   if (model) settings.model = model;
   if (reasoningEffort) settings.reasoningEffort = reasoningEffort;
-  if (args.permissionMode === "plan") {
+  if (droidPermissionMode === "read-only") {
     const specDefaults = sessionDefaultSettings as Record<string, unknown>;
     if (model) specDefaults.specModeModel = model;
     if (reasoningEffort) specDefaults.specModeReasoningEffort = reasoningEffort;
@@ -1423,6 +1443,7 @@ function quotePowerShellArg(value: string): string {
 
 function droidPowerShellCommand(args: {
   permissionMode: AgentChatPermissionMode | null | undefined;
+  droidPermissionMode?: AgentChatDroidPermissionMode | null;
   model?: string | null;
   reasoningEffort?: string | null;
   prompt?: string;
@@ -1451,6 +1472,7 @@ function droidPowerShellCommand(args: {
 
 function buildDroidCommandLine(args: {
   permissionMode: AgentChatPermissionMode | null | undefined;
+  droidPermissionMode?: AgentChatDroidPermissionMode | null;
   model?: string | null;
   reasoningEffort?: string | null;
   prompt?: string;
@@ -1731,6 +1753,10 @@ export function buildTrackedCliResumeLaunchCommand(
   const fastMode = overrides.fastMode !== undefined
     ? overrides.fastMode
     : metadata.launch.fastMode ?? metadata.launch.codexFastMode;
+  const droidPermissionMode = overrides.permissionMode !== undefined
+    ? droidPermissionModeFromLegacyPermissionMode(permissionMode)
+    : metadata.launch.droidPermissionMode
+      ?? droidPermissionModeFromLegacyPermissionMode(permissionMode);
   const prompt = normalizeCliFlagValue(overrides.prompt);
   validateLaunchProfilePermissionMode(metadata.provider, permissionMode);
 
@@ -1799,7 +1825,7 @@ export function buildTrackedCliResumeLaunchCommand(
   }
 
   if (metadata.provider === "droid") {
-    if (permissionMode == null && !normalizeCliFlagValue(model) && !normalizeCliFlagValue(reasoningEffort)) {
+    if (permissionMode == null && droidPermissionMode == null && !normalizeCliFlagValue(model) && !normalizeCliFlagValue(reasoningEffort)) {
       const parts = ["droid"];
       if (targetId) parts.push("--resume", targetId);
       else parts.push("--resume");
@@ -1812,6 +1838,7 @@ export function buildTrackedCliResumeLaunchCommand(
     }
     const droidArgs = {
       permissionMode,
+      droidPermissionMode,
       model,
       reasoningEffort,
       ...(prompt ? { prompt } : {}),

--- a/apps/desktop/src/shared/cursorModes.test.ts
+++ b/apps/desktop/src/shared/cursorModes.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+import {
+  CURSOR_AVAILABLE_MODE_IDS,
+  CURSOR_DEFAULT_MODE_ID,
+  effectiveCursorModeId,
+  legacyPermissionModeToCursorModeId,
+} from "./cursorModes";
+
+describe("Cursor mode compatibility mapping", () => {
+  it("maps native legacy modes and preserves absence for plain-agent modes", () => {
+    expect(legacyPermissionModeToCursorModeId("full-auto")).toBe("full-auto");
+    expect(legacyPermissionModeToCursorModeId("plan")).toBe("plan");
+    // Materialising "agent" would pin the next launch to a real selection.
+    expect(legacyPermissionModeToCursorModeId("default")).toBeNull();
+    expect(legacyPermissionModeToCursorModeId("edit")).toBeNull();
+    expect(legacyPermissionModeToCursorModeId("ask")).toBeNull();
+    expect(CURSOR_AVAILABLE_MODE_IDS).toContain(CURSOR_DEFAULT_MODE_ID);
+  });
+
+  it("prefers an explicit native mode over the legacy permission field", () => {
+    expect(effectiveCursorModeId("agent", "full-auto")).toBe("agent");
+    expect(effectiveCursorModeId("ask", "plan")).toBe("ask");
+    expect(effectiveCursorModeId("  agent  ", "full-auto")).toBe("agent");
+    expect(effectiveCursorModeId("", "plan")).toBe("plan");
+  });
+
+  it("resolves legacy modes and the default when no explicit mode exists", () => {
+    expect(effectiveCursorModeId(null, "full-auto")).toBe("full-auto");
+    expect(effectiveCursorModeId(undefined, "plan")).toBe("plan");
+    expect(effectiveCursorModeId(null, "edit")).toBe(CURSOR_DEFAULT_MODE_ID);
+    expect(effectiveCursorModeId(null, null)).toBe(CURSOR_DEFAULT_MODE_ID);
+    expect(effectiveCursorModeId(null)).toBe(CURSOR_DEFAULT_MODE_ID);
+  });
+});

--- a/apps/desktop/src/shared/cursorModes.test.ts
+++ b/apps/desktop/src/shared/cursorModes.test.ts
@@ -3,6 +3,7 @@ import {
   CURSOR_AVAILABLE_MODE_IDS,
   CURSOR_DEFAULT_MODE_ID,
   effectiveCursorModeId,
+  formatCursorModeLabel,
   legacyPermissionModeToCursorModeId,
 } from "./cursorModes";
 
@@ -30,5 +31,12 @@ describe("Cursor mode compatibility mapping", () => {
     expect(effectiveCursorModeId(null, "edit")).toBe(CURSOR_DEFAULT_MODE_ID);
     expect(effectiveCursorModeId(null, null)).toBe(CURSOR_DEFAULT_MODE_ID);
     expect(effectiveCursorModeId(null)).toBe(CURSOR_DEFAULT_MODE_ID);
+  });
+
+  it("formats aliases and provider-defined mode ids consistently", () => {
+    expect(formatCursorModeLabel("default")).toBe("Agent");
+    expect(formatCursorModeLabel("FULL-AUTO")).toBe("Full auto");
+    expect(formatCursorModeLabel("debug_tools")).toBe("Debug Tools");
+    expect(formatCursorModeLabel("  ")).toBe("Agent");
   });
 });

--- a/apps/desktop/src/shared/cursorModes.ts
+++ b/apps/desktop/src/shared/cursorModes.ts
@@ -1,11 +1,11 @@
 /**
- * Canonical Cursor mode IDs and labels.
+ * ADE-facing Cursor chat selections and labels.
  *
  * Both AgentChatPane (fallback snapshot) and AgentChatComposer (mode labels)
  * must reference the same set. Import from here instead of hardcoding.
  */
 
-/** The set of Cursor mode IDs exposed to the user in the mode picker. */
+/** The set of Cursor selections exposed to the user in the mode picker. */
 export const CURSOR_AVAILABLE_MODE_IDS = ["agent", "ask", "plan", "full-auto"] as const;
 
 export type CursorModeId = (typeof CURSOR_AVAILABLE_MODE_IDS)[number];
@@ -23,13 +23,24 @@ export const CURSOR_MODE_LABELS: Record<string, string> = {
 /** The Cursor mode a session runs in when it names none. */
 export const CURSOR_DEFAULT_MODE_ID = "agent" satisfies CursorModeId;
 
+/** Format provider-returned Cursor mode ids consistently across every surface. */
+export function formatCursorModeLabel(modeId: string): string {
+  const normalized = modeId.trim().toLowerCase();
+  if (!normalized.length) return CURSOR_MODE_LABELS.agent;
+  if (CURSOR_MODE_LABELS[normalized]) return CURSOR_MODE_LABELS[normalized];
+  return normalized
+    .split(/[-_/]+/)
+    .filter(Boolean)
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(" ");
+}
+
 /**
- * The native Cursor mode a legacy `permissionMode` asks for, or `null` when it
+ * The ADE-facing Cursor selection a legacy `permissionMode` asks for, or `null` when it
  * asks for nothing Cursor names.
  *
- * Only the two modes Cursor itself has are mapped. `full-auto` and `plan` are
- * real Cursor modes and `resolveCursorSdkPolicy` already runs the session under
- * them, so the session must say so; leaving `cursorModeId` empty is what made a
+ * `full-auto` and `plan` are ADE selections; the provider SDK still receives
+ * its supported execution mode separately. Leaving `cursorModeId` empty made a
  * `--permissions full-auto` child report `agent` in its mode snapshot.
  *
  * `default` and `edit` both run as Cursor `agent`, and `ask` is a deliberate

--- a/apps/desktop/src/shared/cursorModes.ts
+++ b/apps/desktop/src/shared/cursorModes.ts
@@ -19,3 +19,43 @@ export const CURSOR_MODE_LABELS: Record<string, string> = {
   "full-auto": "Full auto",
   debug: "Debug",
 };
+
+/** The Cursor mode a session runs in when it names none. */
+export const CURSOR_DEFAULT_MODE_ID = "agent" satisfies CursorModeId;
+
+/**
+ * The native Cursor mode a legacy `permissionMode` asks for, or `null` when it
+ * asks for nothing Cursor names.
+ *
+ * Only the two modes Cursor itself has are mapped. `full-auto` and `plan` are
+ * real Cursor modes and `resolveCursorSdkPolicy` already runs the session under
+ * them, so the session must say so; leaving `cursorModeId` empty is what made a
+ * `--permissions full-auto` child report `agent` in its mode snapshot.
+ *
+ * `default` and `edit` both run as Cursor `agent`, and `ask` is a deliberate
+ * user choice with no legacy spelling. Returning `null` for them keeps absence
+ * absent: a materialised `agent` here is read back as a real selection on the
+ * next launch and pins the session to it. That is the durable-pin bug the
+ * Droid and Claude native controls carry the same warning about.
+ */
+export function legacyPermissionModeToCursorModeId(
+  mode: string | null | undefined,
+): CursorModeId | null {
+  if (mode === "full-auto") return "full-auto";
+  if (mode === "plan") return "plan";
+  return null;
+}
+
+/**
+ * The Cursor mode a session presents, resolving the empty case to the default.
+ * Use for display and preview; use `legacyPermissionModeToCursorModeId` when
+ * deciding what to persist.
+ */
+export function effectiveCursorModeId(
+  cursorModeId: string | null | undefined,
+  permissionMode?: string | null,
+): string {
+  const explicit = typeof cursorModeId === "string" ? cursorModeId.trim() : "";
+  if (explicit.length) return explicit;
+  return legacyPermissionModeToCursorModeId(permissionMode) ?? CURSOR_DEFAULT_MODE_ID;
+}

--- a/apps/desktop/src/shared/types/chat.test.ts
+++ b/apps/desktop/src/shared/types/chat.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "vitest";
 import {
+  droidPermissionModeFromLegacyPermissionMode,
+  isAgentChatDroidPermissionMode,
+  legacyPermissionModeFromDroidPermissionMode,
   activeTurnDispatchModes,
   activeTurnInterruptContinues,
   defaultActiveTurnDispatchMode,
@@ -13,6 +16,18 @@ import {
   type AgentChatFileRef,
   type AgentChatModelsArgs,
 } from "./chat";
+
+describe("Droid permission vocabulary", () => {
+  it("validates native tiers and converts the shared legacy ladder", () => {
+    expect(isAgentChatDroidPermissionMode("auto-high")).toBe(true);
+    expect(isAgentChatDroidPermissionMode("AUTO-HIGH")).toBe(false);
+    expect(isAgentChatDroidPermissionMode("unknown")).toBe(false);
+    expect(droidPermissionModeFromLegacyPermissionMode("default")).toBe("auto-medium");
+    expect(droidPermissionModeFromLegacyPermissionMode("full-auto")).toBe("auto-high");
+    expect(legacyPermissionModeFromDroidPermissionMode("auto-medium")).toBe("default");
+    expect(legacyPermissionModeFromDroidPermissionMode("agi")).toBeUndefined();
+  });
+});
 
 describe("active-turn dispatch modes", () => {
   it("is the one table every surface reads: Claude all three, Cursor no inline, others queue-only", () => {

--- a/apps/desktop/src/shared/types/chat.ts
+++ b/apps/desktop/src/shared/types/chat.ts
@@ -216,6 +216,28 @@ export const AGENT_CHAT_DROID_PERMISSION_MODE_VALUES = [
   "agi",
 ] as const satisfies readonly AgentChatDroidPermissionMode[];
 
+/** Shared copy for every Droid permission picker (chat, handoff, and CLI launch). */
+export const AGENT_CHAT_DROID_PERMISSION_MODE_DETAILS: Record<
+  AgentChatDroidPermissionMode,
+  { label: string; detail: string }
+> = {
+  "read-only": { label: "Read-only", detail: "No auto flag. Droid stays in read-only mode for analysis and planning." },
+  "auto-low": { label: "Auto low", detail: "Passes --auto low for safe file edits and low-risk operations." },
+  "auto-medium": { label: "Auto medium", detail: "Passes --auto medium for local development operations such as builds, tests, and package installs." },
+  "auto-high": { label: "Auto high", detail: "Passes --auto high for broad automation. Use only in trusted workspaces." },
+  agi: { label: "AGI (orchestrator)", detail: "Droid decomposes the task into a mission and spawns worker subagents." },
+};
+
+export const AGENT_CHAT_DROID_PERMISSION_MODE_OPTIONS = AGENT_CHAT_DROID_PERMISSION_MODE_VALUES.map((value) => ({
+  value,
+  ...AGENT_CHAT_DROID_PERMISSION_MODE_DETAILS[value],
+}));
+
+export function isAgentChatDroidPermissionMode(value: unknown): value is AgentChatDroidPermissionMode {
+  return typeof value === "string"
+    && (AGENT_CHAT_DROID_PERMISSION_MODE_VALUES as readonly string[]).includes(value);
+}
+
 export type AgentChatResumeFailureKind = "thread_missing" | "provider_environment" | "transient" | "unknown";
 export type AgentChatSpawnKind = "subagent" | "peer";
 
@@ -1626,6 +1648,42 @@ export const AGENT_CHAT_PERMISSION_MODE_VALUES = [
   "full-auto",
   "config-toml",
 ] as const satisfies readonly AgentChatPermissionMode[];
+
+/** Convert ADE's generic permission ladder to Droid's native autonomy tier. */
+export function droidPermissionModeFromLegacyPermissionMode(
+  mode: AgentChatPermissionMode | null | undefined,
+): AgentChatDroidPermissionMode | undefined {
+  switch (mode) {
+    case "plan":
+      return "read-only";
+    case "edit":
+      return "auto-low";
+    case "default":
+      return "auto-medium";
+    case "full-auto":
+      return "auto-high";
+    default:
+      return undefined;
+  }
+}
+
+/** Convert a Droid tier back to ADE's generic label when a legacy field is needed. */
+export function legacyPermissionModeFromDroidPermissionMode(
+  mode: AgentChatDroidPermissionMode | null | undefined,
+): AgentChatPermissionMode | undefined {
+  switch (mode) {
+    case "read-only":
+      return "plan";
+    case "auto-low":
+      return "edit";
+    case "auto-medium":
+      return "default";
+    case "auto-high":
+      return "full-auto";
+    default:
+      return undefined;
+  }
+}
 export type AgentChatExecutionMode = "focused" | "parallel" | "subagents" | "teams";
 export type AgentChatInteractionMode =
   | "default"
@@ -1904,6 +1962,8 @@ export type AgentChatSessionSummary = {
   droidPermissionMode?: AgentChatDroidPermissionMode;
   cursorModeSnapshot?: AgentChatCursorModeSnapshot;
   cursorModeId?: string | null;
+  /** True when the host explicitly cleared Cursor's mode with `null`. */
+  cursorModeIdWasCleared?: boolean;
   cursorConfigValues?: Record<string, AgentChatCursorConfigValue> | null;
   /** Caller-injected MCP servers, echoed back so an embedder can confirm them. */
   mcpServers?: Record<string, AgentChatMcpServerConfig>;

--- a/apps/desktop/src/shared/types/chat.ts
+++ b/apps/desktop/src/shared/types/chat.ts
@@ -207,6 +207,14 @@ export type AgentChatCodexSandbox = "read-only" | "workspace-write" | "danger-fu
 export type AgentChatCodexConfigSource = "flags" | "config-toml";
 export type AgentChatOpenCodePermissionMode = "plan" | "edit" | "full-auto" | "config-toml";
 export type AgentChatDroidPermissionMode = "read-only" | "auto-low" | "auto-medium" | "auto-high" | "agi";
+/** Public Droid-native permission values accepted by chat creation surfaces. */
+export const AGENT_CHAT_DROID_PERMISSION_MODE_VALUES = [
+  "read-only",
+  "auto-low",
+  "auto-medium",
+  "auto-high",
+  "agi",
+] as const satisfies readonly AgentChatDroidPermissionMode[];
 
 export type AgentChatResumeFailureKind = "thread_missing" | "provider_environment" | "transient" | "unknown";
 export type AgentChatSpawnKind = "subagent" | "peer";
@@ -1609,6 +1617,15 @@ export type AgentChatEventHistoryPage = {
 };
 
 export type AgentChatPermissionMode = "default" | "auto" | "plan" | "edit" | "full-auto" | "config-toml";
+/** Runtime vocabulary shared by chat creation, CLI launches, and CTO tools. */
+export const AGENT_CHAT_PERMISSION_MODE_VALUES = [
+  "default",
+  "auto",
+  "plan",
+  "edit",
+  "full-auto",
+  "config-toml",
+] as const satisfies readonly AgentChatPermissionMode[];
 export type AgentChatExecutionMode = "focused" | "parallel" | "subagents" | "teams";
 export type AgentChatInteractionMode =
   | "default"

--- a/apps/desktop/src/shared/types/sessions.ts
+++ b/apps/desktop/src/shared/types/sessions.ts
@@ -9,6 +9,7 @@ import type {
   AgentChatCodexConfigSource,
   AgentChatCodexSandbox,
   AgentChatCliLaunchProvider,
+  AgentChatDroidPermissionMode,
   AgentChatModelHandoff,
   AgentChatSpawnKind,
 } from "./chat";
@@ -184,6 +185,7 @@ export type TerminalResumeTargetKind = "session" | "thread";
 
 export type TerminalResumeLaunchConfig = {
   permissionMode?: AgentChatPermissionMode | null;
+  droidPermissionMode?: AgentChatDroidPermissionMode | null;
   model?: string | null;
   reasoningEffort?: string | null;
   fastMode?: boolean | null;
@@ -414,6 +416,7 @@ export type PtyCreateArgs = {
   runtimeCliLaunch?: {
     provider: AgentChatCliLaunchProvider;
     permissionMode: AgentChatPermissionMode;
+    droidPermissionMode?: AgentChatDroidPermissionMode | null;
     orchestrationRole?: OrchestrationRole | null;
     sessionId?: string;
     model?: string | null;

--- a/apps/desktop/src/shared/types/sync.ts
+++ b/apps/desktop/src/shared/types/sync.ts
@@ -2,6 +2,7 @@ import type {
   AgentChatCodexApprovalPolicy,
   AgentChatCodexConfigSource,
   AgentChatCodexSandbox,
+  AgentChatDroidPermissionMode,
   AgentChatEventEnvelope,
   AgentChatEventHistoryPage,
   AgentChatPermissionMode,
@@ -1708,6 +1709,7 @@ export type SyncStartCliSessionArgs = {
   laneId: string;
   provider: SyncCliLaunchProvider;
   permissionMode?: AgentChatPermissionMode | null;
+  droidPermissionMode?: AgentChatDroidPermissionMode | null;
   title?: string | null;
   initialInput?: string | null;
   cols?: number;

--- a/apps/ios/ADE/Models/RemoteModels.swift
+++ b/apps/ios/ADE/Models/RemoteModels.swift
@@ -859,6 +859,10 @@ struct AgentChatSessionSummary: Codable, Identifiable, Equatable {
   var droidPermissionMode: String?
   var cursorModeSnapshot: RemoteJSONValue?
   var cursorModeId: String?
+  /// True when the host explicitly sent `cursorModeId: null`. Optional keeps
+  /// summaries from older hosts decodable while preserving the null-vs-absent
+  /// distinction for the current host.
+  var cursorModeIdWasCleared: Bool? = nil
   var cursorConfigValues: [String: RemoteJSONValue]?
   /// Cursor Cloud agent id when this chat is a live cloud mirror. Older hosts omit it.
   var cursorCloudAgentId: String? = nil
@@ -926,6 +930,7 @@ struct AgentChatSessionSummary: Codable, Identifiable, Equatable {
       && lhs.opencodePermissionMode == rhs.opencodePermissionMode
       && lhs.droidPermissionMode == rhs.droidPermissionMode
       && lhs.cursorModeId == rhs.cursorModeId
+      && lhs.cursorModeIdWasCleared == rhs.cursorModeIdWasCleared
       && lhs.cursorModeSnapshot == rhs.cursorModeSnapshot
       && lhs.cursorConfigValues == rhs.cursorConfigValues
       && lhs.cursorCloudAgentId == rhs.cursorCloudAgentId
@@ -1098,10 +1103,12 @@ extension AgentChatSessionSummary {
     if let v = update.droidPermissionMode { droidPermissionMode = v }
     if let v = update.cursorModeId {
       cursorModeId = v
+      cursorModeIdWasCleared = false
     } else if update.cursorModeIdWasCleared {
       // Explicit `cursorModeId: null` from the host — drop the mode rather than
       // leaving the stale one in place.
       cursorModeId = nil
+      cursorModeIdWasCleared = true
     }
     if let v = update.cursorModeSnapshot { cursorModeSnapshot = v }
     if let v = update.cursorConfigValues {
@@ -1126,15 +1133,11 @@ extension AgentChatSessionSummary {
   /// never null-clears them, and a partial refresh summary that omits one must
   /// not blank the live value.
   ///
-  /// Cursor fields (`cursorModeId` / `cursorConfigValues`) copy WHOLESALE,
-  /// including a nil. The cache is authoritative for cursor state — every writer
-  /// (the `session_meta_updated` fold via `applyModeUpdate`, a full host summary
-  /// via `cacheChatSummary`, or a lane-list refresh) stores the host's true
-  /// value, and the host includes the field whenever a mode/config exists (a
-  /// clear arrives as an explicit `null`, an unset session simply has no mode).
-  /// So mirroring the cache's cursor fields — nil included — is exactly how an
-  /// explicit clear reaches the live composer, with no separate clear flag or
-  /// stateful marker to go stale.
+  /// Cursor mode copies when present; an explicit nil is applied only when
+  /// `cursorModeIdWasCleared` travels with it. The marker keeps Swift's
+  /// Optional decoder from conflating an explicit clear with an omitted field.
+  /// A later non-null mode resets the marker, so a restored host mode cannot be
+  /// re-cleared by stale state.
   mutating func mergeModeFields(from other: AgentChatSessionSummary) {
     if let v = other.permissionMode { permissionMode = v }
     if let v = other.interactionMode { interactionMode = v }
@@ -1144,7 +1147,13 @@ extension AgentChatSessionSummary {
     if let v = other.codexConfigSource { codexConfigSource = v }
     if let v = other.opencodePermissionMode { opencodePermissionMode = v }
     if let v = other.droidPermissionMode { droidPermissionMode = v }
-    cursorModeId = other.cursorModeId
+    if other.cursorModeIdWasCleared == true {
+      cursorModeId = nil
+      cursorModeIdWasCleared = true
+    } else if let v = other.cursorModeId {
+      cursorModeId = v
+      cursorModeIdWasCleared = false
+    }
     if let v = other.cursorModeSnapshot { cursorModeSnapshot = v }
     cursorConfigValues = other.cursorConfigValues
     if let v = other.spawnKind { spawnKind = v }

--- a/apps/ios/ADE/Models/RemoteModels.swift
+++ b/apps/ios/ADE/Models/RemoteModels.swift
@@ -3503,6 +3503,10 @@ struct AgentChatSteerRequest: Codable, Equatable {
 struct AgentChatCancelSteerRequest: Codable, Equatable {
   var sessionId: String
   var steerId: String
+  /// The staged-row cancel path must fail if the host already delivered the
+  /// steer; otherwise a mobile refresh/cancel race can leave the user thinking
+  /// the message was removed while it still runs.
+  var requireQueued: Bool? = nil
 }
 
 struct AgentChatEditSteerRequest: Codable, Equatable {

--- a/apps/ios/ADE/Services/SyncService.swift
+++ b/apps/ios/ADE/Services/SyncService.swift
@@ -13764,7 +13764,7 @@ final class SyncService: ObservableObject {
     let scope = chatCommandScope(for: sessionId)
     _ = try await sendChatCommand(
       action: chatActionName("chat.cancelSteer", sessionId: sessionId),
-      payload: AgentChatCancelSteerRequest(sessionId: sessionId, steerId: steerId, requireQueued: true),
+      payload: AgentChatCancelSteerRequest(sessionId: sessionId, steerId: steerId),
       targetProjectId: scope.projectId,
       targetProjectRootPath: scope.rootPath
     )

--- a/apps/ios/ADE/Services/SyncService.swift
+++ b/apps/ios/ADE/Services/SyncService.swift
@@ -13764,7 +13764,7 @@ final class SyncService: ObservableObject {
     let scope = chatCommandScope(for: sessionId)
     _ = try await sendChatCommand(
       action: chatActionName("chat.cancelSteer", sessionId: sessionId),
-      payload: AgentChatCancelSteerRequest(sessionId: sessionId, steerId: steerId),
+      payload: AgentChatCancelSteerRequest(sessionId: sessionId, steerId: steerId, requireQueued: true),
       targetProjectId: scope.projectId,
       targetProjectRootPath: scope.rootPath
     )

--- a/apps/ios/ADE/Views/Work/WorkStatusAndFormattingHelpers.swift
+++ b/apps/ios/ADE/Views/Work/WorkStatusAndFormattingHelpers.swift
@@ -1113,6 +1113,9 @@ func workInitialRuntimeMode(_ summary: AgentChatSessionSummary) -> String {
   case "opencode":
     return workNormalizedOpenCodeRuntimeMode(summary.opencodePermissionMode ?? summary.permissionMode)
   case "cursor":
+    if summary.cursorModeIdWasCleared == true {
+      return "default"
+    }
     switch summary.cursorModeId ?? workCursorCurrentModeId(summary.cursorModeSnapshot) {
     case "plan": return "plan"
     case "ask": return "edit"
@@ -1165,7 +1168,10 @@ func workDroidRuntimeMode(droidPermissionMode: String?, permissionMode: String?)
 }
 
 func workInitialCursorModeId(_ summary: AgentChatSessionSummary) -> String {
-  summary.cursorModeId ?? workCursorCurrentModeId(summary.cursorModeSnapshot) ?? "agent"
+  if summary.cursorModeIdWasCleared == true {
+    return "agent"
+  }
+  return summary.cursorModeId ?? workCursorCurrentModeId(summary.cursorModeSnapshot) ?? "agent"
 }
 
 func workCursorModeIds(_ snapshot: RemoteJSONValue?, fallback: String) -> [String] {

--- a/apps/ios/ADETests/ADETests.swift
+++ b/apps/ios/ADETests/ADETests.swift
@@ -6410,12 +6410,11 @@ final class ADETests: XCTestCase {
 
     let cancel = try jsonDictionary(from: AgentChatCancelSteerRequest(
       sessionId: "session-1",
-      steerId: "steer-1",
-      requireQueued: true
+      steerId: "steer-1"
     ))
     XCTAssertEqual(cancel["sessionId"] as? String, "session-1")
     XCTAssertEqual(cancel["steerId"] as? String, "steer-1")
-    XCTAssertEqual(cancel["requireQueued"] as? Bool, true)
+    XCTAssertNil(cancel["requireQueued"], "Ordinary cancel must also clear persisted messages without a live runtime.")
 
     let sessionId = try jsonDictionary(from: AgentChatSessionIdRequest(sessionId: "session-1"))
     XCTAssertEqual(sessionId["sessionId"] as? String, "session-1")
@@ -18008,6 +18007,34 @@ final class ADETests: XCTestCase {
     XCTAssertEqual(summary.requestedCwd, "apps/ios/ADE")
   }
 
+  func testAgentChatSessionSummaryPreservesExplicitCursorModeClear() throws {
+    let payload: [String: Any] = [
+      "sessionId": "chat-cleared",
+      "laneId": "lane-1",
+      "provider": "cursor",
+      "model": "composer-2",
+      "permissionMode": "default",
+      "cursorModeSnapshot": [
+        "currentModeId": "full-auto",
+        "availableModeIds": ["agent", "ask", "plan", "full-auto"],
+      ],
+      "cursorModeId": NSNull(),
+      "cursorModeIdWasCleared": true,
+      "status": "idle",
+      "startedAt": "2026-03-25T00:00:00.000Z",
+      "lastActivityAt": "2026-03-25T00:00:00.000Z",
+    ]
+
+    let summary = try JSONDecoder().decode(
+      AgentChatSessionSummary.self,
+      from: try JSONSerialization.data(withJSONObject: payload)
+    )
+
+    XCTAssertTrue(summary.cursorModeIdWasCleared == true)
+    XCTAssertEqual(workInitialRuntimeMode(summary), "default")
+    XCTAssertEqual(workInitialCursorModeId(summary), "agent")
+  }
+
   func testAgentChatMetaModeUpdateAppliesCursorConfigAndExplicitClear() throws {
     let summaryPayload: [String: Any] = [
       "sessionId": "chat-1",
@@ -18056,9 +18083,11 @@ final class ADETests: XCTestCase {
     XCTAssertTrue(clearUpdate.hasAnyField)
     summary.applyModeUpdate(clearUpdate)
     XCTAssertNil(summary.cursorModeId)
+    XCTAssertTrue(summary.cursorModeIdWasCleared == true)
 
     // A partial update that omits cursorModeId entirely must NOT clear it.
     summary.cursorModeId = "agent"
+    summary.cursorModeIdWasCleared = false
     let unrelatedUpdate = try JSONDecoder().decode(
       AgentChatSessionMetaModeUpdate.self,
       from: try JSONSerialization.data(withJSONObject: [
@@ -18094,11 +18123,11 @@ final class ADETests: XCTestCase {
 
     // The cache fold above is only half the story: the open chat view rebuilds
     // its LIVE summary from the cache via `mergeModeFields(from:)`. The cache is
-    // authoritative for cursor fields, so the merge mirrors them wholesale —
-    // nil included — which is exactly how an explicit clear reaches the live
-    // composer, with no stateful clear marker.
+    // authoritative for cursor fields, and the explicit clear marker travels
+    // with the nullable mode so Swift does not mistake null for omission.
     var cachedAfterClear = summary
     cachedAfterClear.cursorModeId = nil
+    cachedAfterClear.cursorModeIdWasCleared = true
     cachedAfterClear.cursorConfigValues = nil
     var liveSummary = summary
     liveSummary.cursorModeId = "agent"
@@ -18109,11 +18138,11 @@ final class ADETests: XCTestCase {
     XCTAssertNil(mergedCleared.cursorConfigValues, "explicit cache clear must null the live cursor config")
 
     // Regression guard (the "stale clear marker wins" bug): after a clear, a
-    // host that RESTORES a non-null mode/config must NOT be re-cleared. With no
-    // persistent clear state, each reconcile mirrors the current authoritative
-    // cache, so a restored value survives.
+    // host that RESTORES a non-null mode/config must reset the marker, so the
+    // restored value survives.
     var cachedRestored = summary
     cachedRestored.cursorModeId = "plan"
+    cachedRestored.cursorModeIdWasCleared = false
     cachedRestored.cursorConfigValues = ["voice": .bool(false)]
     var liveAfterClear = liveSummary
     liveAfterClear.cursorModeId = nil

--- a/apps/ios/ADETests/ADETests.swift
+++ b/apps/ios/ADETests/ADETests.swift
@@ -6408,6 +6408,15 @@ final class ADETests: XCTestCase {
     XCTAssertEqual(steer["sessionId"] as? String, "session-1")
     XCTAssertEqual(steer["text"] as? String, "Keep going")
 
+    let cancel = try jsonDictionary(from: AgentChatCancelSteerRequest(
+      sessionId: "session-1",
+      steerId: "steer-1",
+      requireQueued: true
+    ))
+    XCTAssertEqual(cancel["sessionId"] as? String, "session-1")
+    XCTAssertEqual(cancel["steerId"] as? String, "steer-1")
+    XCTAssertEqual(cancel["requireQueued"] as? Bool, true)
+
     let sessionId = try jsonDictionary(from: AgentChatSessionIdRequest(sessionId: "session-1"))
     XCTAssertEqual(sessionId["sessionId"] as? String, "session-1")
 

--- a/docs/features/chat/agent-routing.md
+++ b/docs/features/chat/agent-routing.md
@@ -12,6 +12,7 @@ where the machinery lives.
 | `apps/desktop/src/shared/modelProfiles.ts` | Curated selection helpers (task routing, default pickers). |
 | `apps/desktop/src/shared/chatModelSwitching.ts` | `canSwitchChatSessionModel` / `filterChatModelIdsForSession` -- rules for mid-session model changes. |
 | `apps/desktop/src/main/services/chat/agentChatService.ts` | `handoffSession`, permission translation, per-provider adapter. |
+| `apps/desktop/src/shared/cursorModes.ts` | Canonical Cursor mode vocabulary and compatibility mapping from the legacy ADE permission field; permission-only full-auto/plan launches persist the native mode that the UI and later clients read. |
 | `apps/desktop/src/main/utils/codexComputerUse.ts` | macOS-only signed Codex Computer Use MCP resolver. Requires explicit Codex config opt-in and verifies the standalone OpenAI client before it can be injected into a chat or CLI runtime. |
 | `apps/desktop/src/shared/cliLaunch.ts` | Tracked provider CLI start/resume builders, including model/reasoning/permission flags and the canonical `computer_use` MCP overrides for Codex. Reasoning/fast variants are per-provider: Claude/Codex/Droid/Pi keep their flags, but tracked OpenCode launches always run the root TUI (`opencode [-m model] [--agent plan] [--prompt …]`) — no `run --interactive` branch and no `--variant`, because the root command silently drops unknown args; variants remain a chat-runtime feature. |
 | `apps/desktop/src/main/services/ai/providerRuntimeHealth.ts` | Tracks provider readiness/auth/network failures so the UI can surface degraded states. |
@@ -764,13 +765,31 @@ OpenCode, Pi and Droid keeps its `stop_and_clear` contract.
 
 ### Abstract-to-native mapping
 
-`AgentChatPermissionMode` is `default | plan | edit | full-auto | config-toml`.
+`AgentChatPermissionMode` is `default | auto | plan | edit | full-auto | config-toml`.
 `providerOptions.ts` exposes `mapPermissionModeToNativeFields()`, which
 translates the abstract value into the correct provider-native fields:
 
 - `claude`: `claudePermissionMode = "default" | "auto" | "plan" | "acceptEdits" | "bypassPermissions"`. The `auto` mode hands permission decisions to the SDK's automatic gate and surfaces in the desktop and `ade code` permission pickers alongside the existing modes.
 - `codex`: `codexApprovalPolicy` + `codexSandbox` pair.
 - `opencode`: `opencodePermissionMode = "plan" | "edit" | "full-auto"`.
+- `cursor`: `opencodePermissionMode` carries the collapsed level, and
+  `cursorModeId` carries the native mode Cursor itself names.
+  `legacyPermissionModeToCursorModeId` (`shared/cursorModes.ts`) maps
+  `full-auto` -> `"full-auto"` and `plan` -> `"plan"`, and returns **null** for
+  everything else: `default` and `edit` both run as Cursor `agent`, and `ask` is
+  a deliberate user choice with no legacy spelling. Returning null keeps absence
+  absent for the same reason Droid does — a materialised `agent` is read back as
+  a real selection on the next launch and pins the chat to it. The derivation
+  fills only when the caller named no mode
+  (`applyCursorModeIdFromLegacyPermissionMode`, run from both
+  `normalizeSessionNativePermissionControls` and
+  `hydrateNativePermissionControls`), so an explicit `cursorModeId` always wins;
+  an explicit `permissionMode` **update** overwrites through
+  `applyLegacyPermissionModeToNativeControls`, so lowering the level clears a
+  derived `full-auto` instead of leaving it pinned. Without this a
+  `permissionMode`-only create — `ade new chat --provider cursor --permissions
+  full-auto`, `chat.createSession`, mobile/web `chat.create`, the `@ade-dev`
+  SDK — ran full-auto while every mode-reading surface reported `agent`.
 - `droid`: `droidPermissionMode = "read-only" | "auto-low" | "auto-medium" | "auto-high" | "agi"`, or **absent** when the user has picked nothing. Absent is meaningful: it lets `~/.factory/settings.json` resolve autonomy, so nothing materialises a fallback onto the session. See [Provider config ownership](#provider-config-ownership).
 - `pi`: no provider-specific permission field — the abstract `permissionMode`
   *is* Pi's native field. It is read directly by

--- a/docs/features/chat/composer-and-ui.md
+++ b/docs/features/chat/composer-and-ui.md
@@ -722,7 +722,12 @@ that could not work without it.
 - **Pending steers.** When steers are queued during an active turn, the
   composer renders a pending-steers section above the input area with
   per-message controls. Each `PendingSteerItem` displays a "Sends after
-  turn" badge plus the message text. Hover-revealed actions per
+  turn" badge plus the message text. The action strip
+  (`data-testid="pending-steer-actions"`) hides itself behind hover **only**
+  inside `@media (hover: hover)`; a touch pointer never hovers, so on mobile and
+  ADE Web the controls stay visible. Both the hidden state and the
+  `group-hover` reveal sit inside that one media query, and `group-hover` wins
+  on specificity, so the reveal never depends on stylesheet order. Actions per
   entry: edit (guard-cancel the queued entry with `requireQueued: true`, then
   merge its text, file attachments, and structured context attachments into the
   main composer so the user can revise it and choose a delivery mode again),
@@ -738,11 +743,19 @@ that could not work without it.
   Claude query. Cursor sessions get the interrupt action only, labelled
   **Interrupt & continue** — `dispatchSteer({ mode: "interrupt" })` there
   promotes the staged row to the cancel-and-resend redirect, and `"inline"` is
-  rejected. The tooltips and the hover hint above the staged list follow the
-  same table and name the real provider, so a Cursor session reads "Hover to
-  interrupt with this message, edit, or remove." rather than promising an inline
-  send. Both buttons are hidden for the remaining providers (Codex, OpenCode,
-  Droid, Pi), which only support post-turn delivery.
+  rejected. The tooltips and the hint above the staged list follow the same
+  table and name the real provider (`stagedSteerHint`), so a Cursor session
+  reads "Interrupt with this message, edit or remove." rather than promising an
+  inline send. Both buttons are hidden for the remaining providers (Codex,
+  OpenCode, Droid, Pi), which only support post-turn delivery — and for those
+  the hint says so outright ("Codex cannot take a message mid-turn, so this one
+  waits for the turn to end."). That sentence keys off `capability.modes`, not
+  the wired handlers, so a Claude chat whose dispatch handler is merely unwired
+  never claims Claude is queue-only.
+- **A cancel that fails is reported.** `onCancelSteer` catches the rejection and
+  raises "Couldn't remove the queued message: …" in the pane error banner. A
+  swallowed rejection read as a cancellation that never happened while the agent
+  still sent the message.
 - **Mid-turn split Send button.** While a Claude or Cursor turn is active, the
   composer's primary send control is a split button
   (`ActiveTurnSendButton`, Claude Code parity). The caret selects a delivery

--- a/docs/features/chat/tool-system.md
+++ b/docs/features/chat/tool-system.md
@@ -59,7 +59,8 @@ not need to parse the raw structured object to show those values.
 
 ### Permission gate
 
-`PermissionMode` (`plan | edit | full-auto`) maps to tool categories
+`PermissionMode` (`default | auto | plan | edit | full-auto | config-toml`)
+maps to tool categories
 (`read`, `write`, `bash`). The gate rejects writes and bash in `plan`
 mode. `edit` requires `onApprovalRequest` to return `{ approved: true }`
 for bash (or for writes on hosted workers without the session-level
@@ -167,7 +168,7 @@ uses to act on ADE itself:
 
 | Tool family | Purpose |
 |---|---|
-| `spawnChat` | Spawn a new chat session with an explicit model, reasoning effort, and initial prompt. Lane resolution goes through `resolveExecutionLane`: an explicit `laneId` wins, and omitting it creates a **fresh** lane (`freshLaneName` / `freshLaneDescription`) rather than reusing the caller's. For the CTO that is load-bearing — its session is pinned to the project's primary lane, so a fallback would run spawned agents against the primary worktree. |
+| `spawnChat` | Spawn a new chat session with an explicit model, reasoning effort, initial prompt, and optional `permissionMode` (`default` \| `auto` \| `plan` \| `edit` \| `full-auto` \| `config-toml`, forwarded to `chat.createSession` only when supplied, so an omitted value keeps the provider default rather than pinning a substituted one). Droid's provider-native `droidPermissionMode` (`read-only` \| `auto-low` \| `auto-medium` \| `auto-high` \| `agi`) is forwarded independently when supplied; `agi` starts Droid's read-only orchestrator mode. Lane resolution goes through `resolveExecutionLane`: an explicit `laneId` wins, and omitting it creates a **fresh** lane (`freshLaneName` / `freshLaneDescription`) rather than reusing the caller's. For the CTO that is load-bearing — its session is pinned to the project's primary lane, so a fallback would run spawned agents against the primary worktree. |
 | `interruptChat`, `steerChat`, `cancelSteer`, `listSubagents`, `approveToolUse` | Mid-session control over other chat sessions: interrupt a turn, inject a steer instruction, cancel a pending steer by its `steerId`, enumerate spawned sub-agents, and answer a pending permission prompt. Each is a **required** dep on `CtoOperatorToolDeps` and maps onto the corresponding `agentChatService` method (`approveToolUse` translates the tool's `toolUseId` to the service's `itemId`), so none of them can be advertised without an implementation behind it. |
 | `createTerminal`, `runCommand` | Create untracked shells or run fire-and-forget commands. `createTerminal` passes explicit `cols: 100`, `rows: 30`, and a title, rather than relying on the pty service's default clamp. |
 | `listLanes`, `createLane`, `renameLane`, `archiveLane`, `inspectLane` | Lane management. |

--- a/docs/features/chat/transcript-and-turns.md
+++ b/docs/features/chat/transcript-and-turns.md
@@ -777,6 +777,34 @@ the queued steers the runtime actually cancelled, emits `queue_recovery`, and
 accepts one `restoreCancelledQueue` call for eight seconds; expiry and restore
 are persisted as terminal recovery events so replay cannot resurrect Undo.
 
+Codex stages a mid-turn message on the app-server's own queue
+(`thread/queue/add`) whenever the live turn rejects a steer — during compaction
+or a review turn — and ADE keeps the `steerId` -> `submissionId` mapping on the
+runtime object only. That mapping does not survive a runtime restart, a
+rehydration, or a cancel routed in from another machine, while the transcript
+still renders the staged chip, so `cancelSteer` re-reads the server queue first:
+every entry carries the ADE `steerId` ADE sent as `clientUserMessageId`, which
+makes the app-server the durable half of the mapping. Three rules follow:
+
+- A `thread/queue/delete` that **fails** raises. The submission is still queued
+  and will run, so clearing the chip would report a cancellation that did not
+  happen.
+- If ADE cannot read the app-server queue during recovery, it also raises and
+  leaves the chip in place. A failed lookup is not evidence that the submission
+  disappeared; the user can retry after the temporary failure clears.
+- A submission that is recoverable **nowhere** — no mapping, nothing on the
+  server — still clears the chip and emits the `Queued message cancelled.`
+  notice. Nothing can deliver that message, and the old silent return left a
+  control that did nothing every time it was pressed.
+- A cancel on a session with **no runtime** clears the chip and also drops the
+  steer from the persisted `pendingSteers`. `persistChatState` carries the
+  previous file's list forward verbatim whenever the live runtime is not Claude,
+  so without that the next runtime hydrated the steer straight back and sent the
+  message the user had just cancelled.
+
+`requireQueued: true` (the composer's Edit path) still refuses rather than
+clearing, because Edit must not lose a message it cannot first take back.
+
 A Codex turn ends through several paths — Stop, the local interrupt finish, the
 app-server's `turn/aborted`, runtime teardown, `thread/deleted`, an app-server
 crash — and every one of them runs `settleCodexPendingInputs` so the turn cannot


### PR DESCRIPTION
## Problem
Cursor Composer 2 child chats launched with ADE full-auto policy displayed the provider-native Agent mode, while queued/staged messages could become impossible to cancel or edit across desktop, web, and iOS. Provider-native Droid autonomy also did not survive every CLI/RPC/sync launch path.

## Cause
ADE treated its generic permission policy, provider-native mode, and provider SDK execution mode as one loosely synchronized value. Cursor requires SDK `agent` execution plus a separate ADE full-auto policy, and Codex queue cancellation could not always recover the live queue submission. Several clients also conflated an omitted nullable Cursor mode with an explicit clear.

## Change and boundary
- Preserve Cursor native mode and full-auto policy separately, including explicit clear propagation to iOS; keep the SDK request on its supported `agent` mode.
- Carry explicit Droid autonomy through shared launch metadata, CLI, RPC, sync, resume, and Windows launch builders.
- Recover Codex queued submissions by ADE steer id, surface cancellation/edit failures, and keep staged controls reachable on touch/no-hover clients.
- Forward CTO spawn permission fields and centralize shared provider vocabulary/validation.
- Keep provider-specific limitations explicit; no provider is given a mode its SDK/CLI does not support.

## Verification
- Desktop focused suites: 8 files, 818 tests passed, 1 skipped.
- Agent chat regression: 986 tests passed.
- CLI/RPC/sync suites: 3 files, 652 tests passed, 2 skipped; sync/TUI suite 183 tests passed.
- Desktop CI-style shard 1/8: 99 files, 2,012 tests passed.
- iOS simulator selected tests: 3 passed, 0 failures.
- Desktop and CLI typechecks/builds passed; desktop lint 0 errors (333 existing warnings); docs validation passed for 257 files.

GPT-5.6 Codex via ADE Work/Codex app-server.

<!-- ade:link v=1 type=pr repo=arul28/ADE branch=ade%2Fcursor-full-auto-mode num=1214 -->
<p>
  <img src="https://ade-app.dev/logo.png" height="18" align="left" alt="ADE">
  &nbsp;&nbsp;<strong>Open in ADE</strong>
  &nbsp;·&nbsp; <a href="https://ade-app.dev/open?type=branch&amp;repo=arul28%2FADE&amp;branch=ade%2Fcursor-full-auto-mode&amp;pr=1214">ade/cursor-full-auto-mode branch</a>
  &nbsp;·&nbsp; <a href="https://ade-app.dev/open?type=pr&amp;repo=arul28%2FADE&amp;number=1214">PR #1214</a>
</p>
<!-- /ade:link -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes span agent permission persistence, CLI/RPC launch contracts, and Codex queue cancellation—areas that affect autonomy levels and whether staged messages are truly dropped.
> 
> **Overview**
> This PR threads **explicit Droid autonomy** (`droidPermissionMode`, including `agi`) through CLI flags, `start_cli_session` RPC, sync `work.startCliSession`, tracked CLI launch/resume builders, and launch-config parsing—while centralizing permission enums and legacy↔native conversion in shared chat types.
> 
> **Cursor** sessions now keep ADE’s generic `permissionMode` separate from persisted `cursorModeId`: `full-auto`/`plan` map to native IDs, `default`/`edit` no longer materialize a pinned `agent`, explicit `null` clears propagate through summaries/TUI/composer, and SDK policy prefers canonical `permissionMode` over stale OpenCode fields.
> 
> **Queued messages** get harder server-side behavior: Codex cancels recover queue submission IDs via `thread/queue/list`, refuse false successes on delete failures, tombstone persisted steers when the runtime is gone, and the desktop/web composer shows touch-visible controls plus surfaced cancel errors.
> 
> CTO **`spawnChat`** optionally forwards `permissionMode` / `droidPermissionMode` without substituting defaults; CLI dry-run previews and Cursor `edit`→`agent` mapping align with what create paths actually persist.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1c10c5211648e62c89884ade5fe5d18c5736f0fd. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added Droid-specific autonomy controls, including read-only, automatic autonomy tiers, and AGI mode, across chat and CLI workflows.
  - Added validation, provider-aware handling, configuration previews, and native launch support for Droid autonomy settings.
  - Improved Cursor mode labeling and compatibility, including clearer handling of Agent, Ask, and explicitly cleared modes.

- **Bug Fixes**
  - Improved queued-message cancellation recovery after restarts and surfaced cancellation failures instead of reporting false success.
  - Improved touch-device visibility for queued-message actions and clarified provider-specific guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->