### PR TITLE
fix(ios): reset Linear launch drafts per issue

### DIFF
--- a/apps/ios/ADE/Views/Linear/LinearLaunchModel.swift
+++ b/apps/ios/ADE/Views/Linear/LinearLaunchModel.swift
@@ -52,6 +52,8 @@ struct LinearLaunchViewIdentity: Hashable {
   let laneOnly: Bool
 }
 
+let linearLaunchKickoffAccessibilityIdentifier = "linear-launch-kickoff"
+
 // MARK: - Orchestration
 
 /// Injected side-effects so `runLinearLaunch` is unit-testable without a live

--- a/apps/ios/ADE/Views/Linear/LinearLaunchModel.swift
+++ b/apps/ios/ADE/Views/Linear/LinearLaunchModel.swift
@@ -44,6 +44,14 @@ struct LinearLaunchConfig: Equatable {
   var kickoff: String
 }
 
+/// Identity for the launch destination's editable draft. SwiftUI can retain
+/// `@State` when a navigation destination is reused, so the issue and launch
+/// mode must both participate in the identity of this screen.
+struct LinearLaunchViewIdentity: Hashable {
+  let issueID: String
+  let laneOnly: Bool
+}
+
 // MARK: - Orchestration
 
 /// Injected side-effects so `runLinearLaunch` is unit-testable without a live

--- a/apps/ios/ADE/Views/Linear/LinearLaunchScreen.swift
+++ b/apps/ios/ADE/Views/Linear/LinearLaunchScreen.swift
@@ -1,5 +1,43 @@
 import SwiftUI
 
+private struct LinearLaunchKickoffAccessibilityMarker: UIViewRepresentable {
+  func makeUIView(context: Context) -> UIView {
+    UIView()
+  }
+
+  func updateUIView(_ marker: UIView, context: Context) {
+    markEditor(near: marker, attemptsRemaining: 4)
+  }
+
+  private func markEditor(near marker: UIView, attemptsRemaining: Int) {
+    var ancestor = marker.superview
+    while let container = ancestor {
+      if let textView = firstTextView(in: container) {
+        textView.accessibilityIdentifier = linearLaunchKickoffAccessibilityIdentifier
+        return
+      }
+      ancestor = container.superview
+    }
+    guard attemptsRemaining > 0 else { return }
+    DispatchQueue.main.async { [weak marker] in
+      guard let marker else { return }
+      markEditor(near: marker, attemptsRemaining: attemptsRemaining - 1)
+    }
+  }
+
+  private func firstTextView(in view: UIView) -> UITextView? {
+    if let textView = view as? UITextView {
+      return textView
+    }
+    for subview in view.subviews {
+      if let textView = firstTextView(in: subview) {
+        return textView
+      }
+    }
+    return nil
+  }
+}
+
 /// Streamlined launch config for a single Linear issue: session type + model +
 /// permission mode + editable kickoff prompt, then create-lane → launch-agent →
 /// navigate to the new session. Model/permission controls reuse the Work
@@ -194,6 +232,8 @@ struct LinearLaunchScreen: View {
         .font(.subheadline)
         .foregroundStyle(ADEColor.textPrimary)
         .adePromptInputTraits()
+        .accessibilityIdentifier(linearLaunchKickoffAccessibilityIdentifier)
+        .background(LinearLaunchKickoffAccessibilityMarker())
         .frame(minHeight: 120)
         .scrollContentBackground(.hidden)
         .padding(10)

--- a/apps/ios/ADE/Views/Linear/LinearPaneSheet.swift
+++ b/apps/ios/ADE/Views/Linear/LinearPaneSheet.swift
@@ -1,5 +1,19 @@
 import SwiftUI
 
+/// Navigation destination for a Linear launch. The explicit identity is
+/// important because `LinearLaunchScreen` owns editable `@State`; SwiftUI can
+/// otherwise reuse the first issue's draft when a navigation destination is
+/// replaced with another issue.
+struct LinearLaunchDestination: View {
+  let issue: NormalizedLinearIssue
+  let laneOnly: Bool
+
+  var body: some View {
+    LinearLaunchScreen(issue: issue, laneOnly: laneOnly)
+      .id(LinearLaunchViewIdentity(issueID: issue.id, laneOnly: laneOnly))
+  }
+}
+
 /// The global Linear pane: a full-screen sheet hosting a `NavigationStack`
 /// (issue list → detail → launch). Presented from the Work top-bar Linear
 /// button and by `ade://linear-issue/<IDENT>` deep links. Active-project scoped.
@@ -42,7 +56,7 @@ struct LinearPaneSheet: View {
         case let .issue(issue):
           LinearIssueDetailScreen(issue: issue, hasLane: store.attachedIssueIds.contains(issue.id))
         case let .launch(issue, laneOnly):
-          LinearLaunchScreen(issue: issue, laneOnly: laneOnly)
+          LinearLaunchDestination(issue: issue, laneOnly: laneOnly)
         case .connection:
           LinearConnectionScreen(store: store)
         }

--- a/apps/ios/ADETests/ADETests.swift
+++ b/apps/ios/ADETests/ADETests.swift
@@ -27464,6 +27464,20 @@ private struct LinearLaunchViewTestHost: View {
   }
 }
 
+@MainActor
+private func viewWithAccessibilityIdentifier(_ identifier: String, in rootView: UIView) -> UIView? {
+  if rootView.accessibilityIdentifier == identifier {
+    return rootView
+  }
+
+  for subview in rootView.subviews {
+    if let identifiedView = viewWithAccessibilityIdentifier(identifier, in: subview) {
+      return identifiedView
+    }
+  }
+  return nil
+}
+
 private func firstTextView(in view: UIView) -> UITextView? {
   if let textView = view as? UITextView {
     return textView
@@ -27474,6 +27488,18 @@ private func firstTextView(in view: UIView) -> UITextView? {
     }
   }
   return nil
+}
+
+@MainActor
+private func kickoffText(in rootView: UIView) -> String? {
+  guard let editorView = viewWithAccessibilityIdentifier(
+    linearLaunchKickoffAccessibilityIdentifier,
+    in: rootView
+  ) else { return nil }
+  if let textView = editorView as? UITextView {
+    return textView.text
+  }
+  return firstTextView(in: editorView)?.text
 }
 
 private final class LinearPaneSyncSpy: LinearPaneSyncing {
@@ -27576,14 +27602,16 @@ final class LinearPaneTests: XCTestCase {
     drainMainQueueForTesting()
     host.view.setNeedsLayout()
     host.view.layoutIfNeeded()
-    XCTAssertEqual(firstTextView(in: host.view)?.text, linearDefaultKickoff(for: firstIssue))
+    drainMainQueueForTesting()
+    XCTAssertEqual(kickoffText(in: host.view), linearDefaultKickoff(for: firstIssue))
 
     state.issue = secondIssue
     drainMainQueueForTesting()
     drainMainQueueForTesting()
     host.view.setNeedsLayout()
     host.view.layoutIfNeeded()
-    XCTAssertEqual(firstTextView(in: host.view)?.text, linearDefaultKickoff(for: secondIssue))
+    drainMainQueueForTesting()
+    XCTAssertEqual(kickoffText(in: host.view), linearDefaultKickoff(for: secondIssue))
   }
 
   func testLinearIssueBranchNameSlugifiesAndSanitizes() {

--- a/apps/ios/ADETests/ADETests.swift
+++ b/apps/ios/ADETests/ADETests.swift
@@ -27444,6 +27444,38 @@ private actor LinearLaunchSpy {
 }
 
 @MainActor
+private final class LinearLaunchViewTestState: ObservableObject {
+  @Published var issue: NormalizedLinearIssue
+  @Published var laneOnly = false
+
+  init(issue: NormalizedLinearIssue) {
+    self.issue = issue
+  }
+}
+
+@MainActor
+private struct LinearLaunchViewTestHost: View {
+  @ObservedObject var state: LinearLaunchViewTestState
+  let syncService: SyncService
+
+  var body: some View {
+    LinearLaunchDestination(issue: state.issue, laneOnly: state.laneOnly)
+      .environmentObject(syncService)
+  }
+}
+
+private func firstTextView(in view: UIView) -> UITextView? {
+  if let textView = view as? UITextView {
+    return textView
+  }
+  for subview in view.subviews {
+    if let textView = firstTextView(in: subview) {
+      return textView
+    }
+  }
+  return nil
+}
+
 private final class LinearPaneSyncSpy: LinearPaneSyncing {
   var linearConnectionStatus: LinearConnectionStatus? = LinearConnectionStatus(connected: true)
   var searchResults: [LinearIssueSearchResult] = []
@@ -27510,6 +27542,48 @@ final class LinearPaneTests: XCTestCase {
 
   func testLinearIssueLaneNameJoinsIdentifierAndTitle() {
     XCTAssertEqual(linearIssueLaneName(identifier: " ENG-1 ", title: " Do it "), "ENG-1 Do it")
+  }
+
+  func testLinearLaunchViewIdentityDistinguishesIssueAndMode() {
+    let firstIssue = LinearLaunchViewIdentity(issueID: "issue-1", laneOnly: false)
+    let secondIssue = LinearLaunchViewIdentity(issueID: "issue-2", laneOnly: false)
+    let laneOnly = LinearLaunchViewIdentity(issueID: "issue-1", laneOnly: true)
+
+    XCTAssertEqual(firstIssue, LinearLaunchViewIdentity(issueID: "issue-1", laneOnly: false))
+    XCTAssertNotEqual(firstIssue, secondIssue)
+    XCTAssertNotEqual(firstIssue, laneOnly)
+  }
+
+  @MainActor
+  func testLinearLaunchDestinationRecreatesKickoffForASecondIssue() {
+    let firstIssue = makeIssue(id: "issue-1", identifier: "VER-372", title: "First issue")
+    let secondIssue = makeIssue(id: "issue-2", identifier: "VER-373", title: "Second issue")
+    let state = LinearLaunchViewTestState(issue: firstIssue)
+    let database = DatabaseService(
+      baseURL: FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString, isDirectory: true)
+    )
+    let syncService = SyncService(database: database)
+    let host = UIHostingController(
+      rootView: LinearLaunchViewTestHost(state: state, syncService: syncService)
+    )
+    let window = UIWindow(frame: CGRect(x: 0, y: 0, width: 390, height: 844))
+    window.rootViewController = host
+    window.makeKeyAndVisible()
+    host.view.frame = window.bounds
+    host.view.layoutIfNeeded()
+    defer { window.isHidden = true }
+
+    drainMainQueueForTesting()
+    host.view.setNeedsLayout()
+    host.view.layoutIfNeeded()
+    XCTAssertEqual(firstTextView(in: host.view)?.text, linearDefaultKickoff(for: firstIssue))
+
+    state.issue = secondIssue
+    drainMainQueueForTesting()
+    drainMainQueueForTesting()
+    host.view.setNeedsLayout()
+    host.view.layoutIfNeeded()
+    XCTAssertEqual(firstTextView(in: host.view)?.text, linearDefaultKickoff(for: secondIssue))
   }
 
   func testLinearIssueBranchNameSlugifiesAndSanitizes() {


### PR DESCRIPTION
**Problem**
The iOS Linear launcher reused the first issue's kickoff prompt when several issue launch destinations were created in succession.

**Cause**
SwiftUI retained `LinearLaunchScreen`'s editable `@State` while the navigation destination changed issues. Lane naming used the current issue, but the launch payload still used the retained prompt.

**Change and boundary**
Key the iOS launch destination by Linear issue identity and launch mode, and add a hosted SwiftUI regression covering an issue switch. Desktop, hosted web, CLI, TUI, and shared host routing were audited and remain unchanged.

**Verification**
`xcodebuild test` on the iOS Simulator ran `ADETests/LinearPaneTests`: 21 passed, 0 failed, including the hosted issue-switch regression; `git diff --check` passed; the cross-surface audit found no analogous non-iOS path.

Authored with GPT-5 via Codex/ADE.

<!-- ade:link v=1 type=pr repo=arul28/ADE branch=ade%2Fstart-skill-versic-project-machine num=1233 -->
<p>
  <img src="https://ade-app.dev/logo.png" height="18" align="left" alt="ADE">
  &nbsp;&nbsp;<strong>Open in ADE</strong>
  &nbsp;·&nbsp; <a href="https://ade-app.dev/open?type=branch&amp;repo=arul28%2FADE&amp;branch=ade%2Fstart-skill-versic-project-machine&amp;pr=1233">ade/start-skill-versic-project-machine branch</a>
  &nbsp;·&nbsp; <a href="https://ade-app.dev/open?type=pr&amp;repo=arul28%2FADE&amp;number=1233">PR #1233</a>
</p>
<!-- /ade:link -->

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/arul28/ade/pull/1233" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where navigating between Linear issues could reuse the previous issue’s launch draft.
  * Launch screens now correctly refresh when switching issues or changing lane-only mode.
  * Kickoff editor content now updates reliably when moving between issues.

* **Tests**
  * Added coverage to verify that launch state is properly separated for different issues and modes.
  * Added validation that the kickoff editor displays the newly selected issue’s content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->



<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR prevents SwiftUI from retaining a Linear launch draft across issue or launch-mode changes by assigning each launch destination an explicit identity.
- Adds issue-and-mode-based launch view identity.
- Routes launch navigation through the newly identified destination.
- Adds a hosted regression test covering an issue switch.
- Replaces positional test lookup with an accessibility-identifier-based lookup.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with no outstanding correctness, security, or repository-rule issues identified.

The launch destination identity now includes both issue ID and launch mode, so changing either recreates the editable SwiftUI state. The regression test targets the kickoff editor through a stable accessibility identifier. The previous test-fragility thread was manually resolved without explanation, and the current implementation addresses its concern.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| apps/ios/ADE/Views/Linear/LinearLaunchModel.swift | Defines the issue-and-mode launch identity and the kickoff editor accessibility identifier. |
| apps/ios/ADE/Views/Linear/LinearLaunchScreen.swift | Assigns the stable accessibility identifier to the kickoff editor’s underlying text view. |
| apps/ios/ADE/Views/Linear/LinearPaneSheet.swift | Recreates launch-screen state whenever the selected issue or lane-only mode changes. |
| apps/ios/ADETests/ADETests.swift | Adds hosted state-reset coverage and identifies the kickoff editor without relying on its hierarchy position. |

<sub>Reviews (2): Last reviewed commit: ["test(ios): target Linear kickoff editor ..."](https://github.com/arul28/ade/commit/81b2b756b109f40d9b6832a47ebf63c4d6cfa352) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=62948381)</sub>

<!-- /greptile_comment -->