### PR TITLE
fix(sdk): parse npm 12 pack JSON when publishing the runtime

### DIFF
--- a/.github/workflows/publish-runtime-packages.yml
+++ b/.github/workflows/publish-runtime-packages.yml
@@ -168,11 +168,15 @@ jobs:
         if: steps.token.outputs.present == 'true'
         run: |
           set -euo pipefail
+          # Outside the checkout so the repo `.gitignore` (`node_modules`) cannot
+          # strip native/node_modules from `npm pack`.
+          OUT_DIR="${RUNNER_TEMP}/runtime-packages"
+          echo "RUNTIME_PACKAGES_DIR=$OUT_DIR" >> "$GITHUB_ENV"
           node apps/ade-cli/scripts/build-runtime-npm-packages.mjs \
             --artifacts-dir release-artifacts \
             --version "${{ steps.version.outputs.version }}" \
-            --out-dir runtime-packages
-          ls -la runtime-packages
+            --out-dir "$OUT_DIR"
+          ls -la "$OUT_DIR"
 
       # Between build and publish, never after. npm-packlist honors a
       # `.gitignore` or `.npmignore` shipped inside a packed subdirectory, so a
@@ -182,7 +186,7 @@ jobs:
         if: steps.token.outputs.present == 'true'
         run: |
           set -euo pipefail
-          for DIR in runtime-packages/runtime-*/; do
+          for DIR in "$RUNTIME_PACKAGES_DIR"/runtime-*/; do
             node apps/ade-cli/scripts/verify-runtime-package-contents.mjs "$DIR"
           done
 
@@ -200,19 +204,19 @@ jobs:
           # optionalDependencies, so publishing it first would leave a window in
           # which installing it resolves nothing.
           ORDER=""
-          for DIR in runtime-packages/*/; do
+          for DIR in "$RUNTIME_PACKAGES_DIR"/*/; do
             case "$DIR" in
-              runtime-packages/runtime/) ;;
+              */runtime/) ;;
               *) ORDER="$ORDER $DIR" ;;
             esac
           done
-          ORDER="$ORDER runtime-packages/runtime/"
+          ORDER="$ORDER $RUNTIME_PACKAGES_DIR/runtime/"
 
           # Skip-if-exists, matching publish-sdk-packages.yml's auto route: a
           # re-run after a partial failure must publish only what is missing
           # rather than abort on the packages that already landed.
           for DIR in $ORDER; do
-            PKG=$(node -p "require('./${DIR}package.json').name")
+            PKG=$(node -p "require(require('node:path').resolve('$DIR', 'package.json')).name")
             if npm view "$PKG@$VERSION" version >/dev/null 2>&1; then
               echo "$PKG@$VERSION already published; skipping." >> "$GITHUB_STEP_SUMMARY"
               continue

--- a/apps/ade-cli/scripts/build-runtime-npm-packages.mjs
+++ b/apps/ade-cli/scripts/build-runtime-npm-packages.mjs
@@ -386,6 +386,34 @@ function defaultPackRunner(cwd) {
  * comment claimed: that script walks `packages/` only, and these packages are
  * built into `runtime-packages/`, which it never sees.
  */
+/**
+ * Paths `npm pack --dry-run --json` says it would publish.
+ *
+ * npm 10/11 emit an array of entries. npm 12 (what `npm@latest` is on the
+ * publish runner) emits an object keyed by package name. Treating that object
+ * as the entry made `files` undefined, so a real native tree reported every
+ * on-disk path as missing, starting at `bin/ade`.
+ */
+export function packedPathsFromNpmPackJson(parsed) {
+  if (parsed == null) return [];
+  let entry = null;
+  if (Array.isArray(parsed)) {
+    entry = parsed[0] ?? null;
+  } else if (Array.isArray(parsed.files)) {
+    entry = parsed;
+  } else {
+    entry = Object.values(parsed).find((value) => value && Array.isArray(value.files)) ?? null;
+  }
+  const files = Array.isArray(entry?.files) ? entry.files : [];
+  const paths = [];
+  for (const file of files) {
+    const raw = typeof file === "string" ? file : file?.path;
+    if (typeof raw !== "string" || raw.length === 0) continue;
+    paths.push(raw.replace(/^package\//, ""));
+  }
+  return paths;
+}
+
 export function verifyPackedRuntimeFiles({ packageDir, runPack = defaultPackRunner }) {
   // The directory name carries the target, so the launcher's name is decided,
   // not a choice of two. Accepting either one let a `runtime-win32-x64`
@@ -414,8 +442,7 @@ export function verifyPackedRuntimeFiles({ packageDir, runPack = defaultPackRunn
         `package whose contents were never verified.`,
     );
   }
-  const entry = Array.isArray(parsed) ? parsed[0] : parsed;
-  const packed = new Set((Array.isArray(entry?.files) ? entry.files : []).map((file) => file.path));
+  const packed = new Set(packedPathsFromNpmPackJson(parsed));
   const missing = onDisk.filter((file) => !packed.has(file));
   if (missing.length > 0) {
     throw new Error(
@@ -628,8 +655,7 @@ export function verifyPackedMetaFiles({ packageDir, runPack = defaultPackRunner 
         `package whose contents were never verified.`,
     );
   }
-  const entry = Array.isArray(parsed) ? parsed[0] : parsed;
-  const packed = new Set((Array.isArray(entry?.files) ? entry.files : []).map((file) => file.path));
+  const packed = new Set(packedPathsFromNpmPackJson(parsed));
   for (const required of ["LICENSE", EXCEPTION_FILE_NAME, "README.md", "package.json"]) {
     if (!packed.has(required)) {
       throw new Error(

--- a/apps/ade-cli/scripts/build-runtime-npm-packages.test.mjs
+++ b/apps/ade-cli/scripts/build-runtime-npm-packages.test.mjs
@@ -13,6 +13,7 @@ import {
   buildMetaPackage,
   buildRuntimePackage,
   metaPackageManifest,
+  packedPathsFromNpmPackJson,
   parseArgs,
   readLicenseFiles,
   runtimeAssetNames,
@@ -128,6 +129,21 @@ test("npm pack dry-run buffer is large enough for a real native tree", () => {
   assert.match(source, /maxBuffer:\s*NPM_PACK_MAX_BUFFER_BYTES/);
 });
 
+test("reads npm 12 pack --json objects keyed by package name", () => {
+  assert.deepEqual(
+    packedPathsFromNpmPackJson({
+      "@ade-dev/runtime-linux-x64": {
+        files: [{ path: "bin/ade" }, { path: "package/native/manifest.json" }],
+      },
+    }),
+    ["bin/ade", "native/manifest.json"],
+  );
+  assert.deepEqual(
+    packedPathsFromNpmPackJson([{ files: [{ path: "bin/ade" }, { path: "package.json" }] }]),
+    ["bin/ade", "package.json"],
+  );
+});
+
 test("Windows native archive is ade-win32-x64.native.tar.gz, not glued onto .exe", () => {
   assert.deepEqual(runtimeAssetNames("win32-x64"), {
     binaryAsset: "ade-win32-x64.exe",
@@ -145,6 +161,8 @@ test("publish workflow checksum step uses runtimeAssetNames", () => {
     "utf8",
   );
   assert.match(workflow, /runtimeAssetNames/);
+  assert.match(workflow, /\$\{RUNNER_TEMP\}/);
+  assert.match(workflow, /RUNTIME_PACKAGES_DIR/);
   assert.doesNotMatch(workflow, /ade-win32-x64\\.exe\(\\\.native\\.tar\\.gz\)\?/);
 });
 


### PR DESCRIPTION
## Problem

After #1217, `Publish ADE runtime packages` still failed at Build. It reported 11233 missing files starting with `bin/ade`. Nothing reached npm.

## Cause

The workflow installs `npm@latest`. npm 12 emits `pack --json` as an object keyed by package name, not an array. The verifier treated that object as the pack entry, so `files` was undefined and every on-disk path looked missing.

## Change and boundary

Parse both npm 10/11 arrays and npm 12 keyed objects. Build the packages under `$RUNNER_TEMP` so the repo `.gitignore` (`node_modules`) cannot strip `native/node_modules`. No packages were published by the failed runs.

## Verification

- `node --test apps/ade-cli/scripts/build-runtime-npm-packages.test.mjs apps/ade-cli/scripts/verify-runtime-package-contents.test.mjs`: 43 passed

Authored with Cursor Grok 4.6 via ADE.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed runtime package verification for npm 12 output formats.
  * Improved package publishing reliability by using consistent temporary build paths.
  * Prevented valid packaged files from being incorrectly reported as missing.

* **Tests**
  * Added coverage for npm 10/11 and npm 12 package metadata formats.
  * Added checks confirming the publishing workflow uses the configured temporary package directory.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->